### PR TITLE
fix: pin SSRF-validated IP to close DNS-rebinding TOCTOU in auto_extract (#74)

### DIFF
--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -15,7 +15,7 @@ import socket
 import sys
 import re
 import time
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunparse
 import requests
 from bs4 import BeautifulSoup
 import util
@@ -31,26 +31,41 @@ except ImportError:
 MAX_REDIRECTS = 5
 
 
-def _resolved_ips_are_public(host):
-    """Resolve a hostname and ensure no address is private/loopback/internal.
+def _resolve_and_validate(host):
+    """Resolve a hostname once and ensure every A/AAAA record is public.
 
-    Returns (ok, reason). Blocks SSRF to the cloud metadata endpoint
+    Returns ``(ok, reason, ip_set, pinned_ip)``. ``ip_set`` is a frozenset of the
+    resolved address strings and ``pinned_ip`` is one validated address the caller
+    can connect to directly. Blocks SSRF to the cloud metadata endpoint
     (169.254.169.254), localhost, and RFC1918 / link-local / reserved ranges.
     """
     try:
         infos = socket.getaddrinfo(host, None)
     except socket.gaierror:
-        return False, f"Could not resolve host: {host}"
+        return False, f"Could not resolve host: {host}", frozenset(), None
+    ips = []
     for info in infos:
         ip_str = info[4][0]
         try:
             ip = ipaddress.ip_address(ip_str)
         except ValueError:
-            return False, f"Unresolvable address for host: {host}"
+            return False, f"Unresolvable address for host: {host}", frozenset(), None
         if (ip.is_private or ip.is_loopback or ip.is_link_local
                 or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
-            return False, f"Refusing to fetch internal address {ip} (host {host})"
-    return True, None
+            return False, f"Refusing to fetch internal address {ip} (host {host})", frozenset(), None
+        ips.append(ip_str)
+    if not ips:
+        return False, f"Could not resolve host: {host}", frozenset(), None
+    return True, None, frozenset(ips), ips[0]
+
+
+def _resolved_ips_are_public(host):
+    """Resolve a hostname and ensure no address is private/loopback/internal.
+
+    Returns (ok, reason). Thin wrapper over :func:`_resolve_and_validate`.
+    """
+    ok, reason, _, _ = _resolve_and_validate(host)
+    return ok, reason
 
 
 def _validate_fetch_url(url):
@@ -63,12 +78,72 @@ def _validate_fetch_url(url):
     return _resolved_ips_are_public(parsed.hostname)
 
 
-def _get_with_retries(url, headers, timeout, retries=2, backoff=1.5):
+def _validate_and_pin(url):
+    """Validate scheme/host and resolve+validate the host in one place.
+
+    Returns ``(ok, reason, host, ip_set, pinned_ip)`` so the caller can connect
+    to the exact IP that was validated (closing the check-then-connect gap).
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False, f"Only http(s) URLs may be fetched (got '{parsed.scheme}')", None, frozenset(), None
+    host = parsed.hostname
+    if not host:
+        return False, "URL has no host", None, frozenset(), None
+    ok, reason, ip_set, pinned_ip = _resolve_and_validate(host)
+    return ok, reason, host, ip_set, pinned_ip
+
+
+class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
+    """HTTPAdapter that connects to a pre-validated IP for a specific host.
+
+    Closes the SSRF DNS-rebinding (TOCTOU) gap in ``safe_get``: instead of letting
+    the transport resolve DNS a second, unchecked time, the socket connects to the
+    exact IP that the SSRF guard already validated as public. The original
+    hostname is preserved for the ``Host`` header, the TLS SNI (``server_hostname``)
+    and certificate hostname verification (``assert_hostname``), so normal HTTPS to
+    public hosts keeps working and certificates are still checked against the name.
+    """
+
+    def __init__(self, host, pinned_ip, **kwargs):
+        self._pinned_host = host
+        self._pinned_ip = pinned_ip
+        super().__init__(**kwargs)
+
+    def send(self, request, **kwargs):
+        parsed = urlparse(request.url)
+        if parsed.hostname == self._pinned_host:
+            ip = self._pinned_ip
+            # Bracket IPv6 literals for the URL netloc.
+            netloc_host = f"[{ip}]" if ":" in ip else ip
+            netloc = f"{netloc_host}:{parsed.port}" if parsed.port else netloc_host
+            request.url = urlunparse(parsed._replace(netloc=netloc))
+            # Preserve the real hostname for the Host header (urllib3 would
+            # otherwise derive it from the IP in the rewritten URL).
+            request.headers["Host"] = self._pinned_host
+            if parsed.scheme == "https":
+                # SNI + certificate hostname must match the real host, not the IP.
+                pool_kw = self.poolmanager.connection_pool_kw
+                pool_kw["server_hostname"] = self._pinned_host
+                pool_kw["assert_hostname"] = self._pinned_host
+        return super().send(request, **kwargs)
+
+
+def _build_pinned_session(host, pinned_ip):
+    """A one-host requests.Session whose connections are pinned to pinned_ip."""
+    session = requests.Session()
+    adapter = _PinnedIPAdapter(host, pinned_ip)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def _get_with_retries(session, url, headers, timeout, retries=2, backoff=1.5):
     """GET a single URL, retrying only transient network errors with backoff."""
     last_exc = None
     for attempt in range(retries + 1):
         try:
-            return requests.get(
+            return session.get(
                 url, headers=headers, timeout=timeout, allow_redirects=False
             )
         except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
@@ -84,13 +159,33 @@ def safe_get(url, headers, timeout=30):
     Never falls back to verify=False — TLS errors propagate. Redirects are
     followed manually so every hop's host is re-checked against the SSRF guard.
     Transient network errors are retried with backoff.
+
+    Each hop is resolved and validated, then the connection is *pinned* to the
+    validated IP so DNS is not resolved again on the wire (issue #74). As defense
+    in depth, the host is re-resolved and the fetch is rejected if its address set
+    changed between the check and the connect (a DNS-rebinding resolver).
     """
     current = url
     for _ in range(MAX_REDIRECTS + 1):
-        ok, reason = _validate_fetch_url(current)
+        ok, reason, host, ip_set, pinned_ip = _validate_and_pin(current)
         if not ok:
             raise ValueError(reason)
-        response = _get_with_retries(current, headers, timeout)
+        # Re-resolve and require an identical address set. This defeats a
+        # DNS-rebinding attacker that answers the validation with a public IP and
+        # the connect with an internal one: any change means we refuse to fetch.
+        ok2, reason2, ip_set2, _ = _resolve_and_validate(host)
+        if not ok2:
+            raise ValueError(reason2)
+        if ip_set != ip_set2:
+            raise ValueError(
+                f"Host {host} resolved to a different address set between "
+                f"validation and connect (possible DNS rebinding); refusing to fetch"
+            )
+        session = _build_pinned_session(host, pinned_ip)
+        try:
+            response = _get_with_retries(session, current, headers, timeout)
+        finally:
+            session.close()
         if response.is_redirect or response.status_code in (301, 302, 303, 307, 308):
             location = response.headers.get("Location")
             if not location:

--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -78,11 +78,37 @@ def _validate_fetch_url(url):
     return _resolved_ips_are_public(parsed.hostname)
 
 
+def _idna_ascii(host):
+    """Return the ASCII (IDNA/punycode) form of ``host``.
+
+    ``requests`` IDNA-encodes a non-ASCII host to punycode when it prepares the
+    URL it actually puts on the wire, so the pinned host must be stored and
+    compared in that same ASCII form. Otherwise an internationalized (Unicode)
+    hostname would never equal ``urlparse(request.url).hostname`` inside the
+    adapter, the pin would be skipped, and the transport would re-resolve DNS
+    unchecked — the exact DNS-rebinding hole this guard closes. Raises
+    ``ValueError`` on an invalid international label (fail closed).
+    """
+    host = host.lower()
+    try:
+        host.encode("ascii")
+        return host  # already ASCII — requests leaves it unchanged
+    except UnicodeEncodeError:
+        pass
+    try:
+        import idna  # requests' own IDNA dependency; matches its uts46 encoding
+        return idna.encode(host, uts46=True).decode("ascii")
+    except Exception as e:
+        raise ValueError(f"URL has an invalid international host label: {host!r}") from e
+
+
 def _validate_and_pin(url):
     """Validate scheme/host and resolve+validate the host in one place.
 
     Returns ``(ok, reason, host, ip_set, pinned_ip)`` so the caller can connect
-    to the exact IP that was validated (closing the check-then-connect gap).
+    to the exact IP that was validated (closing the check-then-connect gap). The
+    returned ``host`` is normalized to its ASCII (IDNA) form so it matches the
+    host ``requests`` will send, and so resolution and pinning use one identity.
     """
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
@@ -90,6 +116,10 @@ def _validate_and_pin(url):
     host = parsed.hostname
     if not host:
         return False, "URL has no host", None, frozenset(), None
+    try:
+        host = _idna_ascii(host)
+    except ValueError as e:
+        return False, str(e), None, frozenset(), None
     ok, reason, ip_set, pinned_ip = _resolve_and_validate(host)
     return ok, reason, host, ip_set, pinned_ip
 
@@ -112,20 +142,27 @@ class _PinnedIPAdapter(requests.adapters.HTTPAdapter):
 
     def send(self, request, **kwargs):
         parsed = urlparse(request.url)
-        if parsed.hostname == self._pinned_host:
-            ip = self._pinned_ip
-            # Bracket IPv6 literals for the URL netloc.
-            netloc_host = f"[{ip}]" if ":" in ip else ip
-            netloc = f"{netloc_host}:{parsed.port}" if parsed.port else netloc_host
-            request.url = urlunparse(parsed._replace(netloc=netloc))
-            # Preserve the real hostname for the Host header (urllib3 would
-            # otherwise derive it from the IP in the rewritten URL).
-            request.headers["Host"] = self._pinned_host
-            if parsed.scheme == "https":
-                # SNI + certificate hostname must match the real host, not the IP.
-                pool_kw = self.poolmanager.connection_pool_kw
-                pool_kw["server_hostname"] = self._pinned_host
-                pool_kw["assert_hostname"] = self._pinned_host
+        if parsed.hostname != self._pinned_host:
+            # Fail closed. Forwarding a request whose host is not the one we
+            # validated and pinned (e.g. an IDNA-encoding mismatch) would let the
+            # transport resolve DNS a second, unchecked time — the TOCTOU hole.
+            raise ValueError(
+                f"Refusing to fetch: request host {parsed.hostname!r} does not "
+                f"match the validated pinned host {self._pinned_host!r}"
+            )
+        ip = self._pinned_ip
+        # Bracket IPv6 literals for the URL netloc.
+        netloc_host = f"[{ip}]" if ":" in ip else ip
+        netloc = f"{netloc_host}:{parsed.port}" if parsed.port else netloc_host
+        request.url = urlunparse(parsed._replace(netloc=netloc))
+        # Preserve the real hostname for the Host header (urllib3 would
+        # otherwise derive it from the IP in the rewritten URL).
+        request.headers["Host"] = self._pinned_host
+        if parsed.scheme == "https":
+            # SNI + certificate hostname must match the real host, not the IP.
+            pool_kw = self.poolmanager.connection_pool_kw
+            pool_kw["server_hostname"] = self._pinned_host
+            pool_kw["assert_hostname"] = self._pinned_host
         return super().send(request, **kwargs)
 
 

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -6,10 +6,14 @@ Covers the core parsing/validation helpers with happy-path + malformed input.
 
 import json
 import os
+import socket
 import tempfile
 import unittest
 from datetime import date, datetime
 from unittest import mock
+from urllib.parse import urlparse
+
+import requests
 
 import util
 import auto_extract as ax
@@ -131,6 +135,81 @@ class SsrfGuard(unittest.TestCase):
     def test_rejects_non_http_scheme(self):
         ok, _ = ax._validate_fetch_url("file:///etc/passwd")
         self.assertFalse(ok)
+
+
+class SsrfDnsRebinding(unittest.TestCase):
+    """Regression tests for the check-then-connect (TOCTOU) SSRF gap, issue #74."""
+
+    @staticmethod
+    def _addrinfo(ip):
+        """A getaddrinfo-shaped result for a single address."""
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+    def test_rejects_rebind_to_private_ip(self):
+        # Resolver answers the validation with a public IP and the re-check with
+        # the cloud metadata endpoint: the fetch must be refused, never performed.
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            side_effect=[self._addrinfo("93.184.216.34"), self._addrinfo("169.254.169.254")],
+        ) as m:
+            with self.assertRaises(ValueError):
+                ax.safe_get("https://victim.example", headers={})
+        # Only the two resolver calls happened — no socket connection was attempted.
+        self.assertEqual(m.call_count, 2)
+
+    def test_rejects_address_set_change_between_check_and_connect(self):
+        # Even when both answers are public, a changed address set means the host
+        # rebound between check and connect, so we refuse rather than connect.
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            side_effect=[self._addrinfo("93.184.216.34"), self._addrinfo("203.0.113.7")],
+        ) as m:
+            with self.assertRaises(ValueError):
+                ax.safe_get("https://victim.example", headers={})
+        self.assertEqual(m.call_count, 2)
+
+    def test_validate_and_pin_accepts_stable_public_ip(self):
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            return_value=self._addrinfo("93.184.216.34"),
+        ):
+            ok, reason, host, ip_set, pinned = ax._validate_and_pin("https://good.example/path")
+        self.assertTrue(ok, reason)
+        self.assertEqual(host, "good.example")
+        self.assertEqual(pinned, "93.184.216.34")
+        self.assertIn("93.184.216.34", ip_set)
+
+    def test_safe_get_pins_stable_public_ip(self):
+        # A stable public IP passes the guard: safe_get builds a pinned session
+        # and performs the fetch (transport mocked so no real network I/O).
+        fake = mock.Mock(is_redirect=False, status_code=200)
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            return_value=self._addrinfo("93.184.216.34"),
+        ), mock.patch("auto_extract._get_with_retries", return_value=fake) as get:
+            out = ax.safe_get("https://good.example/path", headers={})
+        self.assertIs(out, fake)
+        session = get.call_args[0][0]
+        adapter = session.get_adapter("https://good.example/path")
+        self.assertIsInstance(adapter, ax._PinnedIPAdapter)
+
+    def test_adapter_dials_ip_but_keeps_host_and_sni(self):
+        # The connection is dialed at the validated IP, while the Host header, TLS
+        # SNI and certificate hostname stay bound to the original hostname.
+        adapter = ax._PinnedIPAdapter("good.example", "93.184.216.34")
+        prepared = requests.Request(
+            "GET", "https://good.example/path", headers={"User-Agent": "x"}
+        ).prepare()
+        with mock.patch("requests.adapters.HTTPAdapter.send", return_value="sent") as send:
+            out = adapter.send(prepared)
+        self.assertEqual(out, "sent")
+        dialed = send.call_args[0][0]
+        self.assertEqual(urlparse(dialed.url).hostname, "93.184.216.34")
+        self.assertEqual(dialed.headers["Host"], "good.example")
+        pool_kw = adapter.poolmanager.connection_pool_kw
+        self.assertEqual(pool_kw["server_hostname"], "good.example")
+        self.assertEqual(pool_kw["assert_hostname"], "good.example")
 
 
 class DeadlineWatcherRules(unittest.TestCase):

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -211,6 +211,52 @@ class SsrfDnsRebinding(unittest.TestCase):
         self.assertEqual(pool_kw["server_hostname"], "good.example")
         self.assertEqual(pool_kw["assert_hostname"], "good.example")
 
