### PR TITLE
fix: make failed push retries exit non-zero across workflows (#71)

### DIFF
--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -56,11 +56,14 @@ jobs:
           git add .github/scripts/listings.json README.md assets/hackathons-banner.svg
           git commit -m "$COMMIT_MSG" || echo "No changes to commit"
           # Rebase and retry push up to 3 times
+          ok=false
           for i in 1 2 3; do
-            git fetch origin main && git rebase origin/main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            git fetch origin main || { sleep 2; continue; }
+            if git rebase origin/main && git push origin main; then ok=true; break; fi
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          $ok || { echo "::error::push failed after 3 attempts"; exit 1; }
 
       - name: Handle duplicate detection
         if: steps.extract.outputs.is_duplicate == 'true'

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -41,8 +41,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md assets/hackathons-banner.svg
           git commit -m "chore: update closing-soon badges (${CHANGES:-0} changes)"
+          ok=false
           for i in 1 2 3; do
-            git fetch origin main && git rebase origin/main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            git fetch origin main || { sleep 2; continue; }
+            if git rebase origin/main && git push origin main; then ok=true; break; fi
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          $ok || { echo "::error::push failed after 3 attempts"; exit 1; }

--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -59,11 +59,14 @@ jobs:
             git commit -m "$COMMIT_MSG"
           fi
           # Rebase and retry push up to 3 times
+          ok=false
           for i in 1 2 3; do
-            git fetch origin main && git rebase origin/main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            git fetch origin main || { sleep 2; continue; }
+            if git rebase origin/main && git push origin main; then ok=true; break; fi
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          $ok || { echo "::error::push failed after 3 attempts"; exit 1; }
 
       - name: Close issue with success message
         if: success()

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -42,8 +42,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "chore: rebuild photo gallery"
+          ok=false
           for i in 1 2 3; do
-            git fetch origin main && git rebase origin/main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            git fetch origin main || { sleep 2; continue; }
+            if git rebase origin/main && git push origin main; then ok=true; break; fi
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          $ok || { echo "::error::push failed after 3 attempts"; exit 1; }

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -48,11 +48,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add README.md assets/hackathons-banner.svg
           git commit -m "${COMMIT_MSG:-chore: update README}"
+          ok=false
           for i in 1 2 3; do
-            git fetch origin main && git rebase origin/main && git push origin main && break
-            echo "Push attempt $i failed, retrying..."
+            git fetch origin main || { sleep 2; continue; }
+            if git rebase origin/main && git push origin main; then ok=true; break; fi
+            git rebase --abort 2>/dev/null || true
             sleep 2
           done
+          $ok || { echo "::error::push failed after 3 attempts"; exit 1; }
 
       - name: Report failure
         if: failure()


### PR DESCRIPTION
## Problem (#71)

Five workflows retried `git push` with a `cmd && cmd && cmd && break` chain inside a `for` loop:

```bash
for i in 1 2 3; do
  git fetch origin main && git rebase origin/main && git push origin main && break
  echo "Push attempt $i failed, retrying..."
  sleep 2
done
```

Under `bash -eo pipefail` (what GitHub Actions uses), a failure inside an `&&` list does **not** trigger `set -e`. The last command executed each iteration is `sleep 2` (exit 0), so when all 3 attempts fail the step **exits 0 and the job goes green while nothing was pushed**. A failed rebase also left `.git/rebase-merge/` behind, poisoning attempts 2 and 3.

## Fix

Each retry loop is replaced with one that tracks success explicitly, aborts a failed rebase between attempts, and fails the step when all attempts are exhausted:

```bash
ok=false
for i in 1 2 3; do
  git fetch origin main || { sleep 2; continue; }
  if git rebase origin/main && git push origin main; then ok=true; break; fi
  git rebase --abort 2>/dev/null || true
  sleep 2
done
$ok || { echo "::error::push failed after 3 attempts"; exit 1; }
```

Applied identically to all five affected workflows:
- `.github/workflows/auto_extract.yml`
- `.github/workflows/contribution_approved.yml`
- `.github/workflows/closing_soon.yml`
- `.github/workflows/gallery.yml`
- `.github/workflows/update_readmes.yml`

Only the retry loop was touched; `concurrency:` keys and all surrounding steps are unchanged (a separate PR handles concurrency).

## Acceptance criteria

- [x] All 3 attempts failing now exits **non-zero** (verified: extracted loop under `bash --noprofile --norc -eo pipefail` with a failing git stub → `EXIT_CODE=1` + `::error::push failed after 3 attempts`)
- [x] Success on a retry still exits 0 (verified: push succeeding on attempt 2 → `EXIT_CODE=0`)
- [x] A failed rebase is aborted between attempts (`git rebase --abort`) so retries aren't poisoned
- [x] All workflow YAML still parses (`yaml.safe_load` over `.github/workflows/*.yml`)
- [x] Existing indentation and surrounding steps preserved; `concurrency:` untouched

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)
