### PR TITLE
fix(ci): serialize all README-committing workflows on one concurrency group (#72)

### DIFF
--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -9,7 +9,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: add_opportunity
+  group: repo-writes
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: repo-writes
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled]
 
 concurrency:
-  group: add_opportunity
+  group: repo-writes
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: repo-writes
+  cancel-in-progress: false
+
 jobs:
   update-gallery:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: repo-writes
+  cancel-in-progress: false
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes #72. Three README-committing workflows had no `concurrency:` group, so they could run simultaneously and race on `README.md` (and `assets/hackathons-banner.svg`), producing conflicting commits and failed pushes. Two other workflows used a separate `add_opportunity` group, so they only serialized against each other and not against the rest.

This PR puts **every workflow that commits to the repo** into a single shared serialization group `repo-writes` with `cancel-in-progress: false`, so at most one runs at a time and none are cancelled mid-run.

### Changes
- `auto_extract.yml` — changed group `add_opportunity` → `repo-writes`
- `contribution_approved.yml` — changed group `add_opportunity` → `repo-writes`
- `closing_soon.yml` — added top-level `concurrency:` block
- `update_readmes.yml` — added top-level `concurrency:` block
- `gallery.yml` — added top-level `concurrency:` block

`deadline_watch.yml` is intentionally left on its own `deadline-watch` group (it does not commit README the same way). The `run:` retry-loop steps are untouched (handled by a separate PR).

## Acceptance criteria
- [x] All five README-committing workflows share `group: repo-writes`
- [x] Each uses `cancel-in-progress: false`
- [x] `deadline_watch.yml` left unchanged
- [x] Only the top-level `concurrency:` key added/modified; `run:` steps untouched
- [x] All workflow YAML files still parse (`yaml.safe_load`)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)