### PR TITLE
chore: tech-debt cleanup checklist (#51)

### DIFF
--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -261,57 +261,11 @@ Return ONLY valid JSON, no other text."""
         util.fail(f"OpenAI API error: {str(e)}")
 
 
-def parse_issue_body(body):
-    """Parse the issue body to get URL and notes."""
-    lines = body.strip().split("\n")
-    data = {}
-
-    current_field = None
-    current_value = []
-
-    for line in lines:
-        if line.startswith("### "):
-            if current_field and current_value:
-                data[current_field] = "\n".join(current_value).strip()
-            # Convert "Link to Hackathon" -> "link_to_hackathon"
-            current_field = line[4:].strip().lower().replace(" ", "_").replace("?", "").replace("(", "").replace(")", "")
-            current_value = []
-        elif current_field:
-            if line.strip() and line.strip() != "_No response_":
-                current_value.append(line)
-
-    if current_field and current_value:
-        data[current_field] = "\n".join(current_value).strip()
-
-    return data
-
-
-def parse_state(data):
-    """Map optional issue status field to listing state."""
-    status = (data.get("status", "") or "").strip().lower()
-    if "soon" in status:
-        return "opens_soon"
-    if "open" in status:
-        return "open"
-    # Sensible default for auto-extracted listings.
-    return "open"
-
-
-def parse_deadline(data):
-    """Parse optional deadline and normalize to ISO YYYY-MM-DD."""
-    raw = (data.get("deadline_optional", "") or data.get("deadline", "")).strip()
-    if not raw:
-        return None
-    try:
-        return util.parse_deadline_date(raw).isoformat()
-    except ValueError:
-        util.fail("Invalid deadline format. Please use YYYY-MM-DD or MM/DD/YYYY.")
-
-
 def extract_url_from_body(body):
     """Try multiple methods to extract URL from issue body."""
-    # Method 1: Parse structured fields
-    data = parse_issue_body(body)
+    # Method 1: Parse structured fields (strip_symbols matches the field keys
+    # this script looks up, e.g. deadline_optional).
+    data = util.parse_issue_body(body, strip_symbols=True)
 
     # Try various field names
     url_fields = [
@@ -365,8 +319,8 @@ def main():
     print(f"Extracted URL: {url}")
 
     notes = data.get("any_additional_context_optional", "") or data.get("notes", "")
-    state = parse_state(data)
-    deadline = parse_deadline(data)
+    state = util.parse_state(data)
+    deadline = util.parse_deadline(data, "deadline_optional", "deadline")
 
     print(f"Fetching content from: {url}")
 

--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -26,64 +26,6 @@ def get_first(data, *keys):
     return ""
 
 
-def parse_state(data):
-    """Map issue fields to listing state."""
-    status = get_first(data, "status")
-    status_lc = status.lower()
-    if "soon" in status_lc:
-        return "opens_soon"
-    if "open" in status_lc:
-        return "open"
-
-    # Backward compatibility with older template field.
-    active_str = get_first(
-        data,
-        "is_this_hackathon_currently_open_for_registration?",
-        "is_this_hackathon_currently_open_for_registration",
-    ).lower()
-    if active_str == "no":
-        return "opens_soon"
-    return "open"
-
-
-def parse_deadline(data):
-    """Parse optional deadline and normalize to ISO YYYY-MM-DD."""
-    raw = get_first(data, "deadline", "deadline_(optional)")
-    if not raw:
-        return None
-    try:
-        return util.parse_deadline_date(raw).isoformat()
-    except ValueError:
-        util.fail("Invalid deadline format. Please use YYYY-MM-DD or MM/DD/YYYY.")
-
-
-def parse_issue_body(body, labels):
-    """Parse the issue body based on issue type."""
-    lines = body.strip().split("\n")
-    data = {}
-
-    current_field = None
-    current_value = []
-
-    for line in lines:
-        # Check for field headers (### Field Name)
-        if line.startswith("### "):
-            if current_field and current_value:
-                data[current_field] = "\n".join(current_value).strip()
-            current_field = line[4:].strip().lower().replace(" ", "_")
-            current_value = []
-        elif current_field:
-            # Skip "_No response_" placeholders
-            if line.strip() != "_No response_":
-                current_value.append(line)
-
-    # Don't forget the last field
-    if current_field and current_value:
-        data[current_field] = "\n".join(current_value).strip()
-
-    return data
-
-
 def handle_new_opportunity(data, username, is_quick_add=False):
     """Handle adding a new hackathon."""
     listings = util.get_listings_from_json()
@@ -125,8 +67,8 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     # Get prize (optional)
     prize = get_first(data, "prize_pool_(optional)", "prize") or "—"
     # Map user-submitted status/deadline fields into canonical listing fields.
-    state = parse_state(data)
-    deadline = parse_deadline(data)
+    state = util.parse_state(data)
+    deadline = util.parse_deadline(data, "deadline", "deadline_(optional)")
 
     # Create new listing
     new_listing = {
@@ -223,7 +165,7 @@ def main():
     username = issue.get("user", {}).get("login", "unknown")
 
     # Parse the issue body
-    data = parse_issue_body(body, labels)
+    data = util.parse_issue_body(body)
 
     # Check if this is a quick add
     is_quick_add = "quick_add" in labels

--- a/.github/scripts/generate_gallery.py
+++ b/.github/scripts/generate_gallery.py
@@ -51,12 +51,20 @@ def esc(text):
 
 def tile(photo):
     image = esc(photo["image"])
-    hackathon = esc(photo.get("hackathon", ""))
+    # Surface caption + credit so contributor attribution isn't dropped. In a
+    # justified image collage there's no room for a visible caption line, so the
+    # metadata rides along in the alt/title (hover tooltip + accessibility).
+    parts = [p for p in (photo.get("hackathon", ""), photo.get("caption", "")) if p]
+    credit = photo.get("credit", "")
+    credit_url = photo.get("credit_url", "")
+    if credit:
+        parts.append(f"Photo: {credit}" + (f" ({credit_url})" if credit_url else ""))
+    label = esc(" · ".join(parts)) if parts else esc(photo.get("hackathon", ""))
     # Fixed height + no width keeps each photo's aspect ratio, so they tile
     # together like a collage instead of sitting in separate boxes.
     return (
         f'<a href="{image}">'
-        f'<img src="{image}" height="{ROW_HEIGHT}" alt="{hackathon}"></a>'
+        f'<img src="{image}" height="{ROW_HEIGHT}" alt="{label}" title="{label}"></a>'
     )
 
 

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -8,7 +8,6 @@ import unittest
 from datetime import date
 
 import util
-import contribution_approved as ca
 import auto_extract as ax
 
 
@@ -55,24 +54,30 @@ class ParseIssueBody(unittest.TestCase):
             "### Hackathon Name\nHackMIT 2026\n\n"
             "### Link to Hackathon Page\nhttps://hackmit.org\n"
         )
-        data = ca.parse_issue_body(body, [])
+        data = util.parse_issue_body(body)
         self.assertEqual(data["hackathon_name"], "HackMIT 2026")
         self.assertEqual(data["link_to_hackathon_page"], "https://hackmit.org")
 
     def test_skips_no_response_placeholder(self):
-        data = ca.parse_issue_body("### Prize Pool (optional)\n_No response_\n", [])
+        data = util.parse_issue_body("### Prize Pool (optional)\n_No response_\n")
         self.assertFalse(data.get("prize_pool_(optional)"))
+
+    def test_strip_symbols_normalizes_keys(self):
+        data = util.parse_issue_body("### Deadline (optional)\n2026-07-04\n", strip_symbols=True)
+        self.assertEqual(data.get("deadline_optional"), "2026-07-04")
 
 
 class ParseStateAndDeadline(unittest.TestCase):
     def test_state(self):
-        self.assertEqual(ca.parse_state({"status": "Opens soon"}), "opens_soon")
-        self.assertEqual(ca.parse_state({"status": "Open now"}), "open")
-        self.assertEqual(ca.parse_state({}), "open")
+        self.assertEqual(util.parse_state({"status": "Opens soon"}), "opens_soon")
+        self.assertEqual(util.parse_state({"status": "Open now"}), "open")
+        self.assertEqual(util.parse_state({}), "open")
 
     def test_deadline(self):
-        self.assertEqual(ca.parse_deadline({"deadline": "2026-07-04"}), "2026-07-04")
-        self.assertIsNone(ca.parse_deadline({}))
+        self.assertEqual(
+            util.parse_deadline({"deadline": "2026-07-04"}, "deadline"), "2026-07-04"
+        )
+        self.assertIsNone(util.parse_deadline({}, "deadline"))
 
 
 class SsrfGuard(unittest.TestCase):

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -258,6 +258,80 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
+DEFAULT_REPO = "Jose-Gael-Cruz-Lopez/hackhq"
+
+
+def repo_slug():
+    """owner/repo — from GITHUB_REPOSITORY (set by Actions) or the default."""
+    return os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO
+
+
+def repo_url():
+    """Base GitHub URL for this repository."""
+    return f"https://github.com/{repo_slug()}"
+
+
+def parse_issue_body(body, strip_symbols=False):
+    """Parse a GitHub issue body's '### Field' sections into a {field: value} dict.
+
+    Field names are lowercased with spaces -> underscores. Set strip_symbols=True
+    to also drop ? ( ) from keys (used where field lookups omit those chars).
+    Shared by contribution_approved.py and auto_extract.py.
+    """
+    data = {}
+    current_field = None
+    current_value = []
+    for line in body.strip().split("\n"):
+        if line.startswith("### "):
+            if current_field and current_value:
+                data[current_field] = "\n".join(current_value).strip()
+            name = line[4:].strip().lower().replace(" ", "_")
+            if strip_symbols:
+                name = name.replace("?", "").replace("(", "").replace(")", "")
+            current_field = name
+            current_value = []
+        elif current_field:
+            if line.strip() and line.strip() != "_No response_":
+                current_value.append(line)
+    if current_field and current_value:
+        data[current_field] = "\n".join(current_value).strip()
+    return data
+
+
+def parse_state(data):
+    """Map issue status fields to a listing state (open / opens_soon)."""
+    status = str(data.get("status") or "").strip().lower()
+    if "soon" in status:
+        return "opens_soon"
+    if "open" in status:
+        return "open"
+    # Backward compatibility with the older registration-open field.
+    active = str(
+        data.get("is_this_hackathon_currently_open_for_registration?")
+        or data.get("is_this_hackathon_currently_open_for_registration")
+        or ""
+    ).strip().lower()
+    if active == "no":
+        return "opens_soon"
+    return "open"
+
+
+def parse_deadline(data, *keys):
+    """Return an ISO deadline from the first present key, or None (fail on bad format)."""
+    raw = ""
+    for key in keys:
+        value = data.get(key)
+        if value and str(value).strip():
+            raw = str(value).strip()
+            break
+    if not raw:
+        return None
+    try:
+        return parse_deadline_date(raw).isoformat()
+    except ValueError:
+        fail("Invalid deadline format. Please use YYYY-MM-DD or MM/DD/YYYY.")
+
+
 def clean_url(url):
     """Clean and normalize a URL."""
     url = url.strip()

--- a/.github/scripts/weekly_digest.py
+++ b/.github/scripts/weekly_digest.py
@@ -15,6 +15,8 @@ import re
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+import util
+
 PST = ZoneInfo("America/Los_Angeles")
 README = os.path.join(os.path.dirname(__file__), "..", "..", "README.md")
 DIGEST = os.path.join(os.path.dirname(__file__), "..", "..", "digest.md")
@@ -123,7 +125,7 @@ def main():
     out = []
     out.append(f"# 📬 Weekly Digest — {today.strftime('%B %d, %Y')}\n")
     out.append(
-        f"_Auto-generated. Source: [README.md](https://github.com/Jose-Gael-Cruz-Lopez/hackhq)._\n"
+        f"_Auto-generated. Source: [README.md]({util.repo_url()})._\n"
     )
 
     if closing_rows:
@@ -142,7 +144,7 @@ def main():
         out.append("\nNo new entries or closing-soon flags this week. Stay tuned 🌱\n")
 
     out.append(
-        f"\n---\n_Want to contribute? [Open an issue](https://github.com/Jose-Gael-Cruz-Lopez/hackhq/issues/new/choose)._"
+        f"\n---\n_Want to contribute? [Open an issue]({util.repo_url()}/issues/new/choose)._"
     )
 
     with open(DIGEST, "w") as f:

--- a/georgetown
+++ b/georgetown
@@ -1,1 +1,0 @@
-| ✅ [OPEN] | Georgetown University | Hoya Hacks 2027 — Jan 22–24, 2027 | In-Person | Washington, DC | 1 non-cash prize | <a href="https://hoya-hacks-2027.devpost.com/"><img src="https://img.shields.io/badge/Register-blue?style=for-the-badge" alt="Register"></a> | Jun 27, 2026 |

--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import type { Hackathon, HackState } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
-import { useHQ } from "./store";
+import { useSelection, useTracker } from "./store";
 
 type StatusFilter = "all" | HackState;
 type FormatFilter = "all" | "In-Person" | "Virtual";
@@ -169,7 +169,7 @@ function FilterPill({
 }
 
 function SaveHeart({ h, dark }: { h: Hackathon; dark?: boolean }) {
-  const { isTracked, save, remove } = useHQ();
+  const { isTracked, save, remove } = useTracker();
   const tracked = isTracked(h.id);
   return (
     <button
@@ -225,7 +225,7 @@ const SPRING_SLOW = { type: "spring", bounce: 0.2, duration: 1.5 } as const;
  * lifts and tilts out of the folder on hover while the flap swings open.
  */
 function HackCard({ h }: { h: Hackathon }) {
-  const { setSelected } = useHQ();
+  const { setSelected } = useSelection();
   const reduceMotion = useReducedMotion();
   const meta = STATE_META[h.state];
   const cd = countdown(h);
@@ -340,7 +340,7 @@ function HackCard({ h }: { h: Hackathon }) {
 }
 
 function HackRow({ h }: { h: Hackathon }) {
-  const { setSelected } = useHQ();
+  const { setSelected } = useSelection();
   const meta = STATE_META[h.state];
   const cd = countdown(h);
 

--- a/web/components/hq/detail-modal.tsx
+++ b/web/components/hq/detail-modal.tsx
@@ -2,19 +2,21 @@
 
 import { useEffect } from "react";
 import { STATE_META, countdown, deadlineDisplay } from "@/lib/types-hq";
-import { useHQ } from "./store";
+import { lockScroll } from "@/lib/scroll-lock";
+import { useSelection, useTracker } from "./store";
 
 export function DetailModal() {
-  const { selected, setSelected, isTracked, save, remove } = useHQ();
+  const { selected, setSelected } = useSelection();
+  const { isTracked, save, remove } = useTracker();
 
   useEffect(() => {
     if (!selected) return;
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && setSelected(null);
     window.addEventListener("keydown", onKey);
-    document.body.style.overflow = "hidden";
+    const release = lockScroll();
     return () => {
       window.removeEventListener("keydown", onKey);
-      document.body.style.overflow = "";
+      release();
     };
   }, [selected, setSelected]);
 

--- a/web/components/hq/disc-player.tsx
+++ b/web/components/hq/disc-player.tsx
@@ -29,21 +29,23 @@ import FramerDiscPlayer from "@/components/vendor/DiscPlayer";
 const FRAMER_DEMO_MP3 =
   "https://framerusercontent.com/assets/8w3IUatLX9a5JVJ6XPCVuHi94.mp3";
 
-declare global {
-  interface Window {
-    __hqAudioPatched?: boolean;
-  }
-}
+// Intercept only `new Audio(FRAMER_DEMO_MP3)` so the vendored component's demo
+// track is silenced (the only sound is the user's Spotify). Runs lazily from
+// the component below rather than as a top-level import side effect, and is
+// idempotent, so it only takes effect when the disc player is actually used and
+// is safe under React's double render.
+let demoAudioMuted = false;
 
-if (typeof window !== "undefined" && !window.__hqAudioPatched) {
-  window.__hqAudioPatched = true;
+function muteFramerDemoAudio() {
+  if (demoAudioMuted || typeof window === "undefined") return;
+  demoAudioMuted = true;
   const RealAudio = window.Audio;
   const PatchedAudio = function (this: unknown, src?: string) {
     const a = new RealAudio(src);
     if (src === FRAMER_DEMO_MP3) {
       // The demo track must NEVER be heard: silence the element for real
-      // and make play() a no-op, so the only sound is the user's Spotify.
-      // ('ended' also never fires, so the needle never lifts mid-session.)
+      // and make play() a no-op. ('ended' also never fires, so the needle
+      // never lifts mid-session.)
       a.muted = true;
       a.volume = 0;
       a.play = () => Promise.resolve();
@@ -98,6 +100,10 @@ function parseSpotifyUri(input: string): string | null {
 }
 
 export function DiscPlayer() {
+  // Scope the demo-audio muting to the disc player: patch only when this
+  // component is actually rendered, not at module import time.
+  muteFramerDemoAudio();
+
   const [panelOpen, setPanelOpen] = useState(false);
   const [playing, setPlaying] = useState(false);
   const [hasMusic, setHasMusic] = useState(false);

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -5,7 +5,7 @@ import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import type { Hackathon } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
-import { useHQ } from "./store";
+import { useSelection } from "./store";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
 
@@ -21,7 +21,7 @@ const SECONDS_PER_REVOLUTION = 110;
 export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
-  const { setSelected } = useHQ();
+  const { setSelected } = useSelection();
   const [zoomedIn, setZoomedIn] = useState(false);
   const hasToken = Boolean(mapboxgl.accessToken);
 

--- a/web/components/hq/preloader.tsx
+++ b/web/components/hq/preloader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { lockScroll } from "@/lib/scroll-lock";
 
 /**
  * Curtain-reveal load screen - native rebuild of the Framer
@@ -28,16 +29,16 @@ export function Preloader() {
       setGone(true);
       return;
     }
-    document.body.style.overflow = "hidden";
+    const release = lockScroll();
     const t1 = setTimeout(() => setCollapsed(true), HOLD_MS);
     const t2 = setTimeout(() => {
       setGone(true);
-      document.body.style.overflow = "";
+      release();
     }, TOTAL_MS);
     return () => {
       clearTimeout(t1);
       clearTimeout(t2);
-      document.body.style.overflow = "";
+      release();
     };
   }, []);
 

--- a/web/components/hq/store.tsx
+++ b/web/components/hq/store.tsx
@@ -21,17 +21,41 @@ export const STAGES: { id: Stage; label: string; color: string }[] = [
 
 type TrackerMap = Record<string, Stage>;
 
-type HQContext = {
+const STAGE_IDS = new Set<string>(STAGES.map((s) => s.id));
+
+/**
+ * Coerce an untrusted parsed localStorage value into a clean TrackerMap:
+ * keep only string ids mapped to a known Stage, drop everything else. Guards
+ * against a valid-JSON-but-wrong-shape payload being cast blindly.
+ */
+function sanitizeTrackerMap(value: unknown): TrackerMap {
+  if (!value || typeof value !== "object") return {};
+  const out: TrackerMap = {};
+  for (const [id, stage] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof stage === "string" && STAGE_IDS.has(stage)) {
+      out[id] = stage as Stage;
+    }
+  }
+  return out;
+}
+
+type TrackerContextValue = {
   tracked: TrackerMap;
   save: (id: string) => void;
   move: (id: string, stage: Stage) => void;
   remove: (id: string) => void;
   isTracked: (id: string) => boolean;
+};
+
+type SelectionContextValue = {
   selected: Hackathon | null;
   setSelected: (h: Hackathon | null) => void;
 };
 
-const Ctx = createContext<HQContext | null>(null);
+// Two contexts so a selection change (opening/closing the detail modal) doesn't
+// re-render every tracker consumer (all the deck cards), and vice versa.
+const TrackerCtx = createContext<TrackerContextValue | null>(null);
+const SelectionCtx = createContext<SelectionContextValue | null>(null);
 
 const LS_KEY = "hackhq-tracker-v1";
 
@@ -43,10 +67,10 @@ export function HQProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     try {
       const raw = localStorage.getItem(LS_KEY);
-      // Deliberate post-mount hydration: localStorage is unavailable during SSR,
-      // and doing this in a lazy initializer would cause a hydration mismatch.
+      // Deliberate post-mount hydration (localStorage is unavailable during
+      // SSR); validate the shape rather than trusting any valid JSON.
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      if (raw) setTracked(JSON.parse(raw));
+      if (raw) setTracked(sanitizeTrackerMap(JSON.parse(raw)));
     } catch {
       /* first visit / corrupted - start fresh */
     }
@@ -82,16 +106,32 @@ export function HQProvider({ children }: { children: React.ReactNode }) {
   );
   const isTracked = useCallback((id: string) => id in tracked, [tracked]);
 
-  const value = useMemo(
-    () => ({ tracked, save, move, remove, isTracked, selected, setSelected }),
-    [tracked, save, move, remove, isTracked, selected],
+  const trackerValue = useMemo(
+    () => ({ tracked, save, move, remove, isTracked }),
+    [tracked, save, move, remove, isTracked],
+  );
+  const selectionValue = useMemo(
+    () => ({ selected, setSelected }),
+    [selected],
   );
 
-  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+  return (
+    <TrackerCtx.Provider value={trackerValue}>
+      <SelectionCtx.Provider value={selectionValue}>
+        {children}
+      </SelectionCtx.Provider>
+    </TrackerCtx.Provider>
+  );
 }
 
-export function useHQ(): HQContext {
-  const ctx = useContext(Ctx);
-  if (!ctx) throw new Error("useHQ must be used inside <HQProvider>");
+export function useTracker(): TrackerContextValue {
+  const ctx = useContext(TrackerCtx);
+  if (!ctx) throw new Error("useTracker must be used inside <HQProvider>");
+  return ctx;
+}
+
+export function useSelection(): SelectionContextValue {
+  const ctx = useContext(SelectionCtx);
+  if (!ctx) throw new Error("useSelection must be used inside <HQProvider>");
   return ctx;
 }

--- a/web/components/hq/tracker.tsx
+++ b/web/components/hq/tracker.tsx
@@ -3,10 +3,11 @@
 import { useMemo, useState } from "react";
 import type { Hackathon } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
-import { STAGES, useHQ, type Stage } from "./store";
+import { STAGES, useSelection, useTracker, type Stage } from "./store";
 
 export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
-  const { tracked, move, remove, setSelected } = useHQ();
+  const { tracked, move, remove } = useTracker();
+  const { setSelected } = useSelection();
   const [dragId, setDragId] = useState<string | null>(null);
   const [overStage, setOverStage] = useState<Stage | null>(null);
 
@@ -22,7 +23,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
         items: Object.entries(tracked)
           .filter(([, stage]) => stage === s.id)
           .map(([id]) => byId[id])
-          .filter(Boolean)
+          .filter((h): h is Hackathon => Boolean(h))
           .sort((a, b) => (a.daysLeft ?? 9999) - (b.daysLeft ?? 9999)),
       })),
     [tracked, byId],

--- a/web/components/legacy/count-up.tsx
+++ b/web/components/legacy/count-up.tsx
@@ -14,7 +14,7 @@ export function CountUp({ end }: { end: number }) {
     let raf = 0;
     const io = new IntersectionObserver(
       ([entry]) => {
-        if (!entry.isIntersecting) return;
+        if (!entry?.isIntersecting) return;
         io.disconnect();
 
         const start = performance.now();

--- a/web/components/legacy/featured-work.tsx
+++ b/web/components/legacy/featured-work.tsx
@@ -46,7 +46,7 @@ export function FeaturedWork({
               className={SIZES[i] === "large" ? "tile-lg" : "tile-sm"}
               delay={i * 60}
             >
-              <ProjectTile opp={opp} size={SIZES[i]} index={i} />
+              <ProjectTile opp={opp} size={SIZES[i] ?? "small"} index={i} />
             </Reveal>
           ))}
         </div>

--- a/web/components/legacy/formats-card.tsx
+++ b/web/components/legacy/formats-card.tsx
@@ -79,7 +79,7 @@ export function FormatsCard({ formats }: { formats: FormatStat[] }) {
             0{active + 1}
           </span>
           <span className="text-sm font-medium">
-            {formats[active].label}
+            {formats[active]?.label}
           </span>
         </div>
 

--- a/web/components/legacy/reveal.tsx
+++ b/web/components/legacy/reveal.tsx
@@ -20,7 +20,7 @@ export function Reveal({
 
     const io = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) {
+        if (entry?.isIntersecting) {
           setVisible(true);
           io.disconnect();
         }

--- a/web/components/legacy/scroll-gallery.tsx
+++ b/web/components/legacy/scroll-gallery.tsx
@@ -150,8 +150,8 @@ export function ScrollGallery({
               aria-hidden
               className="gallery-backdrop absolute inset-0"
               style={{
-                backgroundImage: flyers[active].src
-                  ? `url(${flyers[active].src})`
+                backgroundImage: flyers[active]?.src
+                  ? `url(${flyers[active]?.src})`
                   : undefined,
               }}
             />

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -72,7 +72,7 @@ export function parsePrizeValue(prize: string | undefined): number {
   if (!prize) return 0;
   const m = prize.replace(/,/g, "").match(/\$\s*([\d.]+)\s*([kKmM])?/);
   if (!m) return 0;
-  const n = parseFloat(m[1]);
+  const n = parseFloat(m[1] ?? "");
   if (Number.isNaN(n)) return 0;
   const mult = m[2]?.toLowerCase() === "m" ? 1_000_000 : m[2] ? 1_000 : 1;
   return n * mult;
@@ -95,7 +95,9 @@ function noEmDash(s: string): string {
 
 export function splitTitle(title: string): { title: string; tagline: string | null } {
   const m = title.match(/^(.*?)\s*\(([^)]+)\)\s*$/);
-  if (m && m[1].length >= 6) return { title: m[1].trim(), tagline: m[2].trim() };
+  if (m && (m[1] ?? "").length >= 6) {
+    return { title: (m[1] ?? "").trim(), tagline: (m[2] ?? "").trim() };
+  }
   return { title: title.trim(), tagline: null };
 }
 

--- a/web/lib/parse-readme.test.ts
+++ b/web/lib/parse-readme.test.ts
@@ -30,10 +30,10 @@ describe("parseOpportunities", () => {
   it("parses a well-formed hackathons table", () => {
     const ops = parseOpportunities(md);
     expect(ops).toHaveLength(1);
-    expect(ops[0].organization).toBe("MIT");
-    expect(ops[0].title).toBe("HackMIT 2026");
-    expect(ops[0].status).toBe("OPEN");
-    expect(ops[0].url).toBe("https://hackmit.org/");
+    expect(ops[0]?.organization).toBe("MIT");
+    expect(ops[0]?.title).toBe("HackMIT 2026");
+    expect(ops[0]?.status).toBe("OPEN");
+    expect(ops[0]?.url).toBe("https://hackmit.org/");
   });
 
   it("returns [] when there is no table", () => {

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -8,6 +8,7 @@ import {
   Status,
   SECTION_LABELS,
 } from "./types";
+import { REPO_RAW_BASE } from "./repo";
 
 const README_PATH = path.join(process.cwd(), "..", "README.md");
 const REPO_ROOT = path.join(process.cwd(), "..");
@@ -17,9 +18,6 @@ const LISTINGS_PATH = path.join(
   "scripts",
   "listings.json",
 );
-const REPO_RAW_BASE =
-  "https://raw.githubusercontent.com/Jose-Gael-Cruz-Lopez/hackhq/main/";
-
 const TABLE_RE = /<!-- (\w+)_TABLE_START -->([\s\S]*?)<!-- \1_TABLE_END -->/g;
 
 const MONTH_MAP: Record<string, number> = {
@@ -45,7 +43,7 @@ function parseStatus(cell: string): Status {
 
 function extractUrl(cell: string): string {
   const m = cell.match(/href="([^"]+)"/);
-  return m ? m[1] : "";
+  return m ? (m[1] ?? "") : "";
 }
 
 function earliestUpcomingDate(text: string, today: Date): Date | null {
@@ -53,10 +51,10 @@ function earliestUpcomingDate(text: string, today: Date): Date | null {
   const re = new RegExp(DATE_RE.source, "g");
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
-    const monthIdx = MONTH_MAP[m[1].toLowerCase().replace(".", "")];
+    const monthIdx = MONTH_MAP[(m[1] ?? "").toLowerCase().replace(".", "")];
     if (monthIdx === undefined) continue;
-    const day = parseInt(m[2], 10);
-    const year = parseInt(m[3], 10);
+    const day = parseInt(m[2] ?? "", 10);
+    const year = parseInt(m[3] ?? "", 10);
     const d = new Date(year, monthIdx, day);
     if (d >= today && (!earliest || d < earliest)) earliest = d;
   }
@@ -95,7 +93,7 @@ function loadFeaturedUrls(): Set<string> {
 
 function inlineDeadline(text: string): string {
   const m = text.match(/Deadline:\s*([^|]+?)(?:\s*\(Event:|$)/i);
-  return m ? m[1].trim() : "";
+  return m ? (m[1] ?? "").trim() : "";
 }
 
 function stableId(...parts: string[]): string {
@@ -119,7 +117,7 @@ function extractStatsBannerSrc(markdown: string): string | null {
   const tag = markdown.match(/<img\s+[^>]*alt="Hackathon stats"[^>]*>/i);
   if (!tag) return null;
   const src = tag[0].match(/src="([^"]+)"/i);
-  return src ? resolveAssetSrc(src[1]) : null;
+  return src ? resolveAssetSrc(src[1] ?? "") : null;
 }
 
 function extractGallery(markdown: string): GalleryPhoto[] {
@@ -129,9 +127,9 @@ function extractGallery(markdown: string): GalleryPhoto[] {
   const photos: GalleryPhoto[] = [];
   let m: RegExpExecArray | null;
   const re = new RegExp(IMG_RE.source, "g");
-  while ((m = re.exec(block[1])) !== null) {
+  while ((m = re.exec(block[1] ?? "")) !== null) {
     photos.push({
-      src: resolveAssetSrc(m[1]),
+      src: resolveAssetSrc(m[1] ?? ""),
       alt: m[2] || "Hackathon photo",
     });
   }
@@ -150,7 +148,7 @@ function parseTableRows(
     .filter((l) => l.startsWith("|"));
   if (lines.length < 3) return [];
 
-  const headers = lines[0]
+  const headers = (lines[0] ?? "")
     .split("|")
     .slice(1, -1)
     .map((s) => s.trim());
@@ -252,9 +250,9 @@ export function parseOpportunities(markdown: string): Opportunity[] {
   let m: RegExpExecArray | null;
   const re = new RegExp(TABLE_RE.source, "g");
   while ((m = re.exec(markdown)) !== null) {
-    const key = SECTION_ALIAS[m[1]];
+    const key = SECTION_ALIAS[m[1] ?? ""];
     if (!key) continue;
-    all.push(...parseTableRows(key, m[2], today, featuredUrls));
+    all.push(...parseTableRows(key, m[2] ?? "", today, featuredUrls));
   }
   return all;
 }

--- a/web/lib/repo.ts
+++ b/web/lib/repo.ts
@@ -1,0 +1,7 @@
+// Single source of truth for the repository identity. Override via
+// NEXT_PUBLIC_REPO_SLUG (e.g. on a fork) so URLs don't silently break.
+export const REPO_SLUG =
+  process.env.NEXT_PUBLIC_REPO_SLUG ?? "Jose-Gael-Cruz-Lopez/hackhq";
+
+export const REPO_URL = `https://github.com/${REPO_SLUG}`;
+export const REPO_RAW_BASE = `https://raw.githubusercontent.com/${REPO_SLUG}/main/`;

--- a/web/lib/scroll-lock.ts
+++ b/web/lib/scroll-lock.ts
@@ -1,0 +1,27 @@
+// Shared body scroll-lock with reference counting. Multiple overlays (the
+// preloader curtain, the detail modal) can request a lock at once; the body
+// only scrolls again once every holder has released. This avoids the race
+// where one overlay's cleanup re-enables scrolling while another still needs
+// it locked.
+let locks = 0;
+let previousOverflow = "";
+
+export function lockScroll(): () => void {
+  if (typeof document === "undefined") return () => {};
+
+  if (locks === 0) {
+    previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+  locks += 1;
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    locks = Math.max(0, locks - 1);
+    if (locks === 0) {
+      document.body.style.overflow = previousOverflow;
+    }
+  };
+}

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -1,5 +1,7 @@
 /** Client-safe types + display helpers shared across HackHQ components. */
 
+import { REPO_URL } from "./repo";
+
 export type HackState = "open" | "opens_soon" | "closing_soon" | "closed";
 
 export type Hackathon = {
@@ -66,7 +68,7 @@ export function submitIssueUrl(name = "", url = ""): string {
   const body = encodeURIComponent(
     `**Hackathon name:** ${name || "…"}\n**URL:** ${url || "…"}\n**Location (City, ST or Online):** …\n**Deadline:** …\n**Prize pool:** …\n\n_Submitted via hackhq.dev - the pipeline will extract the rest._`,
   );
-  return `https://github.com/Jose-Gael-Cruz-Lopez/hackhq/issues/new?title=${title}&body=${body}`;
+  return `${REPO_URL}/issues/new?title=${title}&body=${body}`;
 }
 
-export const REPO_URL = "https://github.com/Jose-Gael-Cruz-Lopez/hackhq";
+export { REPO_URL };

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,10 @@
 import type { NextConfig } from "next";
 
+// Single source of repo identity (mirrors lib/repo.ts; kept inline so the
+// config file has no local-module import). Override via NEXT_PUBLIC_REPO_SLUG.
+const REPO_SLUG =
+  process.env.NEXT_PUBLIC_REPO_SLUG ?? "Jose-Gael-Cruz-Lopez/hackhq";
+
 const nextConfig: NextConfig = {
   logging: {
     browserToTerminal: false,
@@ -9,7 +14,7 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "raw.githubusercontent.com",
-        pathname: "/Jose-Gael-Cruz-Lopez/hackhq/**",
+        pathname: `/${REPO_SLUG}/**`,
       },
     ],
     dangerouslyAllowSVG: true,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -72,7 +72,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -359,6 +358,28 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1536,6 +1557,29 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -1979,7 +2023,6 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1990,7 +2033,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2050,7 +2092,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2689,7 +2730,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3043,7 +3083,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3637,7 +3676,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3823,7 +3861,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5669,7 +5706,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.10.tgz",
       "integrity": "sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.10",
         "@swc/helpers": "0.5.15",
@@ -6114,7 +6150,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6124,7 +6159,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6904,7 +6938,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7077,7 +7110,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7564,7 +7596,6 @@
       "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -3,6 +3,13 @@ import { NextResponse } from "next/server";
 
 // Clerk only takes over once its keys exist in .env.local — until then the
 // site runs exactly as before (the /my hub shows setup instructions instead).
+//
+// NOTE (intentional, for now): clerkMiddleware() here only wires up Clerk's
+// session context — it does NOT protect any route (no createRouteMatcher /
+// auth.protect()). The /my sign-in gate is enforced on the client only
+// (my-client.tsx). That's acceptable today because nothing is persisted
+// server-side, but a route matcher + auth.protect() MUST be added here before
+// any real server-side persistence is introduced. See web/README.md.
 const clerkConfigured =
   Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) &&
   Boolean(process.env.CLERK_SECRET_KEY);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
Closes #51 — all ten items. **Stacked on #63** (base `ci/web-app-and-tests`). Merge #60 → #61 → #62 → #63 → this.

| # | Item | What changed |
|---|------|--------------|
| 1 | Duplicated parsing | `parse_issue_body` / `parse_state` / `parse_deadline` consolidated into `util.py`; both scripts call the shared helpers (`strip_symbols` preserves each one's field keys) |
| 2 | Repo identity | `web/lib/repo.ts` (`REPO_SLUG`/`REPO_URL`/`REPO_RAW_BASE`, override via `NEXT_PUBLIC_REPO_SLUG`) used across web; `util.repo_url()` (from `GITHUB_REPOSITORY`) in `weekly_digest.py` |
| 3 | `noUncheckedIndexedAccess` | Enabled; every surfaced nullable handled with safe fallbacks / type-predicate filters (no unchecked `!`) across lib + legacy components |
| 4 | Global `Audio` patch | Now patched lazily from the disc-player component (idempotent), not as a top-level import side effect |
| 5 | Scroll-lock race | Shared ref-counted `lib/scroll-lock.ts` used by preloader + detail modal |
| 6 | localStorage trust | Parsed value validated into a clean `TrackerMap` (unknown ids/stages dropped) |
| 7 | Context coupling | Split into `useSelection` / `useTracker` so a modal open/close doesn't re-render every deck card |
| 8 | Dropped gallery credit | `caption`/`credit`/`credit_url` surfaced in the tile alt/title |
| 9 | Stray file | Removed `georgetown` |
| 10 | Cosmetic auth | Client-only `/my` gate documented at the enforcement point (`proxy.ts`) |

## Verification
- ✅ `next build` + `npm run lint` + `tsc --noEmit` + 15 vitest tests
- ✅ scripts compile + 14 Python unittests

## Notes
- Item 3 touched several unrelated legacy components (the flag is global); all fixes are safe fallbacks, no behavior change.
- Item 4: a *fully* no-global approach isn't possible without editing the vendored Framer component; lazy + idempotent patching is the best feasible scoping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)