+    def test_idna_ascii_normalizes_unicode_host(self):
+        # requests puts the punycode form on the wire, so the pin must be stored
+        # in that same ASCII form or an IDN host silently bypasses the guard.
+        self.assertEqual(ax._idna_ascii("münchen.de"), "xn--mnchen-3ya.de")
+        self.assertEqual(ax._idna_ascii("EXAMPLE.com"), "example.com")  # ascii, lowercased
+        with self.assertRaises(ValueError):
+            ax._idna_ascii("ÿ" * 100)  # invalid (over-long) international label
+
+    def test_validate_and_pin_normalizes_idn_host(self):
+        # An internationalized hostname is normalized to punycode before resolve
+        # and pin, so the adapter's later comparison against the (punycode) request
+        # URL matches and the connection is actually pinned rather than bypassed.
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            return_value=self._addrinfo("93.184.216.34"),
+        ):
+            ok, reason, host, ip_set, pinned = ax._validate_and_pin("http://münchen.de/")
+        self.assertTrue(ok, reason)
+        self.assertEqual(host, "xn--mnchen-3ya.de")
+
+    def test_safe_get_pins_idn_host_not_bypassed(self):
+        # Full path: an IDN host must be fetched through a session pinned to the
+        # punycode host, not forwarded unpinned (which re-resolves DNS on the wire).
+        fake = mock.Mock(is_redirect=False, status_code=200)
+        with mock.patch(
+            "auto_extract.socket.getaddrinfo",
+            return_value=self._addrinfo("93.184.216.34"),
+        ), mock.patch("auto_extract._get_with_retries", return_value=fake) as get:
+            ax.safe_get("http://münchen.de/path", headers={})
+        session = get.call_args[0][0]
+        adapter = session.get_adapter("http://xn--mnchen-3ya.de/path")
+        self.assertIsInstance(adapter, ax._PinnedIPAdapter)
+        self.assertEqual(adapter._pinned_host, "xn--mnchen-3ya.de")
+
+    def test_adapter_fails_closed_on_host_mismatch(self):
+        # If the prepared request's host is not the pinned host, the adapter must
+        # refuse rather than forward it unpinned (the fail-open TOCTOU hole).
+        adapter = ax._PinnedIPAdapter("good.example", "93.184.216.34")
+        prepared = requests.Request(
+            "GET", "https://evil.example/path", headers={"User-Agent": "x"}
+        ).prepare()
+        with mock.patch("requests.adapters.HTTPAdapter.send", return_value="sent") as send:
+            with self.assertRaises(ValueError):
+                adapter.send(prepared)
+        send.assert_not_called()
+
 
 class DeadlineWatcherRules(unittest.TestCase):
     def _base(self, **over):


