### PR TITLE
fix: link-less approved issues no longer write broken URL (#73)

### DIFF
--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -30,11 +30,13 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     """Handle adding a new hackathon."""
     listings = util.get_listings_from_json()
 
-    # Get URL - handle both full and quick templates
+    # Get URL - handle both full and quick templates. Check the RAW value for
+    # emptiness before normalizing: clean_url("") no longer manufactures a URL,
+    # but validating the raw value keeps the "missing URL" error unambiguous.
     url = get_first(data, "link_to_hackathon_page", "link", "link_to_hackathon")
-    url = util.clean_url(url)
-    if not url:
+    if not url.strip():
         util.fail("Missing required field: URL")
+    url = util.clean_url(url)
 
     # Check for duplicates
     for listing in listings:

--- a/.github/scripts/contribution_approved.py
+++ b/.github/scripts/contribution_approved.py
@@ -37,6 +37,11 @@ def handle_new_opportunity(data, username, is_quick_add=False):
     if not url.strip():
         util.fail("Missing required field: URL")
     url = util.clean_url(url)
+    # Re-check after normalization: a bare/host-less scheme ("https://", "//x")
+    # is truthy above but clean_url reduces it to "", which would otherwise be
+    # written as an empty url and rendered as a broken Register button.
+    if not url:
+        util.fail("Missing required field: URL")
 
     # Check for duplicates
     for listing in listings:

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -103,6 +103,20 @@ class CleanUrl(unittest.TestCase):
         )
 
 
+class ContributionApprovedUrlGuard(unittest.TestCase):
+    def test_bare_scheme_url_is_rejected(self):
+        # A host-less scheme is truthy (passes the raw check) but clean_url
+        # reduces it to "", which must not be written as an empty-url listing.
+        import contribution_approved as ca
+        data = {
+            "link_to_hackathon_page": "https://",
+            "hackathon_name": "X",
+            "host_organizer": "Y",
+        }
+        with self.assertRaises(SystemExit):  # util.fail -> exit(1)
+            ca.handle_new_opportunity(data, "tester")
+
+
 class SsrfGuard(unittest.TestCase):
     def test_blocks_internal_hosts(self):
         for host in ("127.0.0.1", "localhost", "169.254.169.254", "10.0.0.1"):

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -81,6 +81,28 @@ class ParseStateAndDeadline(unittest.TestCase):
         self.assertIsNone(util.parse_deadline({}, "deadline"))
 
 
+class CleanUrl(unittest.TestCase):
+    def test_empty_returns_empty(self):
+        # Must not manufacture "https://" out of nothing (issue #73).
+        self.assertEqual(util.clean_url(""), "")
+
+    def test_whitespace_returns_empty(self):
+        self.assertEqual(util.clean_url("   "), "")
+
+    def test_host_less_scheme_returns_empty(self):
+        self.assertEqual(util.clean_url("https://"), "")
+        self.assertEqual(util.clean_url("http://"), "")
+
+    def test_valid_host_normalizes(self):
+        self.assertEqual(util.clean_url("example.com"), "https://example.com")
+
+    def test_strips_tracking_params(self):
+        self.assertEqual(
+            util.clean_url("https://example.com/e?utm_source=x&a=1"),
+            "https://example.com/e?a=1",
+        )
+
+
 class SsrfGuard(unittest.TestCase):
     def test_blocks_internal_hosts(self):
         for host in ("127.0.0.1", "localhost", "169.254.169.254", "10.0.0.1"):

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -333,14 +333,25 @@ def parse_deadline(data, *keys):
 
 
 def clean_url(url):
-    """Clean and normalize a URL."""
-    url = url.strip()
+    """Clean and normalize a URL.
+
+    Returns "" for empty or host-less input. clean_url must never manufacture a
+    URL out of nothing: an empty or whitespace-only value used to become
+    "https://" (and "http://"/"https://" alone stayed host-less), which then
+    slipped past callers' emptiness checks and produced a broken Register link.
+    Callers should treat "" as a missing URL.
+    """
+    url = (url or "").strip()
+    if not url:
+        return ""
     if not url.startswith(("http://", "https://")):
         url = "https://" + url
     # Remove common tracking parameters
     tracking_params = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]
     from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
     parsed = urlparse(url)
+    if not parsed.netloc:
+        return ""
     params = parse_qs(parsed.query)
     cleaned_params = {k: v for k, v in params.items() if k not in tracking_params}
     cleaned_query = urlencode(cleaned_params, doseq=True)


### PR DESCRIPTION
## Summary

Fixes #73. A link-less approved issue could pass the `Missing required field: URL` guard and write a listing with `"url": "https://"` and a broken Register button.

Two changes, applied defensively so neither alone can reintroduce the bug:

1. **`util.clean_url` hardened** — returns `""` for empty, whitespace-only, or host-less input (e.g. a bare `https://`). It no longer manufactures a URL out of nothing, so callers can treat `""` as a missing URL.
2. **`contribution_approved.handle_new_opportunity`** — checks emptiness on the RAW value *before* `clean_url()`, mirroring the existing pattern in `auto_extract.py`. This keeps the "missing URL" error unambiguous.

## Acceptance criteria

- [x] `contribution_approved.py` validates the raw URL value before normalization
- [x] `clean_url("")` returns `""` (not `"https://"`)
- [x] `clean_url("   ")` returns `""`
- [x] Host-less scheme (`https://`, `http://`) returns `""`
- [x] Valid host still normalizes: `clean_url("example.com")` -> `"https://example.com"`
- [x] Existing callers (`auto_extract.py`, `deadline_watcher.py`) reviewed for regressions
- [x] Unit tests added to `test_scripts.py`
- [x] Full suite passes: `python3 -m unittest discover -p 'test_*.py'` -> 26 tests OK

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)