### PR TITLE
fix: correct Qwen Cloud hackathon deadline

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -169,7 +169,7 @@
     "active": true,
     "is_visible": true,
     "date_posted": 1782554400,
-    "date_updated": 1783771200,
+    "date_updated": 1783821900,
     "source": "devpost",
     "deadline": "2026-07-20"
   },


### PR DESCRIPTION
## Summary
- Correct Qwen Cloud listing deadline from Jul 9 to Jul 20, 2026 per official Devpost schedule
- Updates title date range and README status from CLOSING SOON to OPEN

## Test plan
- [ ] Verify Qwen Cloud row shows Jul 20, 2026 deadline and OPEN status in README