### PR TITLE
security: harden CI pipeline against untrusted input (#41, #44, #45)

### DIFF
--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -8,10 +8,13 @@ This script:
 3. Adds the hackathon to listings.json
 """
 
+import ipaddress
 import json
 import os
+import socket
 import sys
 import re
+from urllib.parse import urljoin, urlparse
 import requests
 from bs4 import BeautifulSoup
 import util
@@ -24,6 +27,65 @@ except ImportError:
     HAS_OPENAI = False
 
 
+MAX_REDIRECTS = 5
+
+
+def _resolved_ips_are_public(host):
+    """Resolve a hostname and ensure no address is private/loopback/internal.
+
+    Returns (ok, reason). Blocks SSRF to the cloud metadata endpoint
+    (169.254.169.254), localhost, and RFC1918 / link-local / reserved ranges.
+    """
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False, f"Could not resolve host: {host}"
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False, f"Unresolvable address for host: {host}"
+        if (ip.is_private or ip.is_loopback or ip.is_link_local
+                or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
+            return False, f"Refusing to fetch internal address {ip} (host {host})"
+    return True, None
+
+
+def _validate_fetch_url(url):
+    """Allow only http(s) URLs pointing at public hosts."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False, f"Only http(s) URLs may be fetched (got '{parsed.scheme}')"
+    if not parsed.hostname:
+        return False, "URL has no host"
+    return _resolved_ips_are_public(parsed.hostname)
+
+
+def safe_get(url, headers, timeout=30):
+    """requests.get with SSRF protection and per-hop redirect validation.
+
+    Never falls back to verify=False — TLS errors propagate. Redirects are
+    followed manually so every hop's host is re-checked against the SSRF guard.
+    """
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        ok, reason = _validate_fetch_url(current)
+        if not ok:
+            raise ValueError(reason)
+        response = requests.get(
+            current, headers=headers, timeout=timeout, allow_redirects=False
+        )
+        if response.is_redirect or response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("Location")
+            if not location:
+                return response
+            current = urljoin(current, location)
+            continue
+        return response
+    raise ValueError("Too many redirects while fetching URL")
+
+
 def fetch_page_content(url):
     """Fetch and parse webpage content."""
     headers = {
@@ -33,11 +95,9 @@ def fetch_page_content(url):
     }
 
     try:
-        try:
-            response = requests.get(url, headers=headers, timeout=30, allow_redirects=True)
-        except requests.exceptions.SSLError:
-            print(f"SSL verification failed for {url}, retrying without verification...")
-            response = requests.get(url, headers=headers, timeout=30, allow_redirects=True, verify=False)
+        # Fail closed on TLS errors (no verify=False fallback) and block SSRF to
+        # internal/loopback/link-local hosts, re-checking on every redirect hop.
+        response = safe_get(url, headers=headers, timeout=30)
         response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "html.parser")
@@ -309,11 +369,14 @@ def main():
 
     print(f"Extracted: {json.dumps(extracted, indent=2)}")
 
-    # Validate extracted data
-    company_name = extracted.get("company_name", "").strip()
-    title = extracted.get("title", "").strip()
-    locations = extracted.get("locations", [])
-    fmt = extracted.get("format", "")
+    # Validate extracted data. Model output is fully untrusted: coalesce nulls
+    # (a JSON `null` makes .get() return None, so a bare .strip() would crash),
+    # and sanitize the free-text host/title before they reach listings.json or a
+    # commit message.
+    company_name = util.sanitize_field(extracted.get("company_name"))
+    title = util.sanitize_field(extracted.get("title"))
+    locations = extracted.get("locations") or []
+    fmt = (extracted.get("format") or "").strip()
 
     if not company_name or company_name == "Unknown":
         util.fail("AI extraction failed: could not determine the host/organizer. Please use the Quick Add template instead.")
@@ -344,20 +407,20 @@ def main():
     # Check for duplicates (by URL or by host+title)
     listings = util.get_listings_from_json()
     for listing in listings:
-        if listing["url"] == url:
+        if listing.get("url") == url:
             util.set_output("is_duplicate", "true")
-            util.set_output("duplicate_id", listing["id"])
+            util.set_output("duplicate_id", listing.get("id", ""))
             util.set_output("duplicate_reason", f"This URL already exists in the repository")
             util.set_output("commit_message", "")
-            print(f"DUPLICATE DETECTED: URL already exists (ID: {listing['id']})")
+            print(f"DUPLICATE DETECTED: URL already exists (ID: {listing.get('id')})")
             sys.exit(0)
-        if (listing["company_name"].lower() == company_name.lower() and
-                listing["title"].lower() == title.lower()):
+        if (str(listing.get("company_name", "")).lower() == company_name.lower() and
+                str(listing.get("title", "")).lower() == title.lower()):
             util.set_output("is_duplicate", "true")
-            util.set_output("duplicate_id", listing["id"])
+            util.set_output("duplicate_id", listing.get("id", ""))
             util.set_output("duplicate_reason", f"'{company_name} - {title}' already exists in the repository")
             util.set_output("commit_message", "")
-            print(f"DUPLICATE DETECTED: {company_name} - {title} already exists (ID: {listing['id']})")
+            print(f"DUPLICATE DETECTED: {company_name} - {title} already exists (ID: {listing.get('id')})")
             sys.exit(0)
 
     # Create the listing
@@ -397,4 +460,10 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        # util.fail() and the duplicate path exit intentionally — let them.
+        raise
+    except Exception as e:
+        util.fail(f"Unexpected error during extraction: {e}")

--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -100,10 +100,10 @@ def handle_new_opportunity(data, username, is_quick_add=False):
             util.fail(f"Duplicate: This hackathon already exists (ID: {listing['id']})")
 
     # Get host name - handle both templates
-    company_name = get_first(data, "host/organizer", "host/organizer_name") 
+    company_name = util.sanitize_field(get_first(data, "host/organizer", "host/organizer_name")) 
 
     # Get title - handle both templates
-    title = get_first(data, "hackathon_name", "hackathon_name/edition")
+    title = util.sanitize_field(get_first(data, "hackathon_name", "hackathon_name/edition"))
 
     # Parse locations (default to "Online" if not provided)
     locations_str = get_first(data, "location", "location_(optional)")
@@ -159,8 +159,10 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     # Set outputs
     util.set_output("commit_message", f"Add {company_name} - {title}")
     util.set_output("contributor_name", username)
+    # Validate the contributor-supplied email before it reaches `git config`;
+    # fall back to the bot address if it isn't a clean single-line address.
     email = get_first(data, "email_associated_with_your_github_account_(optional)")
-    util.set_output("contributor_email", email if email else "actions@github.com")
+    util.set_output("contributor_email", email if util.is_valid_email(email) else "actions@github.com")
 
     print(f"Successfully added: {company_name} - {title}")
 

--- a/.github/scripts/generate_gallery.py
+++ b/.github/scripts/generate_gallery.py
@@ -37,7 +37,16 @@ def load_gallery():
 
 
 def esc(text):
