### PR TITLE
Fix keyboard access for HQ detail modal and tracker stage movement

### DIFF
--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -230,14 +230,26 @@ function HackCard({ h }: { h: Hackathon }) {
   const meta = STATE_META[h.state];
   const cd = countdown(h);
   const dim = h.state === "closed";
+  const openDetails = () => setSelected(h);
+  const onOpenKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      openDetails();
+    }
+  };
 
   return (
     <motion.article
-      onClick={() => setSelected(h)}
+      onClick={openDetails}
+      onKeyDown={onOpenKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${h.title}`}
       initial="rest"
       animate="rest"
       whileHover={reduceMotion ? undefined : "open"}
-      className={`group relative aspect-[318/380] cursor-pointer ${dim ? "opacity-55 saturate-50" : ""}`}
+      className={`group relative aspect-[318/380] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 focus-visible:ring-offset-ink ${dim ? "opacity-55 saturate-50" : ""}`}
       style={{ perspective: 1400 }}
     >
       {/* Folder back */}
@@ -343,11 +355,23 @@ function HackRow({ h }: { h: Hackathon }) {
   const { setSelected } = useSelection();
   const meta = STATE_META[h.state];
   const cd = countdown(h);
+  const openDetails = () => setSelected(h);
+  const onOpenKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      openDetails();
+    }
+  };
 
   return (
     <div
-      onClick={() => setSelected(h)}
-      className={`flex cursor-pointer items-center gap-4 px-5 py-4 transition hover:bg-ink/4 sm:px-7 ${h.state === "closed" ? "opacity-50" : ""}`}
+      onClick={openDetails}
+      onKeyDown={onOpenKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${h.title}`}
+      className={`flex cursor-pointer items-center gap-4 px-5 py-4 transition hover:bg-ink/4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset sm:px-7 ${h.state === "closed" ? "opacity-50" : ""}`}
     >
       <span
         className="h-2.5 w-2.5 shrink-0 rounded-full"

--- a/web/components/hq/detail-modal.tsx
+++ b/web/components/hq/detail-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { STATE_META, countdown, deadlineDisplay } from "@/lib/types-hq";
 import { lockScroll } from "@/lib/scroll-lock";
 import { useSelection, useTracker } from "./store";
@@ -8,15 +8,27 @@ import { useSelection, useTracker } from "./store";
 export function DetailModal() {
   const { selected, setSelected } = useSelection();
   const { isTracked, save, remove } = useTracker();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!selected) return;
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && setSelected(null);
     window.addEventListener("keydown", onKey);
     const release = lockScroll();
+    window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
     return () => {
       window.removeEventListener("keydown", onKey);
       release();
+      const previous = previousFocusRef.current;
+      if (previous && document.contains(previous)) {
+        previous.focus();
+      }
     };
   }, [selected, setSelected]);
 
