### PR TITLE
Ignore stale tracked IDs in My HackHQ counts

### DIFF
--- a/web/components/hq/tracker.tsx
+++ b/web/components/hq/tracker.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import type { Hackathon } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
+import { countKnownTracked } from "@/lib/tracker-utils";
 import { STAGES, useSelection, useTracker, type Stage } from "./store";
 
 export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
@@ -29,7 +30,10 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
     [tracked, byId],
   );
 
-  const trackedCount = Object.keys(tracked).length;
+  const trackedCount = useMemo(
+    () => countKnownTracked(tracked, hackathons.map((h) => h.id)),
+    [tracked, hackathons],
+  );
 
   // Deadline radar: the most urgent live deadline you're tracking.
   const urgent = useMemo(() => {
@@ -130,7 +134,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
               <div className="kicker text-[9px] text-coral">Deadline radar</div>
               <div className="mt-1 text-sm font-semibold text-paper">
                 {urgent
-                  ? `${urgent.title} closes in ${urgent.daysLeft} day${urgent.daysLeft === 1 ? "" : "s"}`
+                  ? `${urgent.title} ${countdown(urgent) ?? ""}`.trim()
                   : trackedCount > 0
                     ? "No upcoming deadlines on your radar - you're clear."
                     : "Track a hackathon and its deadline shows up here."}

--- a/web/lib/tracker-utils.test.ts
+++ b/web/lib/tracker-utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { countKnownTracked } from "./tracker-utils";
+
+describe("countKnownTracked", () => {
+  it("ignores stale IDs missing from the current listing set", () => {
+    const tracked = { a: "interested", stale: "going" };
+    expect(countKnownTracked(tracked, ["a"])).toBe(1);
+  });
+
+  it("returns zero when every tracked ID is stale", () => {
+    const tracked = { gone: "interested" };
+    expect(countKnownTracked(tracked, ["a", "b"])).toBe(0);
+  });
+
+  it("counts all IDs when every tracked entry is known", () => {
+    const tracked = { a: "interested", b: "going" };
+    expect(countKnownTracked(tracked, ["a", "b", "c"])).toBe(2);
+  });
+});

--- a/web/lib/tracker-utils.ts
+++ b/web/lib/tracker-utils.ts
@@ -1,0 +1,8 @@
+/** Count tracked IDs that still exist in the current hackathon list. */
+export function countKnownTracked(
+  tracked: Record<string, string>,
+  knownIds: Iterable<string>,
+): number {
+  const known = new Set(knownIds);
+  return Object.keys(tracked).filter((id) => known.has(id)).length;
+}


### PR DESCRIPTION
## Summary

Ignore tracked IDs that no longer exist in the current hackathon list when computing counts and deadline-radar messaging.

## Problem

My HackHQ stored tracked IDs in localStorage, but counts and empty-state copy used the raw map while columns only rendered IDs still present in `listings.json`. Removed listings inflated the count and made the deadline radar claim you were clear while invisible stale IDs remained.

## Changes

- Add `countKnownTracked` helper
- Use it for tracked count and empty-state gating
- Use `countdown()` for deadline radar copy (fixes "closes in 0 days")

## Validation

- `npm test` in `web/` - 54 tests OK

## Scope

Does not auto-prune stale IDs from localStorage (separate UX decision).