-    return (str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    # Escape &, <, >, " and ' so a value containing a quote cannot break out of
+    # the href/src/alt attributes below.
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
 
 
 def tile(photo):

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,3 +1,4 @@
-requests>=2.28.0
-beautifulsoup4>=4.11.0
-openai>=1.0.0
+# Pinned for reproducible CI (see issue #45). Bump deliberately.
+requests==2.32.3
+beautifulsoup4==4.12.3
+openai==1.54.4

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -2,8 +2,10 @@
 Utility functions for managing hackathon listings.
 """
 
+import html
 import json
 import os
+import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -105,16 +107,55 @@ def format_locations(locations):
     return f"<details><summary>{len(locations)} locations</summary>{joined}</details>"
 
 
+def escape_attr(value):
+    """Escape a value for safe interpolation into an HTML attribute.
+
+    Escapes &, <, >, " and ' so a value containing a quote cannot break out of
+    an href/src/alt attribute in the generated README markup.
+    """
+    return html.escape(str(value), quote=True)
+
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def sanitize_field(value, max_len=200):
+    """Normalize an untrusted free-text field (host / title).
+
+    Removes control characters, collapses whitespace, and truncates. These
+    values flow into commit messages, listings.json, and generated markup, so
+    stripping control/newline characters stops them smuggling extra lines or
+    breaking formatting even when the shell interpolation is already quoted.
+    """
+    text = _CONTROL_CHARS.sub(" ", str(value or ""))
+    text = _WHITESPACE.sub(" ", text).strip()
+    if len(text) > max_len:
+        text = text[:max_len].rstrip()
+    return text
+
+
+_EMAIL_RE = re.compile(r"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$")
+
+
+def is_valid_email(email):
+    """Return True for a syntactically valid, single-line email address."""
+    if not isinstance(email, str):
+        return False
+    email = email.strip()
+    return len(email) <= 254 and bool(_EMAIL_RE.match(email))
+
+
 def format_link(url):
     """Format the registration link as a blue button."""
     button_url = "https://img.shields.io/badge/Register-blue?style=for-the-badge"
-    return f'<a href="{url}"><img src="{button_url}" alt="Register"></a>'
+    return f'<a href="{escape_attr(url)}"><img src="{button_url}" alt="Register"></a>'
 
 
 def format_website_link(url):
     """Format a plain website link as a gray button (for upcoming events)."""
     button_url = "https://img.shields.io/badge/Website-gray?style=for-the-badge"
-    return f'<a href="{url}"><img src="{button_url}" alt="Website"></a>'
+    return f'<a href="{escape_attr(url)}"><img src="{button_url}" alt="Website"></a>'
 
 
 def resolve_state(listing):

--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
       - name: Install dependencies
         run: |
-          pip install requests beautifulsoup4 openai
+          pip install -r .github/scripts/requirements.txt
 
       - name: Extract opportunity details
         id: extract
@@ -47,11 +47,13 @@ jobs:
 
       - name: Commit and push changes
         if: steps.extract.outputs.is_duplicate != 'true' && steps.extract.outputs.commit_message != ''
+        env:
+          COMMIT_MSG: ${{ steps.extract.outputs.commit_message }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/scripts/listings.json README.md assets/hackathons-banner.svg
-          git commit -m "${{ steps.extract.outputs.commit_message }}" || echo "No changes to commit"
+          git commit -m "$COMMIT_MSG" || echo "No changes to commit"
           # Rebase and retry push up to 3 times
           for i in 1 2 3; do
             git fetch origin main && git rebase origin/main && git push origin main && break
@@ -61,7 +63,7 @@ jobs:
 
       - name: Handle duplicate detection
         if: steps.extract.outputs.is_duplicate == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const duplicateReason = process.env.DUPLICATE_REASON || 'This opportunity already exists in the repository';
@@ -83,7 +85,7 @@ jobs:
 
       - name: Comment on issue (success)
         if: success() && steps.extract.outputs.is_duplicate != 'true' && steps.extract.outputs.commit_message != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             let extractedData = {};
@@ -123,7 +125,7 @@ jobs:
 
       - name: Close issue
         if: success() && steps.extract.outputs.is_duplicate != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.update({
@@ -135,7 +137,7 @@ jobs:
 
       - name: Comment on issue (failure)
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const errorMessage = process.env.ERROR_MSG || 'An unknown error occurred during extraction.';

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -12,9 +12,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -33,11 +33,13 @@ jobs:
 
       - name: Commit and push
         if: steps.check.outputs.has_changes == 'true'
+        env:
+          CHANGES: ${{ steps.run.outputs.changes }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md assets/hackathons-banner.svg
-          git commit -m "chore: update closing-soon badges (${{ steps.run.outputs.changes }} changes)"
+          git commit -m "chore: update closing-soon badges (${CHANGES:-0} changes)"
           for i in 1 2 3; do
             git fetch origin main && git rebase origin/main && git push origin main && break
             echo "Push attempt $i failed, retrying..."

--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Close issue with success message
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.issues.createComment({
@@ -84,7 +84,7 @@ jobs:
 
       - name: Comment on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ERROR_MSG: ${{ steps.process.outputs.error_message || steps.update_readme.outputs.error_message }}
         with:

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -16,9 +16,9 @@ jobs:
   update-gallery:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -8,16 +8,19 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 
@@ -37,11 +40,13 @@ jobs:
 
       - name: Commit and push
         if: steps.check.outputs.has_changes == 'true'
+        env:
+          COMMIT_MSG: ${{ steps.update.outputs.commit_message }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md assets/hackathons-banner.svg
-          git commit -m "${{ steps.update.outputs.commit_message }}"
+          git commit -m "${COMMIT_MSG:-chore: update README}"
           for i in 1 2 3; do
             git fetch origin main && git rebase origin/main && git push origin main && break
             echo "Push attempt $i failed, retrying..."
@@ -50,6 +55,8 @@ jobs:
 
       - name: Report failure
         if: failure()
+        env:
+          ERROR_MSG: ${{ steps.update.outputs.error_message }}
         run: |
-          echo "Error updating README: ${{ steps.update.outputs.error_message }}"
+          echo "Error updating README: ${ERROR_MSG:-Unknown error}"
           exit 1

--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -13,9 +13,9 @@ jobs:
   digest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
       },
     ],
     dangerouslyAllowSVG: true,
+    // Pair the SVG allowance with a strict CSP + forced download so a
+    // user-influenced SVG served through next/image can't execute script.
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    contentDispositionType: "attachment",
   },
   turbopack: {
     resolveAlias: {


### PR DESCRIPTION
Closes #41, closes #44, closes #45.

First of a stacked series addressing the audit issues (merge bottom-up: this → #43 → #46/#47 → #48 → #51 → #54).

## #41 (Critical) — Actions command/script injection
- Untrusted/derived step outputs (`commit_message`, `error_message`, `changes`) now flow through `env:` and are referenced as **quoted shell vars**, never interpolated as `${{ }}` inside `run:` bodies — `auto_extract.yml`, `update_readmes.yml`, `closing_soon.yml`. (`contribution_approved.yml` was already env-hardened in #55; this PR only pins its actions.)
- `contributor_email` is validated (strict regex) and host/title are sanitized in Python before reaching `git config` / commit messages.

## #44 (Security) — `auto_extract.py` untrusted input
- **TLS:** removed the `verify=False` fallback — SSL errors now fail closed.
- **SSRF:** `safe_get()` allows only `http(s)`, resolves the host and rejects private/loopback/link-local/reserved IPs, and re-validates on **every redirect hop**.
- **Crashes:** null model fields are coalesced (`extracted.get(x) or ""`), dedup uses `listing.get()`, and `main()` is wrapped so unexpected errors become a clean `util.fail`.

## #45 (Security) — config hardening
- `permissions: contents: write` added to `update_readmes.yml`.
- All actions pinned to commit SHAs (`checkout` v4.3.1, `setup-python` v5.6.0, `github-script` v7.1.0); Python deps installed from a pinned `requirements.txt`.
- `"`/`'` escaped in generated markup (`util.format_link`, `generate_gallery.esc`).
- `dangerouslyAllowSVG` paired with a strict CSP + `attachment` disposition in `next.config.ts`.

## Verification
- ✅ All scripts `py_compile`
- ✅ 17 unit checks pass for the new sanitize / email / SSRF / escape helpers (loopback, `169.254.169.254`, RFC1918, `file://` all rejected; public https allowed)
- ✅ All 6 workflows parse as valid YAML
- ✅ `next build` succeeds

## Notes / not included
- DNS-rebinding (TOCTOU between resolve and connect) is out of scope for the stated acceptance criteria; the getaddrinfo + per-hop check meets them and is a large improvement.
- Retries/timeouts on `requests.get`/OpenAI (also mentioned in the audit) are handled in the reliability PR (#46), not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)