@@ -25,6 +37,37 @@ export function DetailModal() {
   const meta = STATE_META[h.state];
   const cd = countdown(h);
   const tracked = isTracked(h.id);
+  const titleId = `detail-modal-title-${h.id}`;
+  const onDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Tab") return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusable = Array.from(
+      panel.querySelectorAll<HTMLElement>(
+        'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [contenteditable="true"], [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((el) => !el.hasAttribute("disabled") && !el.hidden && el.tabIndex >= 0);
+    if (focusable.length === 0) {
+      e.preventDefault();
+      panel.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) return;
+    const active = document.activeElement;
+    if (e.shiftKey) {
+      if (active === first || !panel.contains(active)) {
+        e.preventDefault();
+        last.focus();
+      }
+      return;
+    }
+    if (active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
 
   return (
     <div
@@ -32,7 +75,13 @@ export function DetailModal() {
       onClick={() => setSelected(null)}
     >
       <div
+        ref={panelRef}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={onDialogKeyDown}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
         className="relative w-full max-w-xl overflow-hidden rounded-[2.2rem] border border-white/12 bg-ink shadow-[0_40px_120px_rgba(0,0,0,0.6)]"
       >
         {/* Header band */}
@@ -49,6 +98,7 @@ export function DetailModal() {
             </span>
           </div>
           <button
+            ref={closeButtonRef}
             onClick={() => setSelected(null)}
             aria-label="Close"
             className="flex h-9 w-9 items-center justify-center rounded-full border border-white/15 text-paper/70 transition hover:bg-white/10"
@@ -60,7 +110,7 @@ export function DetailModal() {
         {/* Body */}
         <div className="px-7 py-6">
           <div className="kicker text-coral">{h.host}</div>
-          <h3 className="display mt-2 text-[clamp(1.8rem,4vw,2.6rem)] text-paper">
+          <h3 id={titleId} className="display mt-2 text-[clamp(1.8rem,4vw,2.6rem)] text-paper">
             {h.title}
           </h3>
           {h.tagline && (

--- a/web/components/hq/tracker.tsx
+++ b/web/components/hq/tracker.tsx
@@ -85,7 +85,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
                     className="h-1.5 w-1.5 rounded-full"
                     style={{ background: col.color }}
                   />
-                  {col.label}
+                  <span id={`tracker-stage-${col.id}`}>{col.label}</span>
                 </span>
                 <span className="font-mono text-[10px] text-paper/35">
                   {col.items.length}
@@ -98,6 +98,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
                     key={h.id}
                     h={h}
                     dragging={dragId === h.id}
+                    stageId={col.id}
                     onDragStart={() => setDragId(h.id)}
                     onDragEnd={() => {
                       setDragId(null);
@@ -105,6 +106,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
                     }}
                     onOpen={() => setSelected(h)}
                     onRemove={() => remove(h.id)}
+                    onMoveStage={(stage) => move(h.id, stage)}
                   />
                 ))}
                 {col.items.length === 0 && (
@@ -156,20 +158,34 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
 function TrackerCard({
   h,
   dragging,
+  stageId,
   onDragStart,
   onDragEnd,
   onOpen,
   onRemove,
+  onMoveStage,
 }: {
   h: Hackathon;
   dragging: boolean;
+  stageId: Stage;
   onDragStart: () => void;
   onDragEnd: () => void;
   onOpen: () => void;
   onRemove: () => void;
+  onMoveStage: (stage: Stage) => void;
 }) {
   const meta = STATE_META[h.state];
   const cd = countdown(h);
+  const stageIndex = STAGES.findIndex((stage) => stage.id === stageId);
+  const prevStage = stageIndex > 0 ? STAGES[stageIndex - 1] : null;
+  const nextStage = stageIndex < STAGES.length - 1 ? STAGES[stageIndex + 1] : null;
+  const onOpenKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      onOpen();
+    }
+  };
 
   return (
     <div
@@ -177,7 +193,12 @@ function TrackerCard({
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
       onClick={onOpen}
-      className={`group cursor-grab rounded-2xl border border-white/10 bg-ink-soft p-3.5 transition active:cursor-grabbing ${
+      onKeyDown={onOpenKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`View details for ${h.title}`}
+      aria-describedby={`tracker-stage-${stageId}`}
+      className={`group cursor-grab rounded-2xl border border-white/10 bg-ink-soft p-3.5 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 focus-visible:ring-offset-ink active:cursor-grabbing ${
         dragging ? "opacity-40" : "hover:border-white/25"
       }`}
     >
@@ -215,6 +236,34 @@ function TrackerCard({
           {cd.toUpperCase()}
         </div>
       )}
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {prevStage && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onMoveStage(prevStage.id);
+            }}
+            aria-label={`Move ${h.title} to ${prevStage.label}`}
+            className="rounded-full border border-white/20 px-3 py-1 font-mono text-[9px] tracking-[0.14em] text-paper/80 transition hover:border-white/35 hover:bg-white/10"
+          >
+            ← {prevStage.label.toUpperCase()}
+          </button>
+        )}
+        {nextStage && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onMoveStage(nextStage.id);
+            }}
+            aria-label={`Move ${h.title} to ${nextStage.label}`}
+            className="rounded-full border border-coral/40 px-3 py-1 font-mono text-[9px] tracking-[0.14em] text-coral transition hover:border-coral hover:bg-coral/12"
+          >
+            {nextStage.label.toUpperCase()} →
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Closes #69 

## Summary
- Make HQ detail modal triggers keyboard-operable in deck cards, deck rows, and tracker cards (`role="button"`, `tabIndex`, Enter/Space handlers, focus-visible styles).
- Upgrade `DetailModal` with dialog semantics (`role="dialog"`, `aria-modal`, `aria-labelledby`), initial focus to close button, focus trapping, and focus restore to opener on close.
- Add keyboard-accessible tracker stage transition controls (previous/next stage buttons) as a fallback to drag-and-drop.

## Why
Keyboard and assistive-technology users could not reliably open or stay within the details experience, and tracker stage movement required a mouse. This closes those accessibility gaps.

## Test plan
- [x] Tab to a deck card and press Enter/Space -> detail modal opens
- [x] Tab to a deck list row and press Enter/Space -> detail modal opens
- [x] Tab to a tracker card and press Enter/Space -> detail modal opens
- [x] Screen reader announces modal as a dialog with title
- [x] While modal is open, Tab/Shift+Tab cycles only inside dialog
- [x] Escape closes modal
- [x] Closing modal restores focus to the triggering element
- [x] Use tracker prev/next stage buttons to move cards without drag-and-drop