### PR TITLE
fix(ci): repair invalid `contribution_approved` workflow + harden untrusted inputs

### DIFF
--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -8,6 +8,10 @@ concurrency:
   group: add_opportunity
   cancel-in-progress: false
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   process-contribution:
     # Only run for non-auto_extract issues (manual submissions)
@@ -36,14 +40,23 @@ jobs:
           python .github/scripts/update_readmes.py
 
       - name: Configure Git
+        env:
+          CONTRIBUTOR_NAME: ${{ steps.process.outputs.contributor_name }}
+          CONTRIBUTOR_EMAIL: ${{ steps.process.outputs.contributor_email }}
         run: |
-          git config user.name "${{ steps.process.outputs.contributor_name }}"
-          git config user.email "${{ steps.process.outputs.contributor_email }}"
+          git config user.name "$CONTRIBUTOR_NAME"
+          git config user.email "$CONTRIBUTOR_EMAIL"
 
       - name: Commit and push changes
+        env:
+          COMMIT_MSG: ${{ steps.process.outputs.commit_message }}
         run: |
           git add .github/scripts/listings.json README.md assets/hackathons-banner.svg
-          git commit -m "${{ steps.process.outputs.commit_message }}"
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "$COMMIT_MSG"
+          fi
           # Rebase and retry push up to 3 times
           for i in 1 2 3; do
             git fetch origin main && git rebase origin/main && git push origin main && break
@@ -72,11 +85,14 @@ jobs:
       - name: Comment on failure
         if: failure()
         uses: actions/github-script@v7
+        env:
+          ERROR_MSG: ${{ steps.process.outputs.error_message || steps.update_readme.outputs.error_message }}
         with:
           script: |
+            const errorMsg = process.env.ERROR_MSG || 'Unknown error';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ There was an error processing your contribution. A maintainer will review this issue.\n\nError details: ${{ steps.process.outputs.error_message || steps.update_readme.outputs.error_message || "Unknown error" }}'
+              body: '❌ There was an error processing your contribution. A maintainer will review this issue.\n\nError details: ' + errorMsg
             });


### PR DESCRIPTION
## Problem
`contribution_approved.yml` was an **invalid workflow file** and startup-failed on **every event** (visible as a string of failed `push` runs going back to commits before this work). The cause is on the "Comment on failure" step:

```yaml
body: '... Error details: ${{ steps.process.outputs.error_message || steps.update_readme.outputs.error_message || "Unknown error" }}'
```

GitHub Actions expressions only allow **single-quoted** string literals; the double-quoted `"Unknown error"` is a syntax error that invalidates the whole file. Because the file never loaded, the **manual contribution approval path never ran** (the "Just Paste Link" flow uses the separate, healthy `auto_extract.yml`, so only manual `New Hackathon` / `Close Hackathon` → `approved` submissions were affected).

## Fix
1. **Repair the syntax error** — move `error_message` into `env:` and default to `'Unknown error'` in JS. This also removes the script-injection into the `github-script` body flagged in #41.
2. **Harden the other injection sinks** (they go *live* the moment the workflow starts running again): `commit_message`, `contributor_name`, and `contributor_email` now flow through `env:` and are referenced as quoted shell vars instead of `${{ }}` interpolation into `run:`.
3. **No-op commit guard** — an empty diff no longer fails the run and posts a spurious "error processing your contribution" comment.
4. **Least-privilege `permissions:`** block added (`contents: write`, `issues: write`) — the file previously had none and fell back to the default token scopes.

## Verification
- YAML parses; no double-quoted literal remains inside any `${{ }}`.
- Pushing this branch produced **no** `contribution_approved` startup-failure for the commit, whereas prior branch pushes (with the broken file) did — confirming GitHub now accepts the file.

## Out of scope (tracked in #41)
`auto_extract.yml` has the analogous `commit_message` injection on its own commit step. It's left untouched here to avoid risk to the primary, currently-working add-hackathon flow; it should get the same `env:` treatment as a follow-up.

Refs #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
