### PR TITLE
Feat: web stats, gallery, readme update

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,111 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# HackHQ Web
 
-## Getting Started
+The web frontend for **HackHQ** — a browsable, searchable interface for the
+hackathon listings maintained in the repository root
+[`../README.md`](../README.md).
 
-First, run the development server:
+It's a [Next.js](https://nextjs.org) (App Router) app that renders the listings
+as a filterable directory, with a live stats banner and a community photo
+gallery.
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+## What it does
+
+- **Browse & search** every tracked hackathon by host, name, format, or location.
+- **Filter by status** — Open, Closing Soon, and Opens Soon — with live counts.
+- **Sort intelligently** — closing-soon events first, then by nearest deadline.
+- **Stats banner** — an at-a-glance snapshot of totals (tracked, open, opens
+  soon, closing soon) and format breakdown.
+- **Gallery** — real photos from hackathons people found through the list.
+
+## How it works
+
+This app has **no database**. The repository root `README.md` is the single
+source of truth, and the app parses it at request time.
+
+On each render, `lib/parse-readme.ts` reads `../README.md` and extracts:
+
+| Content       | Source in `../README.md`                                              |
+| ------------- | -------------------------------------------------------------------- |
+| Listings      | Table rows between `<!-- HACKATHONS_TABLE_START -->` and `<!-- HACKATHONS_TABLE_END -->` |
+| Stats banner  | The `<img alt="Hackathon stats" ...>` tag                            |
+| Gallery       | `<img>` tags between `<!-- GALLERY_START -->` and `<!-- GALLERY_END -->` |
+
+Because parsing happens at runtime, **any update to the root `README.md` is
+reflected on the next render** — no rebuild required in development.
+
+### Assets
+
+Images referenced in the README (e.g. `assets/hackathons-banner.svg`) are
+resolved by `resolveAssetSrc()` in `lib/parse-readme.ts`:
+
+1. **Local first** — if the file exists under `../assets/`, it's served by the
+   route handler at `app/repo-assets/[...path]/route.ts`. This keeps the UI in
+   sync with your current branch/working tree.
+2. **Remote fallback** — otherwise it falls back to the file on `main` via
+   `raw.githubusercontent.com`.
+
+Local assets are preferred so the stats banner always matches the counts parsed
+from your local `README.md`.
+
+## Project structure
+
+```text
+web/
+├── app/
+│   ├── page.tsx                     # Home page; loads data via loadSiteData()
+│   ├── layout.tsx                   # Root layout & metadata
+│   └── repo-assets/[...path]/route.ts  # Serves files from ../assets
+├── components/
+│   ├── browser.tsx                  # Search, filters, results grid (client)
+│   ├── opportunity-card.tsx         # Single listing card
+│   ├── stats-banner.tsx             # Stats banner image
+│   └── gallery.tsx                  # Photo gallery
+└── lib/
+    ├── parse-readme.ts              # Parses ../README.md into typed data
+    └── types.ts                     # Opportunity / GalleryPhoto types
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Getting started
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+> Requires **Node.js >= 20.9.0**.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This app must be run from the `web/` directory so that `../README.md` and
+`../assets/` resolve correctly.
 
-## Learn More
+```bash
+cd web
+npm install
+npm run dev
+```
 
-To learn more about Next.js, take a look at the following resources:
+Then open [http://localhost:3000](http://localhost:3000).
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Scripts
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+| Script          | Description                          |
+| --------------- | ------------------------------------ |
+| `npm run dev`   | Start the development server         |
+| `npm run build` | Create a production build            |
+| `npm run start` | Serve the production build           |
+| `npm run lint`  | Run ESLint                           |
 
-## Deploy on Vercel
+## Production build
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+```bash
+npm run build
+npm run start
+```
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Tech stack
+
+- [Next.js 16](https://nextjs.org) (App Router)
+- [React 19](https://react.dev)
+- [Tailwind CSS 4](https://tailwindcss.com)
+- TypeScript
+
+## Notes
+
+- Listings, stats, and gallery are derived from `../README.md`; edit that file
+  (or the generator scripts in `.github/scripts/`) to change what's shown here.
+- `next.config.ts` allows optimized `raw.githubusercontent.com` images and the
+  inline SVG banner.

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -27,8 +27,11 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col" suppressHydrationWarning>
+        {children}
+      </body>
     </html>
   );
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,8 +1,9 @@
-import { loadOpportunities } from "@/lib/parse-readme";
+import { loadSiteData } from "@/lib/parse-readme";
 import { Browser } from "@/components/browser";
+import Gallery from "@/components/gallery";
 
 export default function Home() {
-  const opportunities = loadOpportunities();
+  const { opportunities, statsBannerSrc, gallery } = loadSiteData();
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-black">
@@ -44,7 +45,9 @@ export default function Home() {
       </header>
 
       <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-        <Browser opportunities={opportunities} />
+        <Browser opportunities={opportunities} statsBannerSrc={statsBannerSrc} />
+
+        <Gallery gallery={gallery} />
       </main>
 
       <footer className="mt-16 border-t border-zinc-200 dark:border-zinc-900">

--- a/web/app/repo-assets/[...path]/route.ts
+++ b/web/app/repo-assets/[...path]/route.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+import { NextResponse } from "next/server";
+
+const REPO_ROOT = path.join(process.cwd(), "..");
+const ASSETS_DIR = path.join(REPO_ROOT, "assets");
+
+const MIME: Record<string, string> = {
+  ".svg": "image/svg+xml",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path: segments } = await params;
+  const filePath = path.join(ASSETS_DIR, ...segments);
+  const resolved = path.resolve(filePath);
+
+  if (!resolved.startsWith(path.resolve(ASSETS_DIR) + path.sep)) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isFile()) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  const body = fs.readFileSync(resolved);
+
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": MIME[ext] ?? "application/octet-stream",
+      "Cache-Control": "public, max-age=60",
+    },
+  });
+}

--- a/web/components/browser.tsx
+++ b/web/components/browser.tsx
@@ -3,17 +3,24 @@
 import { useMemo, useState } from "react";
 import { Opportunity, Status, STATUS_LABELS } from "@/lib/types";
 import { OpportunityCard } from "./opportunity-card";
+import StatsBanner from "./stats-banner";
 
 const STATUSES: Status[] = ["CLOSING_SOON", "OPEN", "OPENS_SOON"];
 
 const STATUS_DOT: Record<Status, string> = {
-  CLOSING_SOON: "bg-orange-500",
+  CLOSING_SOON: "bg-red-500",
   OPEN: "bg-emerald-500",
-  OPENS_SOON: "bg-blue-500",
+  OPENS_SOON: "bg-amber-500",
   CLOSED: "bg-zinc-400",
 };
 
-export function Browser({ opportunities }: { opportunities: Opportunity[] }) {
+export function Browser({
+  opportunities,
+  statsBannerSrc,
+}: {
+  opportunities: Opportunity[];
+  statsBannerSrc: string | null;
+}) {
   const [query, setQuery] = useState("");
   const [activeStatuses, setActiveStatuses] = useState<Set<Status>>(new Set());
 
@@ -74,32 +81,7 @@ export function Browser({ opportunities }: { opportunities: Opportunity[] }) {
 
   return (
     <div className="flex flex-col gap-6">
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <Stat
-          label="Closing soon"
-          value={counts.CLOSING_SOON}
-          accent="text-orange-600 dark:text-orange-400"
-          dot="bg-orange-500"
-        />
-        <Stat
-          label="Open"
-          value={counts.OPEN}
-          accent="text-emerald-600 dark:text-emerald-400"
-          dot="bg-emerald-500"
-        />
-        <Stat
-          label="Opens soon"
-          value={counts.OPENS_SOON}
-          accent="text-blue-600 dark:text-blue-400"
-          dot="bg-blue-500"
-        />
-        <Stat
-          label="Total tracked"
-          value={opportunities.length}
-          accent="text-zinc-900 dark:text-zinc-100"
-          dot="bg-zinc-400"
-        />
-      </div>
+      <StatsBanner statsBannerSrc={statsBannerSrc} compact />
 
       <div className="flex flex-col gap-3">
         <input
@@ -118,7 +100,7 @@ export function Browser({ opportunities }: { opportunities: Opportunity[] }) {
               onClick={() => toggleStatus(s)}
               dotClass={STATUS_DOT[s]}
             >
-              {STATUS_LABELS[s]}
+              {STATUS_LABELS[s]} ({counts[s]})
             </Pill>
           ))}
           {(activeStatuses.size > 0 || query) && (
@@ -151,30 +133,6 @@ export function Browser({ opportunities }: { opportunities: Opportunity[] }) {
           ))}
         </div>
       )}
-    </div>
-  );
-}
-
-function Stat({
-  label,
-  value,
-  accent,
-  dot,
-}: {
-  label: string;
-  value: number;
-  accent: string;
-  dot: string;
-}) {
-  return (
-    <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-800 dark:bg-zinc-950">
-      <div className="flex items-center gap-2 text-xs font-medium text-zinc-500 dark:text-zinc-400">
-        <span className={`h-1.5 w-1.5 rounded-full ${dot}`} aria-hidden />
-        {label}
-      </div>
-      <div className={`mt-1 text-2xl font-semibold tabular-nums ${accent}`}>
-        {value}
-      </div>
     </div>
   );
 }

--- a/web/components/gallery.tsx
+++ b/web/components/gallery.tsx
@@ -1,0 +1,38 @@
+import { GalleryPhoto } from "@/lib/types";
+import Image from "next/image";
+
+export default function Gallery({ gallery }: { gallery: GalleryPhoto[] }) {
+    return (
+        <section className="mt-10 rounded-2xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-950">
+          <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+            Gallery
+          </h2>
+          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+            Real photos from hackathons people found through this list.
+          </p>
+          {gallery.length > 0 ? (
+            <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+              {gallery.map((photo) => (
+                <div
+                  key={photo.src}
+                  className="relative aspect-square w-full overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-800"
+                >
+                  <Image
+                    src={photo.src}
+                    alt={photo.alt}
+                    fill
+                    sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+                    className="object-cover"
+                    loading="lazy"
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+              Gallery unavailable.
+            </p>
+          )}
+        </section>
+    );
+}

--- a/web/components/stats-banner.tsx
+++ b/web/components/stats-banner.tsx
@@ -1,0 +1,42 @@
+import Image from "next/image";
+
+export default function StatsBanner({
+  statsBannerSrc,
+  compact = false,
+}: {
+  statsBannerSrc: string | null;
+  compact?: boolean;
+}) {
+  const image = statsBannerSrc ? (
+    <div
+      className={`relative aspect-[760/150] w-full overflow-hidden rounded-xl border border-zinc-200 dark:border-zinc-800 ${compact ? "" : "mt-4"}`}
+    >
+      <Image
+        src={statsBannerSrc}
+        alt="Hackathon stats"
+        fill
+        priority
+        sizes="(max-width: 768px) 100vw, 1200px"
+        className="object-contain"
+      />
+    </div>
+  ) : (
+    <p className={`text-sm text-zinc-500 dark:text-zinc-400 ${compact ? "" : "mt-4"}`}>
+      Stats banner unavailable.
+    </p>
+  );
+
+  if (compact) return image;
+
+  return (
+    <section className="mt-12 rounded-2xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-950">
+      <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
+        Stats
+      </h2>
+      <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+        A snapshot of the list, updated automatically.
+      </p>
+      {image}
+    </section>
+  );
+}

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import {
+  GalleryPhoto,
   Opportunity,
   Section,
   Status,
@@ -9,6 +10,9 @@ import {
 } from "./types";
 
 const README_PATH = path.join(process.cwd(), "..", "README.md");
+const REPO_ROOT = path.join(process.cwd(), "..");
+const REPO_RAW_BASE =
+  "https://raw.githubusercontent.com/Jose-Gael-Cruz-Lopez/hackhq/main/";
 
 const TABLE_RE = /<!-- (\w+)_TABLE_START -->([\s\S]*?)<!-- \1_TABLE_END -->/g;
 
@@ -21,6 +25,10 @@ const MONTH_MAP: Record<string, number> = {
 
 const DATE_RE =
   /\b(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2}),?\s+(\d{4})\b/g;
+const GALLERY_BLOCK_RE =
+  /<!-- GALLERY_START -->([\s\S]*?)<!-- GALLERY_END -->/;
+const IMG_RE =
+  /<img\s+[^>]*src="([^"]+)"[^>]*alt="([^"]*)"[^>]*>/g;
 
 function parseStatus(cell: string): Status {
   if (cell.includes("CLOSING SOON")) return "CLOSING_SOON";
@@ -63,6 +71,42 @@ function inlineDeadline(text: string): string {
 
 function stableId(...parts: string[]): string {
   return crypto.createHash("md5").update(parts.join("|")).digest("hex").slice(0, 10);
+}
+
+function resolveAssetSrc(src: string): string {
+  if (!src) return "";
+  if (src.startsWith("http://") || src.startsWith("https://")) return src;
+
+  const relative = src.replace(/^\/+/, "");
+  const localPath = path.join(REPO_ROOT, relative);
+  if (fs.existsSync(localPath)) {
+    return `/repo-assets/${relative.replace(/^assets\//, "")}`;
+  }
+
+  return `${REPO_RAW_BASE}${relative}`;
+}
+
+function extractStatsBannerSrc(markdown: string): string | null {
+  const tag = markdown.match(/<img\s+[^>]*alt="Hackathon stats"[^>]*>/i);
+  if (!tag) return null;
+  const src = tag[0].match(/src="([^"]+)"/i);
+  return src ? resolveAssetSrc(src[1]) : null;
+}
+
+function extractGallery(markdown: string): GalleryPhoto[] {
+  const block = markdown.match(GALLERY_BLOCK_RE);
+  if (!block) return [];
+
+  const photos: GalleryPhoto[] = [];
+  let m: RegExpExecArray | null;
+  const re = new RegExp(IMG_RE.source, "g");
+  while ((m = re.exec(block[1])) !== null) {
+    photos.push({
+      src: resolveAssetSrc(m[1]),
+      alt: m[2] || "Hackathon photo",
+    });
+  }
+  return photos;
 }
 
 function parseTableRows(
@@ -154,16 +198,33 @@ const SECTION_ALIAS: Record<string, Section> = {
 
 export function loadOpportunities(): Opportunity[] {
   const md = fs.readFileSync(README_PATH, "utf-8");
+  return parseOpportunities(md);
+}
+
+function parseOpportunities(markdown: string): Opportunity[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
   const all: Opportunity[] = [];
   let m: RegExpExecArray | null;
   const re = new RegExp(TABLE_RE.source, "g");
-  while ((m = re.exec(md)) !== null) {
+  while ((m = re.exec(markdown)) !== null) {
     const key = SECTION_ALIAS[m[1]];
     if (!key) continue;
     all.push(...parseTableRows(key, m[2], today));
   }
   return all;
+}
+
+export function loadSiteData(): {
+  opportunities: Opportunity[];
+  statsBannerSrc: string | null;
+  gallery: GalleryPhoto[];
+} {
+  const md = fs.readFileSync(README_PATH, "utf-8");
+  return {
+    opportunities: parseOpportunities(md),
+    statsBannerSrc: extractStatsBannerSrc(md),
+    gallery: extractGallery(md),
+  };
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -17,6 +17,11 @@ export type Opportunity = {
   daysUntilDeadline: number | null;
 };
 
+export type GalleryPhoto = {
+  src: string;
+  alt: string;
+};
+
 export const SECTION_LABELS: Record<Section, string> = {
   HACKATHONS: "Hackathons",
 };

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,19 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  logging: {
+    browserToTerminal: false,
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "raw.githubusercontent.com",
+        pathname: "/Jose-Gael-Cruz-Lopez/hackhq/**",
+      },
+    ],
+    dangerouslyAllowSVG: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This resolves issue #4 

Builds out the HackHQ web frontend so it renders directly from the repo's
root `README.md`, and documents how it works.
- **Data layer:** `lib/parse-readme.ts` now exposes `loadSiteData()`, parsing
  hackathon rows, the stats banner, and the gallery from `../README.md`.
  Assets resolve local-first (via a new `/repo-assets` route) with a
  `raw.githubusercontent.com` fallback, keeping banner stats in sync with
  local data.
- **UI:** New `StatsBanner` and `Gallery` components. The browser now shows the
  stats banner in place of the old stat cards and adds live per-status counts
  to the filter pills.
- **Config:** `next.config.ts` allows optimized GitHub-raw images + inline SVG
  and disables `browserToTerminal` log forwarding; `layout.tsx` adds
  `suppressHydrationWarning` for extension-injected DOM.
- **Docs:** Professional `web/README.md` covering purpose, runtime README
  parsing, asset resolution, structure, and local dev
