### PR TITLE
feat: contributor status deadline fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_opportunity.yaml
+++ b/.github/ISSUE_TEMPLATE/new_opportunity.yaml
@@ -69,15 +69,25 @@ body:
       required: false
 
   - type: dropdown
-    id: active
+    id: status
     attributes:
-      label: Is this hackathon currently open for registration?
+      label: Status
+      description: Is registration currently open?
       multiple: false
       options:
-        - "Yes"
-        - "No"
+        - "Open - Registration is currently open"
+        - "Opens soon - Announced, registration not open yet"
     validations:
       required: true
+
+  - type: input
+    id: deadline
+    attributes:
+      label: Deadline (Optional)
+      description: Registration/application deadline (YYYY-MM-DD or MM/DD/YYYY).
+      placeholder: ex. 07/01/2026
+    validations:
+      required: false
 
   - type: input
     id: email

--- a/.github/ISSUE_TEMPLATE/quick_add.yaml
+++ b/.github/ISSUE_TEMPLATE/quick_add.yaml
@@ -53,3 +53,24 @@ body:
       placeholder: Cambridge, MA
     validations:
       required: false
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      description: Is registration currently open?
+      multiple: false
+      options:
+        - "Open - Registration is currently open"
+        - "Opens soon - Announced, registration not open yet"
+    validations:
+      required: true
+
+  - type: input
+    id: deadline
+    attributes:
+      label: Deadline (Optional)
+      description: Registration/application deadline (YYYY-MM-DD or MM/DD/YYYY).
+      placeholder: ex. 07/01/2026
+    validations:
+      required: false

--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -226,7 +226,10 @@ def parse_deadline(data):
     raw = (data.get("deadline_optional", "") or data.get("deadline", "")).strip()
     if not raw:
         return None
-    return util.parse_deadline_date(raw).isoformat()
+    try:
+        return util.parse_deadline_date(raw).isoformat()
+    except ValueError:
+        util.fail("Invalid deadline format. Please use YYYY-MM-DD or MM/DD/YYYY.")
 
 
 def extract_url_from_body(body):

--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -210,6 +210,25 @@ def parse_issue_body(body):
     return data
 
 
+def parse_state(data):
+    """Map optional issue status field to listing state."""
+    status = (data.get("status", "") or "").strip().lower()
+    if "soon" in status:
+        return "opens_soon"
+    if "open" in status:
+        return "open"
+    # Sensible default for auto-extracted listings.
+    return "open"
+
+
+def parse_deadline(data):
+    """Parse optional deadline and normalize to ISO YYYY-MM-DD."""
+    raw = (data.get("deadline_optional", "") or data.get("deadline", "")).strip()
+    if not raw:
+        return None
+    return util.parse_deadline_date(raw).isoformat()
+
+
 def extract_url_from_body(body):
     """Try multiple methods to extract URL from issue body."""
     # Method 1: Parse structured fields
@@ -267,6 +286,8 @@ def main():
     print(f"Extracted URL: {url}")
 
     notes = data.get("any_additional_context_optional", "") or data.get("notes", "")
+    state = parse_state(data)
+    deadline = parse_deadline(data)
 
     print(f"Fetching content from: {url}")
 
@@ -345,12 +366,15 @@ def main():
         "locations": locations,
         "format": fmt,
         "prize": extracted.get("prize", "—") or "—",
-        "active": True,
+        "state": state,
+        "active": state != "closed",
         "is_visible": True,
         "date_posted": util.get_current_timestamp(),
         "date_updated": util.get_current_timestamp(),
         "source": username
     }
+    if deadline:
+        new_listing["deadline"] = deadline
 
     # Save
     listings.append(new_listing)

--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -14,6 +14,46 @@ import re
 import util
 
 
+def get_first(data, *keys):
+    """Return first non-empty string value for keys."""
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def parse_state(data):
+    """Map issue fields to listing state."""
+    status = get_first(data, "status")
+    status_lc = status.lower()
+    if "soon" in status_lc:
+        return "opens_soon"
+    if "open" in status_lc:
+        return "open"
+
+    # Backward compatibility with older template field.
+    active_str = get_first(
+        data,
+        "is_this_hackathon_currently_open_for_registration?",
+        "is_this_hackathon_currently_open_for_registration",
+    ).lower()
+    if active_str == "no":
+        return "opens_soon"
+    return "open"
+
+
+def parse_deadline(data):
+    """Parse optional deadline and normalize to ISO YYYY-MM-DD."""
+    raw = get_first(data, "deadline", "deadline_(optional)")
+    if not raw:
+        return None
+    return util.parse_deadline_date(raw).isoformat()
+
+
 def parse_issue_body(body, labels):
     """Parse the issue body based on issue type."""
     lines = body.strip().split("\n")
@@ -46,7 +86,7 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     listings = util.get_listings_from_json()
 
     # Get URL - handle both full and quick templates
-    url = data.get("link_to_hackathon_page", "") or data.get("link", "") or data.get("link_to_hackathon", "")
+    url = get_first(data, "link_to_hackathon_page", "link", "link_to_hackathon")
     url = util.clean_url(url)
     if not url:
         util.fail("Missing required field: URL")
