### PR TITLE
fix(web): silence Turbopack NFT whole-project trace warning (#77 item 5)

### DIFF
--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -99,7 +99,7 @@ function cleanTitle(text: string): string {
  */
 function loadFeaturedUrls(): Set<string> {
   try {
-    const raw = fs.readFileSync(LISTINGS_PATH, "utf-8");
+    const raw = fs.readFileSync(/*turbopackIgnore: true*/ LISTINGS_PATH, "utf-8");
     const listings = JSON.parse(raw) as Array<{
       url?: string;
       featured?: boolean;
@@ -128,8 +128,11 @@ export function resolveAssetSrc(src: string): string {
   if (src.startsWith("http://") || src.startsWith("https://")) return src;
 
   const relative = src.replace(/^\/+/, "");
-  const localPath = path.join(REPO_ROOT, relative);
-  if (relative.startsWith("assets/") && fs.existsSync(localPath)) {
+  const localPath = path.join(/*turbopackIgnore: true*/ REPO_ROOT, relative);
+  if (
+    relative.startsWith("assets/") &&
+    fs.existsSync(/*turbopackIgnore: true*/ localPath)
+  ) {
     return `/repo-assets/${relative.replace(/^assets\//, "")}`;
   }
 
@@ -259,7 +262,7 @@ const SECTION_ALIAS: Record<string, Section> = {
  */
 function readReadme(): string {
   try {
-    return fs.readFileSync(README_PATH, "utf-8");
+    return fs.readFileSync(/*turbopackIgnore: true*/ README_PATH, "utf-8");
   } catch (err) {
     console.error(`[parse-readme] could not read ${README_PATH}:`, err);
     throw err;

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -10,8 +10,21 @@ import {
 } from "./types";
 import { REPO_RAW_BASE } from "./repo";
 
-const README_PATH = path.join(process.cwd(), "..", "README.md");
-const REPO_ROOT = path.join(process.cwd(), "..");
+// The README and listings.json live at the repo root, one level ABOVE this
+// Next.js project (web/). Turbopack's NFT file tracer can't follow reads that
+// climb out of the project via `..`, so a plain `fs` read rooted here makes it
+// give up and trace the ENTIRE repo into the serverless bundle — surfacing the
+// "whole project was traced unintentionally" build warning (#77 item 5) with
+// web/next.config.ts as the canary unexpected file.
+//
+// These two data files are instead bundled deterministically via
+// `outputFileTracingIncludes` in next.config.ts, so the tracer does not need to
+// discover them. We mark `process.cwd()` opaque with `turbopackIgnore` here so
+// every path derived from REPO_ROOT is unknown at trace time and nothing under
+// the repo root gets pulled in. This is trace-time only — at runtime
+// `process.cwd()` still resolves normally and the reads work as before.
+const REPO_ROOT = path.join(/*turbopackIgnore: true*/ process.cwd(), "..");
+const README_PATH = path.join(REPO_ROOT, "README.md");
 const LISTINGS_PATH = path.join(
   REPO_ROOT,
   ".github",


### PR DESCRIPTION
## What & why

Addresses **#77 item 5** — the last remaining item on the tech-debt checklist.

`next build` emitted a Turbopack NFT (Next.js File Tracing) warning:

```
Turbopack build encountered 1 warnings:
./web/next.config.ts
Encountered unexpected file in NFT list
A file was traced that indicates that the whole project was traced unintentionally.
...
Import trace:
  Server Component:
    ./web/next.config.ts
    ./web/lib/parse-readme.ts
    ./web/app/hackathons/page.tsx
```

`web/next.config.ts` was only the *canary*: the real cause is that `web/lib/parse-readme.ts` reads the repo-root `README.md` / `.github/scripts/listings.json` via `path.join(process.cwd(), "..")` and a fully dynamic `path.join(REPO_ROOT, relative)` + `fs.existsSync` in `resolveAssetSrc`. Those climb out of `web/` with a value the tracer can't resolve statically, so `@vercel/nft` gives up and pulls the **entire repo root** into every route's serverless trace.

## Fix

Mark the dynamic `fs`/`path` operations opaque to the tracer with `/*turbopackIgnore: true*/` — the exact remedy the warning text itself recommends. The two data files are already bundled deterministically through `outputFileTracingIncludes` in `next.config.ts`, so the tracer never needed to *discover* them by following the reads.

- Consolidated the repo-root paths through a single `REPO_ROOT` and annotated the `process.cwd()` seed.
- Annotated each of the three `fs` read call sites individually (`readFileSync` of README.md and listings.json, and the dynamic `existsSync` in `resolveAssetSrc`). The tracer evaluates each `fs` call independently, so a single annotation at the definition is **not** enough — this mirrors Next.js's own server code (`load-components.js`, `require.js`, `load-manifest.external.js`), which re-annotates at every `join` and read.

This is **trace-time only**: at runtime `process.cwd()` still resolves normally and the reads are unchanged. `next.config.ts` (the intentional `outputFileTracingRoot` + `outputFileTracingIncludes` for the ISR data files) is untouched.

## Before / after — build warning

**Before**
```
Turbopack build encountered 1 warnings:
./web/next.config.ts
Encountered unexpected file in NFT list
A file was traced that indicates that the whole project was traced unintentionally.
```

**After**
```
▲ Next.js 16.2.10 (Turbopack)
  Creating an optimized production build ...
✓ Compiled successfully in 3.6s
...
✓ Generating static pages using 7 workers (8/8)
```
No warnings. Build succeeds; `/` and `/hackathons` prerender as static content (which only happens if `parse-readme.ts` successfully reads both data files — otherwise `readReadme()` throws and the build fails).

## Verification

- `npm run build` — clean, **0 NFT warnings**, all 8 static pages generated.
- Data-file includes preserved — confirmed in `.next/server/app/hackathons/page.js.nft.json`: repo-root inclusions dropped from the whole project to just the two intended files (`../../../../../README.md`, `../../../../../.github/scripts/listings.json`) plus two tiny asset READMEs. `next.config.ts` / `parse-readme.ts` are no longer traced into the bundle.
- `npx vitest run` — 51 passed.
- `npm run lint` — clean.

## Note

This does **not** `Closes #77` — the other checklist items are tracked separately. This PR only closes out item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
