### PR TITLE
Handle escaped pipes in README table parsers

### DIFF
--- a/.github/scripts/generate_banner.py
+++ b/.github/scripts/generate_banner.py
@@ -15,6 +15,8 @@ import re
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+import util
+
 PST = ZoneInfo("America/Los_Angeles")
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 README = os.path.join(ROOT, "README.md")
@@ -34,12 +36,12 @@ def parse_rows():
     lines = [l for l in m.group(1).split("\n") if l.strip().startswith("|")]
     if len(lines) < 3:
         return []
-    headers = [h.strip() for h in lines[0].split("|")[1:-1]]
+    headers = util.split_table_cells(lines[0])
     rows = []
     for line in lines[1:]:
         if re.match(r"^\|\s*-+", line.strip()):
             continue
-        cells = [c.strip() for c in line.split("|")[1:-1]]
+        cells = util.split_table_cells(line)
         if len(cells) != len(headers):
             continue
         rows.append(dict(zip(headers, cells)))

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -90,6 +90,29 @@ class ParseStateAndDeadline(unittest.TestCase):
         self.assertIsNone(util.parse_deadline({}, "deadline"))
 
 
+class SplitTableCells(unittest.TestCase):
+    def test_escaped_pipe_stays_in_one_cell(self):
+        row = (
+            "| ✅ **[OPEN]** | Foo \\| Bar | Some Hack | In-Person | "
+            "Boston, MA | $10k | Jul 15, 2026 | "
+            '<a href="https://example.org">Register</a> | Jul 01, 2026 |'
+        )
+        cells = util.split_table_cells(row)
+        self.assertEqual(cells[1], "Foo | Bar")
+        self.assertEqual(cells[2], "Some Hack")
+        self.assertEqual(cells[6], "Jul 15, 2026")
+
+    def test_ordinary_row_unchanged(self):
+        row = (
+            "| ✅ **[OPEN]** | MIT | HackMIT 2026 | In-Person | Cambridge, MA | "
+            "$20K | Jul 04, 2026 | <a href=\"https://hackmit.org/\">Register</a> | "
+            "Jun 27, 2026 |"
+        )
+        cells = util.split_table_cells(row)
+        self.assertEqual(cells[1], "MIT")
+        self.assertEqual(cells[2], "HackMIT 2026")
+
+
 class CleanUrl(unittest.TestCase):
     def test_empty_returns_empty(self):
         # Must not manufacture "https://" out of nothing (issue #73).

--- a/.github/scripts/util.py
+++ b/.github/scripts/util.py
@@ -169,6 +169,15 @@ def sanitize_table_cell(value):
     return value.strip()
 
 
+def split_table_cells(line):
+    """Split a markdown table row on unescaped pipe delimiters."""
+    text = line.strip().strip("|")
+    return [
+        c.strip().replace("\\|", "|")
+        for c in re.split(r"(?<!\\)\|", text)
+    ]
+
+
 def format_locations(locations):
     """Format location list for display."""
     if not locations:

--- a/.github/scripts/weekly_digest.py
+++ b/.github/scripts/weekly_digest.py
@@ -47,12 +47,12 @@ def parse_table(section_key: str, body: str):
     if len(lines) < 3:
         return []
 
-    headers = [h.strip() for h in lines[0].split("|")[1:-1]]
+    headers = util.split_table_cells(lines[0])
     data_lines = [l for l in lines[1:] if not re.match(r"^\|\s*-+", l.strip())]
 
     rows = []
     for line in data_lines:
-        cells = [c.strip() for c in line.split("|")[1:-1]]
+        cells = util.split_table_cells(line)
         if len(cells) != len(headers):
             continue
         row = dict(zip(headers, cells))

--- a/web/lib/parse-readme.test.ts
+++ b/web/lib/parse-readme.test.ts
@@ -74,4 +74,20 @@ describe("parseOpportunities", () => {
   it("returns [] when there is no table", () => {
     expect(parseOpportunities("just some prose, no table")).toEqual([]);
   });
+
+  it("parses escaped pipes in host without shifting columns", () => {
+    const pipeMd = [
+      "<!-- HACKATHONS_TABLE_START -->",
+      "| Status | Host | Hackathon | Format | Location | Prize | Deadline | Application | Date Posted |",
+      "| ------ | ---- | --------- | ------ | -------- | ----- | -------- | ----------- | ----------- |",
+      '| ✅ **[OPEN]** | Foo \\| Bar | HackMIT 2026 | In-Person | Cambridge, MA | $20K | Jul 04, 2026 | <a href="https://hackmit.org/">Register</a> | Jun 27, 2026 |',
+      "<!-- HACKATHONS_TABLE_END -->",
+    ].join("\n");
+    const ops = parseOpportunities(pipeMd);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]?.organization).toBe("Foo | Bar");
+    expect(ops[0]?.title).toBe("HackMIT 2026");
+    expect(ops[0]?.location).toBe("Cambridge, MA");
+    expect(ops[0]?.url).toBe("https://hackmit.org/");
+  });
 });

--- a/web/lib/parse-readme.ts
+++ b/web/lib/parse-readme.ts
@@ -92,6 +92,14 @@ function cleanTitle(text: string): string {
     .trim();
 }
 
+/** Split a markdown table row on unescaped pipe delimiters. */
+function splitTableCells(line: string): string[] {
+  const inner = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  return inner
+    .split(/(?<!\\)\|/)
+    .map((s) => s.trim().replace(/\\\|/g, "|"));
+}
+
 /**
  * Featured flags come from the structured source of truth (listings.json),
  * not the README markup. This is the single place to swap to Supabase later:
@@ -176,10 +184,7 @@ function parseTableRows(
     .filter((l) => l.startsWith("|"));
   if (lines.length < 3) return [];
 
-  const headers = (lines[0] ?? "")
-    .split("|")
-    .slice(1, -1)
-    .map((s) => s.trim());
+  const headers = splitTableCells(lines[0] ?? "");
 
   const headerIdx = (...names: string[]) => {
     for (const name of names) {
@@ -205,7 +210,7 @@ function parseTableRows(
   const dataLines = lines.slice(1).filter((l) => !/^\|\s*-+/.test(l));
 
   return dataLines.map((line) => {
-    const cells = line.split("|").slice(1, -1).map((s) => s.trim());
+    const cells = splitTableCells(line);
     const get = (i: number) => (i >= 0 ? cells[i] || "" : "");
 
     const status = parseStatus(get(idx.status));


### PR DESCRIPTION
## Summary

Parse markdown table rows on unescaped pipe delimiters so escaped `\|` cell content does not shift columns.

## Problem

The README generator escapes literal pipes as `\|`, but parsers split on every raw `|` character. A pipe in host, title, location, or prize corrupts or drops the row.

## Changes

- Add `split_table_cells` helper in `util.py`
- Use it in `weekly_digest.py` and `generate_banner.py`
- Add `splitTableCells` in `parse-readme.ts` for the frontend parser
- Regression tests in Python and Vitest

## Validation

- `python -m unittest discover -s .github/scripts -p "test_*.py"` - 50 tests OK
- `npm test` in `web/` - 52 tests OK

## Scope

No change to pipe-free rows. `closing_soon.py` already used unescaped-pipe splitting.
