### PR TITLE
Add workflow timeouts and sanitize deadline watcher URLs

### DIFF
--- a/.github/scripts/deadline_watcher.py
+++ b/.github/scripts/deadline_watcher.py
@@ -144,10 +144,11 @@ def _build_report(proposals):
         company = util.sanitize_field(p["company"], max_len=120)
         title = util.sanitize_field(p["title"], max_len=160)
         evidence = util.sanitize_field(p["evidence"], max_len=280)
+        url = util.sanitize_field(p["url"], max_len=500)
         lines += [
             f"### {company} — {title}",
             f"- **Proposed deadline:** `{p['deadline']}` ({p['type']})",
-            f"- **Source:** {p['url']}",
+            f"- **Source:** {url}",
             f"- **Evidence:** > {evidence}",
             f"- **Listing id:** `{p['id']}`",
             "",

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -129,5 +129,24 @@ class DeadlineWatcherRules(unittest.TestCase):
         self.assertIsNone(dw._accept(self._base(deadline="sometime in August")))
 
 
+class DeadlineWatcherReport(unittest.TestCase):
+    def test_build_report_sanitizes_url(self):
+        report = dw._build_report(
+            [
+                {
+                    "id": "abc",
+                    "company": "Acme",
+                    "title": "Hack",
+                    "url": "https://example.com\n@mention",
+                    "deadline": "2026-08-01",
+                    "type": "application",
+                    "evidence": "Applications close August 1, 2026",
+                }
+            ]
+        )
+        self.assertIn("https://example.com @mention", report)
+        self.assertNotIn("\n@mention", report)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -20,6 +20,7 @@ jobs:
       && contains(github.event.issue.labels.*.name, 'approved')
       && contains(github.event.issue.labels.*.name, 'auto_extract')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -17,6 +17,7 @@ jobs:
     # Only run for non-auto_extract issues (manual submissions)
     if: github.event.label.name == 'approved' && !contains(github.event.issue.labels.*.name, 'auto_extract') && contains(github.event.issue.labels.*.name, 'approved')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deadline_watch.yml
+++ b/.github/workflows/deadline_watch.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   update-gallery:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   update-readme:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   web:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: web
@@ -39,6 +40,7 @@ jobs:
 
   scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   digest:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 10` to every workflow job so hung network/LLM steps cannot occupy a runner for hours.
- Route deadline watcher report URLs through `util.sanitize_field`, consistent with company/title/evidence.

Addresses #77 items 7 and 8 only.

## Test plan

- [x] `python -m unittest discover -s .github/scripts -p 'test_*.py'` — 21 passed