### PR TITLE
Serialize weekly digest and reuse open issue

### DIFF
--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -501,5 +501,18 @@ class ClosingSoonDeadlineCell(unittest.TestCase):
         self.assertNotIn(cs.OPEN, new_row)
 
 
+class WeeklyDigestWorkflow(unittest.TestCase):
+    def test_serializes_and_reuses_open_digest_issue(self):
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "workflows", "weekly_digest.yml"
+        )
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("group: weekly-digest", content)
+        self.assertIn("cancel-in-progress: false", content)
+        self.assertIn("Open or refresh digest issue", content)
+        self.assertIn('gh issue list --repo "$REPO" --label "digest"', content)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/workflows/weekly_digest.yml
+++ b/.github/workflows/weekly_digest.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: weekly-digest
+  cancel-in-progress: false
+
 jobs:
   digest:
     runs-on: ubuntu-latest
@@ -32,14 +36,27 @@ jobs:
           gh label create "digest" --color "8B5CF6" --description "Weekly digest of new and closing-soon opportunities" \
             --repo "${{ github.repository }}" 2>/dev/null || true
 
-      - name: Create issue
+      - name: Open or refresh digest issue
         if: steps.gen.outputs.has_content == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CLOSING_COUNT: ${{ steps.gen.outputs.closing_count }}
+          NEW_COUNT: ${{ steps.gen.outputs.new_count }}
         run: |
           DATE=$(date '+%B %d, %Y')
-          gh issue create \
-            --title "📬 Weekly Digest — $DATE" \
-            --body-file digest.md \
-            --label "digest" \
-            --repo "${{ github.repository }}"
+          TITLE="📬 Weekly Digest — $DATE"
+          EXISTING=$(gh issue list --repo "$REPO" --label "digest" \
+            --state open --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --repo "$REPO" \
+              --title "$TITLE" --body-file digest.md
+            gh issue comment "$EXISTING" --repo "$REPO" \
+              --body "Refreshed on ${DATE}: ${CLOSING_COUNT} closing soon, ${NEW_COUNT} new this week."
+            echo "Refreshed existing issue #$EXISTING"
+          else
+            gh issue create --repo "$REPO" \
+              --title "$TITLE" \
+              --body-file digest.md \
+              --label "digest"
+          fi


### PR DESCRIPTION
## Summary

Serialize weekly digest runs and reuse the open digest issue instead of creating a new one every week.

## Problem

`weekly_digest.yml` always called `gh issue create` with no concurrency control. Open digest issues (#59, #27) piled up when prior digests were not closed.

## Changes

- Add `weekly-digest` concurrency group with `cancel-in-progress: false`
- Reuse the existing open `digest`-labeled issue (edit body/title + refresh comment), matching `deadline_watch.yml`
- Workflow regression test

## Validation

- `python -m unittest discover -s .github/scripts -p "test_*.py"` - OK

## Scope

Does not auto-close old digest issues already in the backlog.
