### PR TITLE
Governance: auto-label data submissions `community` + document contribution lanes

### DIFF
--- a/.github/ISSUE_TEMPLATE/close_opportunity.yaml
+++ b/.github/ISSUE_TEMPLATE/close_opportunity.yaml
@@ -1,7 +1,7 @@
 name: Close Hackathon
 description: Request to close/archive a hackathon listing
 title: "Close Hackathon"
-labels: ["close_opportunity"]
+labels: ["close_opportunity", "community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/edit_opportunity.yaml
+++ b/.github/ISSUE_TEMPLATE/edit_opportunity.yaml
@@ -1,7 +1,7 @@
 name: Edit Hackathon (Not Supported)
 description: "⚠️ Editing is not supported. To update a listing: close it and re-add with corrected details."
 title: "Edit Hackathon"
-labels: ["edit_opportunity"]
+labels: ["edit_opportunity", "community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/gallery_photo.yaml
+++ b/.github/ISSUE_TEMPLATE/gallery_photo.yaml
@@ -1,7 +1,7 @@
 name: Share a Hackathon Photo
 description: Add a photo to the community gallery from a hackathon you found here
 title: "Photo: "
-labels: ["gallery"]
+labels: ["gallery", "community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/link_only.yaml
+++ b/.github/ISSUE_TEMPLATE/link_only.yaml
@@ -1,7 +1,7 @@
 name: Add Hackathon (Just Paste Link)
 description: Just paste the link - AI will extract all the details automatically!
 title: "Add: "
-labels: ["new_opportunity", "auto_extract"]
+labels: ["new_opportunity", "auto_extract", "community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/new_opportunity.yaml
+++ b/.github/ISSUE_TEMPLATE/new_opportunity.yaml
@@ -1,7 +1,7 @@
 name: New Hackathon
 description: Contribute a hackathon to our list
 title: "New Hackathon"
-labels: ["new_opportunity"]
+labels: ["new_opportunity", "community"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/quick_add.yaml
+++ b/.github/ISSUE_TEMPLATE/quick_add.yaml
@@ -1,7 +1,7 @@
 name: Quick Add
 description: Quickly add a hackathon with just a link and basic info
 title: "Quick Add"
-labels: ["new_opportunity", "quick_add"]
+labels: ["new_opportunity", "quick_add", "community"]
 body:
   - type: markdown
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,16 @@
 
 Thank you for your interest in contributing! This repository aims to be a single, always-current list of hackathons worth attending.
 
+## Two Ways to Contribute
+
+There are two lanes, and most people only need the first:
+
+**1. Add hackathons — open to everyone, no repo access needed.**
+Spotted a hackathon, a wrong deadline, or a page that needs verifying? Open an issue (see [How to Add a Hackathon](#how-to-add-a-hackathon) below). A maintainer approves it and the automation does the rest. You'll be credited as a contributor, and you never need push access to do this. Issues in this lane are tagged [`community`](../../issues?q=is%3Aissue+label%3Acommunity).
+
+**2. Work on the software — invited developers.**
+Building the site, the automation scripts, and fixing bugs is done by developers we invite to the repo. Those issues carry labels like `frontend`, `backend`, `infra`, `security`, and `bug`, and are locked to collaborators. Not on the dev team yet? You can still propose code by **forking the repo and opening a pull request** — a maintainer reviews it. Want to join the team? Add a few hackathons first, then reach out to a maintainer.
+
 ## How to Add a Hackathon
 
 ### Just Paste the Link! (Recommended)


### PR DESCRIPTION
## What & why

Codifies the **data-vs-dev** contribution model so the two lanes are obvious and self-sorting.

### 1. Auto-apply the `community` label to data-lane issue templates
Every data submission now opens pre-labeled `community`, keeping it visually separate from invited-developer work (`frontend` / `backend` / `infra` / `security` / `bug`).

| Template | Labels before | Labels after |
|---|---|---|
| Add Hackathon (Just Paste Link) | `new_opportunity`, `auto_extract` | + `community` |
| New Hackathon | `new_opportunity` | + `community` |
| Quick Add | `new_opportunity`, `quick_add` | + `community` |
| Edit Hackathon | `edit_opportunity` | + `community` |
| Close Hackathon | `close_opportunity` | + `community` |
| Share a Hackathon Photo | `gallery` | + `community` |

- Existing automation labels are preserved — `auto_extract.yml` / `contribution_approved.yml` triggers (which key off `approved` + `auto_extract` / `new_opportunity` / `close_opportunity`) are unaffected by the extra label.
- **`Other`** is intentionally left unlabeled (catch-all for questions / bug reports / dev requests).

### 2. CONTRIBUTING.md — "Two Ways to Contribute"
Documents the model in words: add hackathons (anyone, via issues, no repo access) vs. work on the software (invited developers; others propose via fork + PR).

## Notes
- The `community` label already exists on the repo and has been applied to the current data issues (#38, #39).
- Companion governance changes made outside this PR: `main` is protected against force-push/deletion, and the dev/app issues (#10–#20, #41–#51) are locked to collaborators-only.

## Test / verify after merge
- Open a new issue from the "Just Paste Link" template → it should arrive pre-tagged `community`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