### PR DESCRIPTION
## Summary
Fixes the check-then-connect (TOCTOU) SSRF gap in `.github/scripts/auto_extract.py` reported in #74.

Previously `safe_get` validated a host's resolved IPs via `_resolved_ips_are_public()` (one `socket.getaddrinfo`) and then called `requests.get(...)`, which resolved DNS **again, independently**. A DNS-rebinding attacker could answer the validation with a public IP and the actual connection with an internal one (e.g. `169.254.169.254`), so the validated IP set was discarded.

## Fix
- Resolve + validate the host **once** in a single place (`_resolve_and_validate` / `_validate_and_pin`), keeping the existing public-IP range checks intact.
- Connect through a new `_PinnedIPAdapter` (a `requests.adapters.HTTPAdapter`) that dials the **validated IP directly** while preserving:
  - the original `Host` header,
  - the TLS SNI (`server_hostname`), and
  - certificate hostname verification (`assert_hostname`).
  So DNS is not resolved a second, unchecked time on the wire.
- **Defense in depth:** re-resolve the host and refuse the fetch if its address set changed between the check and the connect (a rebinding resolver).
- The **same pin-and-connect discipline is applied per redirect hop** — each hop is independently resolved, validated, address-set-compared, and pinned.
- Preserved: existing 30s timeout, manual `allow_redirects=False` redirect handling, no `verify=False` fallback, header behavior, and the private/loopback/link-local/reserved range blocks.

## Acceptance criteria
- [x] Connection pins to an already-validated public IP (no independent second DNS resolution on the wire).
- [x] Original `Host` header + TLS SNI + cert hostname preserved (verified against real `example.com` and `github.com`, both 200 with cert validation on).
- [x] Host whose address set changes between check and connect is rejected.
- [x] Same discipline applied to each redirect hop.
- [x] Existing timeout / manual redirect / header / public-range behavior unchanged.
- [x] New hermetic test in `test_scripts.py`: a resolver returning different addresses on successive calls (public→private and public→different-public) is **rejected without connecting**; a stable single public IP still passes the guard; the adapter dials the IP while keeping Host/SNI on the original host. All mocked — no real network I/O.
- [x] `cd .github/scripts && PYTHONUTF8=1 python3 -m unittest discover -p 'test_*.py'` → 26 tests, all pass.

## Test result
```
Ran 26 tests in 0.005s
OK
```

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)