### PR TITLE
Use portable date formatting in stats banner

### DIFF
--- a/.github/scripts/generate_banner.py
+++ b/.github/scripts/generate_banner.py
@@ -92,8 +92,15 @@ def bar_segments(s, width):
     return segs
 
 
-def svg(s):
-    now = datetime.now(tz=PST).strftime("%B %-d, %Y")
+def format_banner_date(dt: datetime) -> str:
+    """Readable banner date without platform-specific strftime directives."""
+    return f"{dt.strftime('%B')} {dt.day}, {dt.strftime('%Y')}"
+
+
+def svg(s, today=None):
+    if today is None:
+        today = datetime.now(tz=PST)
+    now = format_banner_date(today)
     W, H = 760, 150
     pad = 28
     font = "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif"

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -433,6 +433,32 @@ class UpdateReadmesSkipsBadRows(unittest.TestCase):
         self.assertTrue(any("bad" in str(c) for c in warn.call_args_list))
 
 
+class BannerDateFormat(unittest.TestCase):
+    def test_format_banner_date_avoids_platform_strftime_directive(self):
+        import generate_banner as gb
+
+        dt = datetime(2026, 7, 5, tzinfo=gb.PST)
+        self.assertEqual(gb.format_banner_date(dt), "July 5, 2026")
+
+    def test_svg_includes_formatted_date(self):
+        import generate_banner as gb
+
+        dt = datetime(2026, 12, 9, tzinfo=gb.PST)
+        out = gb.svg(
+            {
+                "total": 1,
+                "open": 1,
+                "opens_soon": 0,
+                "closing": 0,
+                "in_person": 1,
+                "virtual": 0,
+                "hybrid": 0,
+            },
+            today=dt,
+        )
+        self.assertIn("as of December 9, 2026", out)
+
+
 class ClosingSoonDeadlineCell(unittest.TestCase):
     """Regression tests for issue #70.
 


### PR DESCRIPTION
## Summary

Replace glibc-only `%-d` strftime with portable date formatting in the stats banner SVG.

## Problem

`generate_banner.py` used `strftime("%B %-d, %Y")`, which raises `ValueError` on Windows. CI passes on Linux, but local banner regeneration on Windows fails silently behind a warning.

## Changes

- Add `format_banner_date` helper using `dt.day`
- Allow optional `today` in `svg()` for deterministic tests
- Regression tests for formatting and SVG output

## Validation

- `python -m unittest discover -s .github/scripts -p "test_*.py"` - OK (includes `BannerDateFormat`)

## Scope

SVG layout unchanged; only the "as of" date string construction.
