### PR TITLE
fix: derive closing-soon badge from Deadline cell only (#70)

### DIFF
--- a/.github/scripts/closing_soon.py
+++ b/.github/scripts/closing_soon.py
@@ -86,7 +86,11 @@ def update_row(row: str, today: datetime):
     # named "cuHacking 2026 — Jul 10 – Jul 12, 2026" with a "—" Deadline) or the
     # trailing "Date Posted" cell, and mistakes it for a registration deadline
     # (issue #70).
-    cells = [c.strip() for c in row.strip().strip("|").split("|")]
+    # Split on unescaped pipes only: sanitize_table_cell escapes a literal "|"
+    # inside a cell as "\|", and splitting on that would shift the Deadline out
+    # of DEADLINE_COL. Separator pipes are always space-padded ("| "), so a "\|"
+    # (backslash immediately before the pipe) is unambiguously an escaped value.
+    cells = [c.strip() for c in re.split(r"(?<!\\)\|", row.strip().strip("|"))]
     if len(cells) <= DEADLINE_COL:
         return row, False
     deadline_cell = cells[DEADLINE_COL]

--- a/.github/scripts/closing_soon.py
+++ b/.github/scripts/closing_soon.py
@@ -4,8 +4,9 @@ closing_soon.py — flag opportunities closing within 7 days as 🔥 [CLOSING SO
 
 Scans every <!-- *_TABLE_START --> ... <!-- *_TABLE_END --> region in README.md.
 For each row with status ✅ [OPEN] or 🔥 [CLOSING SOON]:
-  - Prefer structured deadline (YYYY-MM-DD or MM/DD/YYYY) if present
-  - Otherwise find the earliest upcoming date in the row text
+  - Read ONLY the Deadline cell (never other cells, whose dates are event dates)
+  - Prefer a structured deadline (YYYY-MM-DD) in that cell, else its earliest date
+  - A row with no deadline ("—") keeps its current status
   - If 0–7 days away: flip status to 🔥 [CLOSING SOON]
   - If >7 days away: flip status back to ✅ [OPEN]
   - If unparseable / past / Rolling / Check site: leave alone
@@ -71,17 +72,29 @@ def parse_iso_deadline(row: str):
         return None
 
 
+DEADLINE_COL = 6  # 0=Status 1=Host 2=Hackathon 3=Format 4=Location 5=Prize 6=Deadline 7=Application 8=Date Posted
+
+
 def update_row(row: str, today: datetime):
     """Return (new_row, changed)."""
     has_open = OPEN in row
     has_closing = CLOSING in row
     if not (has_open or has_closing):
         return row, False
-    # Skip the trailing "Date Posted" cell: a row posted today would otherwise
-    # parse as a deadline 0 days away and be falsely flagged as closing soon.
-    cells = row.rstrip().rstrip("|").split("|")
-    scan_text = "|".join(cells[:-1]) if len(cells) > 1 else row
-    deadline = parse_iso_deadline(scan_text) or earliest_upcoming(scan_text, today)
+    # Derive the closing-soon decision from the Deadline cell ALONE. Scanning any
+    # other cell harvests the event date out of the Hackathon title (e.g. a row
+    # named "cuHacking 2026 — Jul 10 – Jul 12, 2026" with a "—" Deadline) or the
+    # trailing "Date Posted" cell, and mistakes it for a registration deadline
+    # (issue #70).
+    cells = [c.strip() for c in row.strip().strip("|").split("|")]
+    if len(cells) <= DEADLINE_COL:
+        return row, False
+    deadline_cell = cells[DEADLINE_COL]
+    # A row with no real deadline (empty or the "—" placeholder) keeps its
+    # current status — it must never be invented into CLOSING SOON.
+    if deadline_cell in ("", "—", "-"):
+        return row, False
+    deadline = parse_iso_deadline(deadline_cell) or earliest_upcoming(deadline_cell, today)
     if not deadline:
         return row, False
     days_until = (deadline.date() - today.date()).days

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -360,6 +360,21 @@ class ClosingSoonDeadlineCell(unittest.TestCase):
         self.assertFalse(changed)
         self.assertEqual(new_row, row)
 
+    def test_escaped_pipe_in_cell_does_not_shift_deadline_column(self):
+        # A literal "|" in a cell is escaped as "\|" by sanitize_table_cell.
+        # Splitting on it would push the Deadline out of column 6 and misread the
+        # badge. The Host cell holds "Foo \| Bar"; the real Deadline (Jul 15, 4
+        # days out) must still be read and flip the row to CLOSING SOON.
+        row = (
+            "| ✅ **[OPEN]** | Foo \\| Bar | Some Hack — Aug 20, 2026 | Online | "
+            "Remote | $10k | Jul 15, 2026 | "
+            '<a href="https://example.org">Register</a> | Jul 01, 2026 |'
+        )
+        new_row, changed = cs.update_row(row, self.TODAY)
+        self.assertTrue(changed)
+        self.assertIn(cs.CLOSING, new_row)
+        self.assertNotIn(cs.OPEN, new_row)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -8,12 +8,13 @@ import json
 import os
 import tempfile
 import unittest
-from datetime import date
+from datetime import date, datetime
 from unittest import mock
 
 import util
 import auto_extract as ax
 import deadline_watcher as dw
+import closing_soon as cs
 
 
 class ParseDeadlineDate(unittest.TestCase):
@@ -305,6 +306,59 @@ class UpdateReadmesSkipsBadRows(unittest.TestCase):
         self.assertIn("Good Hack", table)
         # The malformed listing surfaced as a warning, not an abort.
         self.assertTrue(any("bad" in str(c) for c in warn.call_args_list))
+
+
+class ClosingSoonDeadlineCell(unittest.TestCase):
+    """Regression tests for issue #70.
+
+    The closing-soon badge must be derived from the Deadline cell alone, never
+    from event dates that live in the Hackathon title (or any other) cell.
+    """
+
+    # Today is 1 day before cuHacking's *event* end date (Jul 12, 2026) — the
+    # date the old code harvested out of the title and mistook for a deadline.
+    TODAY = datetime(2026, 7, 11, tzinfo=cs.PST)
+
+    def test_event_date_in_title_with_dash_deadline_stays_open(self):
+        # Exact cuHacking-style row from issue #70: event dates in the title,
+        # "—" (no deadline) in the Deadline cell. Must NOT become CLOSING SOON.
+        row = (
+            "| ✅ **[OPEN]** | Carleton University | "
+            "cuHacking 2026 — Jul 10 – Jul 12, 2026 | In-Person | Ottawa, ON | "
+            "TBA | — | "
+            '<a href="https://cuhacking.ca"><img '
+            'src="https://img.shields.io/badge/Register-blue?style=for-the-badge" '
+            'alt="Register"></a> | Jul 03, 2026 |'
+        )
+        new_row, changed = cs.update_row(row, self.TODAY)
+        self.assertFalse(changed)
+        self.assertEqual(new_row, row)
+        self.assertIn(cs.OPEN, new_row)
+        self.assertNotIn(cs.CLOSING, new_row)
+
+    def test_real_deadline_within_seven_days_becomes_closing_soon(self):
+        # Deadline Jul 15, 2026 is 4 days from TODAY -> CLOSING SOON. The far-off
+        # event date (Aug 20) in the title must be ignored entirely.
+        row = (
+            "| ✅ **[OPEN]** | Some Org | Some Hack — Aug 20, 2026 | Online | "
+            "Remote | $10k | Jul 15, 2026 | "
+            '<a href="https://example.org">Register</a> | Jul 01, 2026 |'
+        )
+        new_row, changed = cs.update_row(row, self.TODAY)
+        self.assertTrue(changed)
+        self.assertIn(cs.CLOSING, new_row)
+        self.assertNotIn(cs.OPEN, new_row)
+
+    def test_real_deadline_beyond_seven_days_stays_open(self):
+        # Deadline Aug 20 is > 7 days away; title event date is irrelevant.
+        row = (
+            "| ✅ **[OPEN]** | Some Org | Some Hack — Jul 12, 2026 | Online | "
+            "Remote | $10k | Aug 20, 2026 | "
+            '<a href="https://example.org">Register</a> | Jul 01, 2026 |'
+        )
+        new_row, changed = cs.update_row(row, self.TODAY)
+        self.assertFalse(changed)
+        self.assertEqual(new_row, row)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`closing_soon.py` decided the 🔥 **[CLOSING SOON]** badge by scanning **every** README table cell except the last for a date (`scan_text = "|".join(cells[:-1])`). It therefore harvested the *event date* out of the Hackathon **title** cell and treated it as a registration deadline. A row whose **Deadline** column was `—` (no deadline) still got flagged — e.g. cuHacking 2026 (`… cuHacking 2026 — Jul 10 – Jul 12, 2026 … | — | …`) was badged CLOSING SOON purely because the event happened within a week.

## Fix

`update_row` now derives the decision from the **Deadline cell alone** (column index 6: `Status, Host, Hackathon, Format, Location, Prize, Deadline, Application, Date Posted`):

- A row with an empty or `—` Deadline **keeps its current status** — it is never invented into CLOSING SOON.
- A row whose Deadline is a real date **0–7 days** out still flips to CLOSING SOON (behavior preserved).
- Event dates in the title and the trailing Date Posted cell are ignored entirely.

Added `ClosingSoonDeadlineCell` regression tests, including the exact cuHacking-style row from the issue.

## Acceptance criteria

- [x] A row whose Deadline cell is `—` is never flipped to CLOSING SOON
- [x] cuHacking 2026 stays `[OPEN]`
- [x] A row is flagged CLOSING SOON only when its **Deadline** is within 0–7 days
- [x] Regression test covering a row with an event date in the title and no deadline

## Test

```
$ cd .github/scripts && PYTHONUTF8=1 python3 -m unittest discover -p 'test_*.py'
........................
----------------------------------------------------------------------
Ran 24 tests in 0.004s

OK
```

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
