### PR TITLE
Fix listing display and README asset edge cases

### DIFF
--- a/web/lib/listings.test.ts
+++ b/web/lib/listings.test.ts
@@ -6,7 +6,6 @@ import {
   siteStats,
   splitTitle,
   themesFor,
-  siteStats,
 } from "./listings";
 import type { Hackathon } from "./types-hq";
 
@@ -114,6 +113,21 @@ describe("siteStats", () => {
     expect(stats.closingSoon).toBe(1);
     expect(stats.open).toBe(1);
   });
+
+  it.each([
+    [500, "$500+"],
+    [1, "$1+"],
+    [499, "$499+"],
+    [1_000, "$1K+"],
+    [1_999, "$1K+"],
+    [2_000_000, "$2M+"],
+  ])("formats prize total %i as %s", (prizeValue, expected) => {
+    expect(siteStats([hackStub({ prizeValue })]).prizeDisplay).toBe(expected);
+  });
+
+  it("shows $0+ when there is no prize value", () => {
+    expect(siteStats([hackStub({ prizeValue: 0 })]).prizeDisplay).toBe("$0+");
+  });
 });
 
 describe("parsePrizeValue", () => {
@@ -181,41 +195,5 @@ describe("themesFor", () => {
 
   it("returns [] when nothing matches", () => {
     expect(themesFor("generic build weekend")).toEqual([]);
-  });
-});
-
-const hackathon = (prizeValue: number): Hackathon => ({
-  id: "1",
-  host: "X",
-  title: "T",
-  tagline: null,
-  url: "https://x.com",
-  location: "Boston, MA",
-  format: "In-Person",
-  prize: null,
-  prizeValue,
-  state: "open",
-  deadline: null,
-  daysLeft: null,
-  lat: 42,
-  lng: -71,
-  themes: [],
-  postedAt: 0,
-});
-
-describe("siteStats", () => {
-  it.each([
-    [500, "$500+"],
-    [1, "$1+"],
-    [499, "$499+"],
-    [1_000, "$1K+"],
-    [1_999, "$1K+"],
-    [2_000_000, "$2M+"],
-  ])("formats prize total %i as %s", (prizeValue, expected) => {
-    expect(siteStats([hackathon(prizeValue)]).prizeDisplay).toBe(expected);
-  });
-
-  it("shows $0+ when there is no prize value", () => {
-    expect(siteStats([hackathon(0)]).prizeDisplay).toBe("$0+");
   });
 });

--- a/web/lib/listings.test.ts
+++ b/web/lib/listings.test.ts
@@ -6,6 +6,7 @@ import {
   siteStats,
   splitTitle,
   themesFor,
+  siteStats,
 } from "./listings";
 import type { Hackathon } from "./types-hq";
 
@@ -180,5 +181,41 @@ describe("themesFor", () => {
 
   it("returns [] when nothing matches", () => {
     expect(themesFor("generic build weekend")).toEqual([]);
+  });
+});
+
+const hackathon = (prizeValue: number): Hackathon => ({
+  id: "1",
+  host: "X",
+  title: "T",
+  tagline: null,
+  url: "https://x.com",
+  location: "Boston, MA",
+  format: "In-Person",
+  prize: null,
+  prizeValue,
+  state: "open",
+  deadline: null,
+  daysLeft: null,
+  lat: 42,
+  lng: -71,
+  themes: [],
+  postedAt: 0,
+});
+
+describe("siteStats", () => {
+  it.each([
+    [500, "$500+"],
+    [1, "$1+"],
+    [499, "$499+"],
+    [1_000, "$1K+"],
+    [1_999, "$1K+"],
+    [2_000_000, "$2M+"],
+  ])("formats prize total %i as %s", (prizeValue, expected) => {
+    expect(siteStats([hackathon(prizeValue)]).prizeDisplay).toBe(expected);
+  });
+
+  it("shows $0+ when there is no prize value", () => {
+    expect(siteStats([hackathon(0)]).prizeDisplay).toBe("$0+");
   });
 });

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -208,7 +208,11 @@ export function siteStats(list: Hackathon[]): SiteStats {
   const prizeDisplay =
     prizeTotal >= 1_000_000
       ? `$${(prizeTotal / 1_000_000).toFixed(1).replace(/\.0$/, "")}M+`
-      : `$${Math.round(prizeTotal / 1000)}K+`;
+      : prizeTotal >= 1_000
+        ? `$${Math.floor(prizeTotal / 1000)}K+`
+        : prizeTotal > 0
+          ? `$${prizeTotal.toLocaleString("en-US")}+`
+          : "$0+";
   return {
     total: list.length,
     open: live.filter((h) => h.state === "open" || h.state === "closing_soon").length,

--- a/web/lib/parse-readme.test.ts
+++ b/web/lib/parse-readme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveAssetSrc, parseOpportunities } from "./parse-readme";
+import { resolveAssetSrc, parseOpportunities, extractGallery } from "./parse-readme";
 
 describe("resolveAssetSrc", () => {
   it("passes absolute URLs through unchanged", () => {
@@ -15,6 +15,41 @@ describe("resolveAssetSrc", () => {
     const out = resolveAssetSrc("assets/does-not-exist-xyz.png");
     expect(out).toContain("raw.githubusercontent.com");
     expect(out).toContain("assets/does-not-exist-xyz.png");
+  });
+
+  it("falls back to raw.githubusercontent for non-assets repo-root files", () => {
+    const out = resolveAssetSrc("README.md");
+    expect(out).toContain("raw.githubusercontent.com");
+    expect(out).toContain("README.md");
+    expect(out).not.toContain("/repo-assets/");
+  });
+
+  it("maps existing assets/ files to /repo-assets/", () => {
+    const out = resolveAssetSrc("assets/hackathons-banner.svg");
+    expect(out).toBe("/repo-assets/hackathons-banner.svg");
+  });
+});
+
+describe("extractGallery", () => {
+  const gallery = (imgs: string) =>
+    `<!-- GALLERY_START -->\n${imgs}\n<!-- GALLERY_END -->`;
+
+  it("parses img tags when src precedes alt", () => {
+    const photos = extractGallery(
+      gallery('<img src="assets/team.jpg" alt="Team photo">'),
+    );
+    expect(photos).toHaveLength(1);
+    expect(photos[0]?.alt).toBe("Team photo");
+    expect(photos[0]?.src).toContain("team.jpg");
+  });
+
+  it("parses img tags when alt precedes src", () => {
+    const photos = extractGallery(
+      gallery('<img alt="Team photo" src="assets/team.jpg">'),
+    );
+    expect(photos).toHaveLength(1);
+    expect(photos[0]?.alt).toBe("Team photo");
+    expect(photos[0]?.src).toContain("team.jpg");
   });
 });
 

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -35,9 +35,9 @@ const GALLERY_BLOCK_RE =
 const IMG_TAG_RE = /<img\s+[^>]*>/gi;
 
 function parseImgAttributes(tag: string): { src: string; alt: string } | null {
-  const srcMatch = tag.match(/\bsrc="([^"]+)"/i);
+  const srcMatch = tag.match(/(?:^|\s)src="([^"]+)"/i);
   if (!srcMatch) return null;
-  const altMatch = tag.match(/\balt="([^"]*)"/i);
+  const altMatch = tag.match(/(?:^|\s)alt="([^"]*)"/i);
   return {
     src: srcMatch[1] ?? "",
     alt: altMatch?.[1] || "Hackathon photo",

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -32,8 +32,17 @@ const DATE_RE =
   /\b(January|February|March|April|May|June|July|August|September|October|November|December|Jan|Feb|Mar|Apr|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)\s+(\d{1,2}),?\s+(\d{4})\b/g;
 const GALLERY_BLOCK_RE =
   /<!-- GALLERY_START -->([\s\S]*?)<!-- GALLERY_END -->/;
-const IMG_RE =
-  /<img\s+[^>]*src="([^"]+)"[^>]*alt="([^"]*)"[^>]*>/g;
+const IMG_TAG_RE = /<img\s+[^>]*>/gi;
+
+function parseImgAttributes(tag: string): { src: string; alt: string } | null {
+  const srcMatch = tag.match(/\bsrc="([^"]+)"/i);
+  if (!srcMatch) return null;
+  const altMatch = tag.match(/\balt="([^"]*)"/i);
+  return {
+    src: srcMatch[1] ?? "",
+    alt: altMatch?.[1] || "Hackathon photo",
+  };
+}
 
 function parseStatus(cell: string): Status {
   if (cell.includes("CLOSING SOON")) return "CLOSING_SOON";
@@ -107,7 +116,7 @@ export function resolveAssetSrc(src: string): string {
 
   const relative = src.replace(/^\/+/, "");
   const localPath = path.join(REPO_ROOT, relative);
-  if (fs.existsSync(localPath)) {
+  if (relative.startsWith("assets/") && fs.existsSync(localPath)) {
     return `/repo-assets/${relative.replace(/^assets\//, "")}`;
   }
 
@@ -121,17 +130,19 @@ function extractStatsBannerSrc(markdown: string): string | null {
   return src ? resolveAssetSrc(src[1] ?? "") : null;
 }
 
-function extractGallery(markdown: string): GalleryPhoto[] {
+export function extractGallery(markdown: string): GalleryPhoto[] {
   const block = markdown.match(GALLERY_BLOCK_RE);
   if (!block) return [];
 
   const photos: GalleryPhoto[] = [];
   let m: RegExpExecArray | null;
-  const re = new RegExp(IMG_RE.source, "g");
+  const re = new RegExp(IMG_TAG_RE.source, "gi");
   while ((m = re.exec(block[1] ?? "")) !== null) {
+    const parsed = parseImgAttributes(m[0]);
+    if (!parsed) continue;
     photos.push({
-      src: resolveAssetSrc(m[1] ?? ""),
-      alt: m[2] || "Hackathon photo",
+      src: resolveAssetSrc(parsed.src),
+      alt: parsed.alt,
     });
   }
   return photos;


### PR DESCRIPTION
## Summary

- Fix sub-$1K prize totals so small prizes do not render as misleading `$0K+` or `$1K+` values.
- Parse gallery `<img>` tags regardless of `src`/`alt` attribute order.
- Scope `resolveAssetSrc` local mapping to paths under `assets/` so non-asset repo-root files fall back to raw GitHub URLs.

Addresses #77 items 2, 3, and 4 only.

## Test plan

- [x] `cd web && npm test` — 26 passed
- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`
- [x] `cd web && npx tsc --noEmit`

Note: `npm run build` still emits the pre-existing Turbopack NFT warning tracked separately in #77 item 5.