### PR TITLE
Fix media cleanup and reduced-motion autoplay

### DIFF
--- a/web/components/hq/disc-player.tsx
+++ b/web/components/hq/disc-player.tsx
@@ -61,6 +61,7 @@ type SpotifyController = {
   pause: () => void;
   loadUri: (uri: string) => void;
   addListener: (event: string, cb: (e: SpotifyPlaybackEvent) => void) => void;
+  destroy?: () => void;
 };
 
 type SpotifyPlaybackEvent = { data: { isPaused: boolean; isBuffering: boolean } };
@@ -115,11 +116,14 @@ export function DiscPlayer() {
   const discWrapRef = useRef<HTMLDivElement>(null);
   const apiRef = useRef<SpotifyIFrameAPI | null>(null);
   const controllerRef = useRef<SpotifyController | null>(null);
+  const aliveRef = useRef(true);
 
   // Load the Spotify IFrame API once; controllers are created lazily,
   // only when the user loads their own music.
   useEffect(() => {
+    aliveRef.current = true;
     window.onSpotifyIframeApiReady = (api) => {
+      if (!aliveRef.current) return;
       apiRef.current = api;
     };
     const script = document.createElement("script");
@@ -127,8 +131,11 @@ export function DiscPlayer() {
     script.async = true;
     document.body.appendChild(script);
     return () => {
+      aliveRef.current = false;
       script.remove();
       delete window.onSpotifyIframeApiReady;
+      controllerRef.current?.destroy?.();
+      controllerRef.current = null;
     };
   }, []);
 
@@ -148,10 +155,15 @@ export function DiscPlayer() {
     }
     setConnecting(true);
     api.createController(mount, { uri, width: "100%", height: 80 }, (controller) => {
+      if (!aliveRef.current) {
+        controller.destroy?.();
+        return;
+      }
       controllerRef.current = controller;
       setConnecting(false);
       setHasMusic(true);
       controller.addListener("playback_update", (e) => {
+        if (!aliveRef.current) return;
         setPlaying(!e.data.isPaused);
       });
     });

--- a/web/components/hq/globe-hero.tsx
+++ b/web/components/hq/globe-hero.tsx
@@ -13,7 +13,7 @@ export function GlobeHero() {
       video.pause();
       return;
     }
-    void video.play();
+    video.play().catch(() => {});
   }, []);
 
   return (

--- a/web/components/hq/globe-hero.tsx
+++ b/web/components/hq/globe-hero.tsx
@@ -6,9 +6,14 @@ export function GlobeHero() {
   const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      videoRef.current?.pause();
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const video = videoRef.current;
+    if (!video) return;
+    if (reduce) {
+      video.pause();
+      return;
     }
+    void video.play();
   }, []);
 
   return (
@@ -21,7 +26,6 @@ export function GlobeHero() {
             className="h-full w-full object-cover"
             src="/rednote-summit-opening.mp4"
             poster="/rednote-summit-poster.jpg"
-            autoPlay
             muted
             loop
             playsInline


### PR DESCRIPTION
## Summary

- Destroy the Spotify iframe controller on `DiscPlayer` unmount, null the ref, and guard async `createController` / playback listener callbacks with an `alive` flag.
- Remove unconditional hero video `autoPlay`; call `play()` only when `prefers-reduced-motion: reduce` is not set.

Addresses #77 items 1 and 6 only.

## Test plan

- [x] `cd web && npm run lint`
- [x] `cd web && npm run build`
- [x] `cd web && npx tsc --noEmit`
- [ ] Manual: load Spotify on home, navigate home ↔ globe repeatedly — no leaked controllers / no console warnings about setState on unmounted component
- [ ] Manual: with OS reduced motion enabled, globe hero shows poster and video does not autoplay
- [ ] Manual: with reduced motion off, hero video plays as before

Note: `npm run build` still emits the pre-existing Turbopack NFT warning tracked separately in #77 item 5.