@@ -57,15 +97,13 @@ def handle_new_opportunity(data, username, is_quick_add=False):
             util.fail(f"Duplicate: This hackathon already exists (ID: {listing['id']})")
 
     # Get host name - handle both templates
-    company_name = (data.get("host/organizer", "") or
-                    data.get("host/organizer_name", "")).strip()
+    company_name = get_first(data, "host/organizer", "host/organizer_name") 
 
     # Get title - handle both templates
-    title = (data.get("hackathon_name", "") or
-             data.get("hackathon_name/edition", "")).strip()
+    title = get_first(data, "hackathon_name", "hackathon_name/edition")
 
     # Parse locations (default to "Online" if not provided)
-    locations_str = data.get("location", "") or data.get("location_(optional)", "")
+    locations_str = get_first(data, "location", "location_(optional)")
     if locations_str:
         # Support semicolon, pipe, or newline as separators
         locations = [loc.strip() for loc in re.split(r'[;|\n]', locations_str) if loc.strip()]
@@ -82,11 +120,10 @@ def handle_new_opportunity(data, username, is_quick_add=False):
         fmt = "In-Person"
 
     # Get prize (optional)
-    prize = (data.get("prize_pool_(optional)", "") or data.get("prize", "") or "—").strip() or "—"
-
-    # Get active status (default to Yes/True)
-    active_str = data.get("is_this_hackathon_currently_open_for_registration?", "Yes")
-    active = active_str == "Yes" or active_str == ""
+    prize = get_first(data, "prize_pool_(optional)", "prize") or "—"
+    # Map user-submitted status/deadline fields into canonical listing fields.
+    state = parse_state(data)
+    deadline = parse_deadline(data)
 
     # Create new listing
     new_listing = {
@@ -97,12 +134,15 @@ def handle_new_opportunity(data, username, is_quick_add=False):
         "locations": locations,
         "format": fmt,
         "prize": prize,
-        "active": True if is_quick_add else active,
+        "state": state,
+        "active": state != "closed",
         "is_visible": True,
         "date_posted": util.get_current_timestamp(),
         "date_updated": util.get_current_timestamp(),
         "source": username
     }
+    if deadline:
+        new_listing["deadline"] = deadline
 
     # Validate required fields
     if not new_listing["company_name"]:
@@ -116,7 +156,7 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     # Set outputs
     util.set_output("commit_message", f"Add {company_name} - {title}")
     util.set_output("contributor_name", username)
-    email = data.get("email_associated_with_your_github_account_(optional)", "")
+    email = get_first(data, "email_associated_with_your_github_account_(optional)")
     util.set_output("contributor_email", email if email else "actions@github.com")
 
     print(f"Successfully added: {company_name} - {title}")

--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -51,7 +51,10 @@ def parse_deadline(data):
     raw = get_first(data, "deadline", "deadline_(optional)")
     if not raw:
         return None
-    return util.parse_deadline_date(raw).isoformat()
+    try:
+        return util.parse_deadline_date(raw).isoformat()
+    except ValueError:
+        util.fail("Invalid deadline format. Please use YYYY-MM-DD or MM/DD/YYYY.")
 
 
 def parse_issue_body(body, labels):

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -53,6 +53,9 @@ def check_schema(listings):
         for field in REQUIRED_FIELDS:
             if field not in listing:
                 raise ValueError(f"Listing {listing.get('id', 'unknown')} missing field: {field}")
+        deadline = listing.get("deadline")
+        if deadline is not None:
+            parse_deadline_date(deadline)
     return True
 
 
@@ -114,6 +117,19 @@ def format_date(timestamp):
     """Format Unix timestamp as readable date."""
     dt = datetime.fromtimestamp(timestamp, tz=PST)
     return dt.strftime("%b %d, %Y")
+
+
+def parse_deadline_date(value):
+    """Parse deadline date in YYYY-MM-DD or MM/DD/YYYY format."""
+    if not isinstance(value, str):
+        raise ValueError(f"Invalid deadline type: expected string, got {type(value).__name__}")
+    text = value.strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Invalid deadline '{value}' (expected YYYY-MM-DD or MM/DD/YYYY)")
 
 
 def embed_table(filepath, table, start_marker, end_marker):


### PR DESCRIPTION
This PR resolves issue #3 
Adds contributor-facing support for hackathon status and deadline in the issue workflow, so upcoming events no longer need manual edits in `listings.json`.

**What was changed/added:**
- Adds a `Status` dropdown (`Open`, `Opens soon`) and optional `Deadline` input to `new_opportunity` and `quick_add` issue templates.
- Updates `contribution_approved.py` to parse and map those fields into canonical listing fields (`state`, `optional deadline`).
- Updates `auto_extract.py` to apply the same mapping with sensible defaults (state defaults to open when not provided).
- Adds/uses shared deadline parsing support in `util.py` (`YYYY-MM-DD` and `MM/DD/YYYY`) with normalization.
- Preserves backward compatibility for legacy issue bodies (old open/closed field handling).
- Add friendly invalid-deadline validation message to issue ingestion flows (manual + auto-extract).

**Test plan/verification:**
- Verified status mapping:
-- Open -> state: "open"
-- Opens soon -> state: "opens_soon"
- Verified deadline parsing accepts:
-- YYYY-MM-DD
-- MM/DD/YYYY
- Verified legacy field fallback still maps correctly for older issue formats.