### PR TITLE
fix: resolve error in deadline countdown

### DIFF
--- a/web/lib/listings.test.ts
+++ b/web/lib/listings.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect } from "vitest";
 import {
   parsePrizeValue,
   deriveState,
+  daysUntilDeadline,
+  siteStats,
   splitTitle,
   themesFor,
 } from "./listings";
+import type { Hackathon } from "./types-hq";
 
 // Minimal raw listing (deriveState only reads state/active).
 const raw = (over: { state?: string; active?: boolean }) => ({
@@ -13,6 +16,103 @@ const raw = (over: { state?: string; active?: boolean }) => ({
   title: "T",
   url: "https://x.com",
   ...over,
+});
+
+function localMidnight(y: number, m: number, d: number): Date {
+  const today = new Date(y, m, d);
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function hackStub(over: Partial<Hackathon>): Hackathon {
+  return {
+    id: "1",
+    host: "X",
+    title: "T",
+    tagline: null,
+    url: "https://x.com",
+    location: "TBA",
+    format: "Virtual",
+    prize: null,
+    prizeValue: 0,
+    state: "open",
+    deadline: null,
+    daysLeft: null,
+    lat: null,
+    lng: null,
+    themes: [],
+    postedAt: 0,
+    ...over,
+  };
+}
+
+describe("daysUntilDeadline", () => {
+  const today = localMidnight(2026, 6, 9); // Jul 9, 2026
+
+  it("returns 0 for today", () => {
+    expect(daysUntilDeadline("2026-07-09", today)).toBe(0);
+  });
+
+  it("returns -1 for yesterday", () => {
+    expect(daysUntilDeadline("2026-07-08", today)).toBe(-1);
+  });
+
+  it("returns 1 for tomorrow", () => {
+    expect(daysUntilDeadline("2026-07-10", today)).toBe(1);
+  });
+
+  it("returns 7 for a deadline 7 days out", () => {
+    expect(daysUntilDeadline("2026-07-16", today)).toBe(7);
+  });
+
+  it("returns 8 for a deadline 8 days out", () => {
+    expect(daysUntilDeadline("2026-07-17", today)).toBe(8);
+  });
+
+  it("handles spring-forward DST (23-hour day)", () => {
+    const springToday = localMidnight(2025, 2, 9); // Mar 9, 2025
+    expect(daysUntilDeadline("2025-03-10", springToday)).toBe(1);
+  });
+
+  it("handles fall-back DST (25-hour day)", () => {
+    const fallToday = localMidnight(2025, 10, 2); // Nov 2, 2025
+    expect(daysUntilDeadline("2025-11-03", fallToday)).toBe(1);
+  });
+});
+
+describe("deriveState from deadline", () => {
+  const today = localMidnight(2026, 6, 9);
+
+  it("closing_soon when deadline is today", () => {
+    const daysLeft = daysUntilDeadline("2026-07-09", today);
+    expect(daysLeft).toBe(0);
+    expect(deriveState(raw({}), daysLeft)).toBe("closing_soon");
+  });
+
+  it("closed when deadline was yesterday", () => {
+    const daysLeft = daysUntilDeadline("2026-07-08", today);
+    expect(daysLeft).toBeLessThan(0);
+    expect(deriveState(raw({}), daysLeft)).toBe("closed");
+  });
+
+  it("closing_soon at 7 days out, open at 8", () => {
+    expect(deriveState(raw({}), daysUntilDeadline("2026-07-16", today))).toBe(
+      "closing_soon",
+    );
+    expect(deriveState(raw({}), daysUntilDeadline("2026-07-17", today))).toBe("open");
+  });
+});
+
+describe("siteStats", () => {
+  it("excludes expired listings from closingSoon", () => {
+    const list = [
+      hackStub({ state: "closing_soon", daysLeft: 0 }),
+      hackStub({ id: "2", state: "closed", daysLeft: -1 }),
+    ];
+    const stats = siteStats(list);
+    expect(stats.closingSoon).toBe(1);
+    expect(stats.open).toBe(1);
+  });
 });
 
 describe("parsePrizeValue", () => {

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -78,6 +78,11 @@ export function parsePrizeValue(prize: string | undefined): number {
   return n * mult;
 }
 
+export function daysUntilDeadline(deadline: string, today: Date): number {
+  const d = new Date(`${deadline}T00:00:00`);
+  return Math.round((d.getTime() - today.getTime()) / 86_400_000);
+}
+
 export function deriveState(raw: RawListing, daysLeft: number | null): HackState {
   if (raw.state === "opens_soon") return "opens_soon";
   if (raw.state === "closed" || raw.active === false) return "closed";
@@ -148,8 +153,7 @@ export function loadHackathons(): Hackathon[] {
       const location = r.locations?.[0] ?? "TBA";
       let daysLeft: number | null = null;
       if (r.deadline) {
-        const d = new Date(`${r.deadline}T23:59:59`);
-        daysLeft = Math.ceil((d.getTime() - today.getTime()) / 86_400_000);
+        daysLeft = daysUntilDeadline(r.deadline, today);
       }
       const { title, tagline } = splitTitle(r.title);
 


### PR DESCRIPTION
Closes #68 

### Fixes an off-by-one error in daysLeft that made every countdown and deadline-derived status one day too generous.

`loadHackathons` compared deadline end-of-day  against today at local midnight, then used `Math.ceil`. That ~24h offset meant a deadline from yesterday evaluated to `daysLeft === 0`, so expired listings showed as "closes today", ranked first in the sort order, and were counted in `siteStats.closingSoon`.

The fix measures whole days midnight-to-midnight via a new `daysUntilDeadline()` helper `(T00:00:00 + Math.round)`, matching the pattern already used in `parse-readme.ts`. No changes to `deriveState`, `countdown`, sort logic, or `siteStats`, correcting the source value propagates everywhere.

#### Test plan
- [x] Unit tests for `daysUntilDeadline`: today (0), yesterday (-1), tomorrow (1), 7/8-day boundaries, spring/fall DST
 - [x] Integration tests wiring `daysUntilDeadline` → `deriveState` (today → `closing_soon`, yesterday → `closed`, 7 days → `closing_soon`, 8 days → `open`)
 - [x] `siteStats` test confirming expired listings are excluded from `closingSoon`
- [x] Smoke test against real `listings.json`: 0 expired listings wrongly marked `closing_soon`; near-term countdowns render correctly