### PR TITLE
Fix theme false positives from substring matches

### DIFF
--- a/web/lib/listings.test.ts
+++ b/web/lib/listings.test.ts
@@ -181,4 +181,28 @@ describe("themesFor", () => {
   it("returns [] when nothing matches", () => {
     expect(themesFor("generic build weekend")).toEqual([]);
   });
+
+  it.each([
+    ["Backblaze Generative Media Hackathon", "HEALTH"],
+    ["Quantum Computing Hackathon", "FINTECH"],
+    ["Ethics in Tech Hack", "WEB3"],
+    ["Biography of Code", "HEALTH"],
+    ["Immediate Impact Buildathon", "HEALTH"],
+    ["Social Media Weekend", "HEALTH"],
+  ])("does not false-positive %s as %s", (text, tag) => {
+    expect(themesFor(text)).not.toContain(tag);
+  });
+
+  it.each([
+    ["Health Hack", "HEALTH"],
+    ["Biotech Jam", "HEALTH"],
+    ["Medical Innovation Hack", "HEALTH"],
+    ["Quant Trading Challenge", "FINTECH"],
+    ["Ethereum Builders", "WEB3"],
+    ["Blockchain Challenge", "WEB3"],
+    ["Data Hackathon", "DATA"],
+    ["Analytics Challenge", "DATA"],
+  ])("tags %s as %s", (text, tag) => {
+    expect(themesFor(text)).toContain(tag);
+  });
 });

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -55,14 +55,14 @@ const GEO: Record<string, [number, number]> = {
 
 const THEME_RULES: [RegExp, string][] = [
   [/\bai\b|artificial intelligence|agent|llm|gpt|gemini|claude/i, "AI"],
-  [/web3|crypto|eth|blockchain|chain/i, "WEB3"],
-  [/health|bio|med/i, "HEALTH"],
+  [/web3|crypto|\beth(ereum)?\b|blockchain|\bchain\b/i, "WEB3"],
+  [/health|\bbio(tech|medical)?\b|\bmed(ical|icine|tech)?\b/i, "HEALTH"],
   [/climate|sustain|energy/i, "CLIMATE"],
-  [/fintech|finance|trading|quant/i, "FINTECH"],
+  [/fintech|finance|trading|\bquant\b/i, "FINTECH"],
   [/game|gaming/i, "GAMING"],
   [/robot|hardware|embedded/i, "HARDWARE"],
   [/security|cyber|ctf/i, "SECURITY"],
-  [/data|analytics/i, "DATA"],
+  [/\bdata\b|analytics/i, "DATA"],
   [/space|aero/i, "SPACE"],
   [/education|edtech|student/i, "EDU"],
   [/high.?school/i, "HIGH SCHOOL"],


### PR DESCRIPTION
## Summary

- Anchor short `THEME_RULES` substrings with word boundaries so theme chips no longer match inside unrelated words, such as `Media` causing a false `HEALTH` tag.
- Add table-driven vitest coverage for known false positives and true positives via `themesFor()`.

Fixes #76.

## Test plan

- [x] `cd web && npm test`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`
- [x] `cd web && npx tsc --noEmit`

Note: `npm run build` still emits the pre-existing Turbopack NFT warning tracked separately in #77.