### PR TITLE
fix(globe): correct every marker location + stop the card opening on zoom

### DIFF
--- a/.github/scripts/listings.json
+++ b/.github/scripts/listings.json
@@ -251,7 +251,7 @@
     "title": "Agentic AI Build Week 2026 \u2014 Jun 9 \u2013 Jul 11, 2026",
     "url": "https://agentic-ai-build-week-2026.devpost.com/",
     "locations": [
-      "Galaxy Innovation Park"
+      "Ho Chi Minh City, Vietnam"
     ],
     "format": "In-Person",
     "prize": "TBA",
@@ -259,7 +259,7 @@
     "active": false,
     "is_visible": true,
     "date_posted": 1782536400,
-    "date_updated": 1783771200,
+    "date_updated": 1783857600,
     "source": "devpost"
   },
   {

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Hackathons are the fastest way to build something real, meet your future team, a
 | 🔒 **[CLOSED]** | Hack the 6ix | Hack the 6ix 2026 — Jul 17–19, 2026 | In-Person | Toronto, ON, Canada | TBA | — | :lock: | Jun 27, 2026 |
 | 🔒 **[CLOSED]** | Devpost | H0: Hack the Zero Stack with Vercel v0 and AWS Databases — May 27 – Jun 29, 2026 | Virtual | Online | $80,000 | Jun 29, 2026 | :lock: | Jun 27, 2026 |
 | 🔒 **[CLOSED]** | UiPath | UiPath AgentHack — May 15 – Jun 29, 2026 | Virtual | Online | $50,000 | Jun 29, 2026 | :lock: | Jun 27, 2026 |
-| 🔒 **[CLOSED]** | Agentic AI Build Week | Agentic AI Build Week 2026 — Jun 9 – Jul 11, 2026 | In-Person | Galaxy Innovation Park | TBA | — | :lock: | Jun 26, 2026 |
+| 🔒 **[CLOSED]** | Agentic AI Build Week | Agentic AI Build Week 2026 — Jun 9 – Jul 11, 2026 | In-Person | Ho Chi Minh City, Vietnam | TBA | — | :lock: | Jun 26, 2026 |
 <!-- HACKATHONS_TABLE_END -->
 
 ---

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -5,7 +5,6 @@ import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import type { Hackathon } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
-import { useSelection } from "./store";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
 
@@ -21,7 +20,6 @@ const SECONDS_PER_REVOLUTION = 110;
 export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
-  const { setSelected } = useSelection();
   const [zoomedIn, setZoomedIn] = useState(false);
   const hasToken = Boolean(mapboxgl.accessToken);
 
@@ -141,13 +139,16 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         e.stopPropagation();
         spinEnabled = false;
         popup.remove();
+        // Clicking a marker only flies the camera in — it deliberately does NOT
+        // open the detail card, which would cover the very map you just zoomed
+        // into. The hover popup carries the quick facts; full details live in
+        // the Deck / hackathons list.
         map.flyTo({
           center: [h.lng!, h.lat!],
           zoom: 9.5,
           duration: 2600,
           essential: true,
         });
-        setSelected(h);
       });
 
       return new mapboxgl.Marker({ element: el })

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -40,17 +40,38 @@ type RawListing = {
 const GEO: Record<string, [number, number]> = {
   "Amherst, MA": [42.3732, -72.5199],
   "Ann Arbor, MI": [42.2808, -83.743],
+  "Atlanta, GA": [33.749, -84.388],
   "Austin, TX": [30.2672, -97.7431],
   "Berkeley / San Francisco, CA": [37.8715, -122.273],
+  "Blacksburg, VA": [37.2296, -80.4139],
   "Boston, MA": [42.3601, -71.0589],
   "Cambridge, MA": [42.3736, -71.1097],
+  "Chapel Hill, NC": [35.9132, -79.0558],
   "College Park, MD": [38.9897, -76.9378],
+  "Dearborn, MI": [42.3223, -83.1763],
+  "Greensboro, NC": [36.0726, -79.792],
+  "Hamilton, ON": [43.2557, -79.8711],
+  "Ho Chi Minh City, Vietnam": [10.7769, 106.7009],
+  "Houston, TX": [29.7604, -95.3698],
+  "Ithaca, NY": [42.444, -76.5019],
   "Kolkata, India": [22.5726, 88.3639],
   "Los Angeles, CA": [34.0522, -118.2437],
+  "Miami, FL": [25.7617, -80.1918],
   "New York, NY": [40.7128, -74.006],
+  "Newark, NJ": [40.7357, -74.1724],
+  "Ottawa, ON": [45.4215, -75.6972],
   "Philadelphia, PA": [39.9526, -75.1652],
+  "Pittsburgh, PA": [40.4406, -79.9959],
+  "Providence, RI": [41.824, -71.4128],
   "San Francisco, CA": [37.7749, -122.4194],
+  "Santa Clara, CA": [37.3541, -121.9552],
+  "Seattle, WA": [47.6062, -122.3321],
+  "Stony Brook, NY": [40.9257, -73.1409],
+  "Toronto, ON": [43.6532, -79.3832],
+  // Legacy key — older listings spell Toronto with the country suffix.
   "Toronto, ON, Canada": [43.6532, -79.3832],
+  "Troy, NY": [42.7284, -73.6918],
+  "Vancouver, BC": [49.2827, -123.1207],
 };
 
 const THEME_RULES: [RegExp, string][] = [
@@ -162,10 +183,14 @@ export function loadHackathons(): Hackathon[] {
       const geo = GEO[location];
       if (geo && r.format !== "Virtual") {
         const n = (seen[location] = (seen[location] ?? 0) + 1);
-        // spiral jitter ~0.08° per twin so stacked cities stay clickable
+        // Spiral-offset co-located markers just enough to stay individually
+        // clickable when zoomed into a city. Keep this SMALL: 0.01° is ~1.1km,
+        // which separates pins at city zoom while keeping every marker inside
+        // the right city. (This was 0.08° ≈ 9km, which flung a Cambridge pin
+        // clear across town into Roslindale.)
         const angle = n * 2.4;
-        lat = geo[0] + (n > 1 ? 0.08 * Math.sin(angle) : 0);
-        lng = geo[1] + (n > 1 ? 0.08 * Math.cos(angle) : 0);
+        lat = geo[0] + (n > 1 ? 0.01 * Math.sin(angle) : 0);
+        lng = geo[1] + (n > 1 ? 0.01 * Math.cos(angle) : 0);
       }
 
       const format =


### PR DESCRIPTION
## 1. Markers were in the wrong place (or missing entirely)

`web/lib/listings.ts` geocodes via an **exact-string** `GEO` lookup that had only **13 entries**, then applied a "jitter" to un-stack co-located pins:

```js
lat = geo[0] + (n > 1 ? 0.08 * Math.sin(angle) : 0);   // 0.08° ≈ 9 km
```

Two consequences:

- **23 in-person listings had no coordinates at all** and never rendered on the globe — including every recently-added collegiate event (Troy, Ithaca, Pittsburgh, Miami, Seattle, Vancouver, Providence…). `"Toronto, ON"` (3 listings) missed purely because the table only had `"Toronto, ON, Canada"`.
- **The jitter is ~9 km.** With two Cambridge listings, one pin got flung across town into **Roslindale** — the wrong-location dot in the report.

**Fix:** added every missing city, and cut the jitter to `0.01°` (~1.1 km) — still enough to separate pins at city zoom, but each marker stays inside its real city.

| | Before | After |
|---|---:|---:|
| In-person listings on the globe | 17 | **39** |
| Unmapped | 23 | **1** |
| Max displacement from true city centre | ~9 km | **1.11 km** |
| Cambridge | 1 pin in Roslindale | HackMIT **0.00 km**, HackHarvard **1.11 km** |

The single remaining unmapped listing is **Arcangel**, whose location is literally `TBA` — correctly left off the map rather than guessed.

Also fixed one un-geocodable entry: **Agentic AI Build Week** stored the venue string `"Galaxy Innovation Park"` as its location; it's in **Ho Chi Minh City** (per the 2026-07-11 verification pass), so it now maps.

## 2. Clicking a dot popped the detail card

The marker click handler called **both** `flyTo()` and `setSelected()`, so the detail card covered the very map you'd just zoomed into.

Clicking a marker now **only flies the camera in**. The hover popup still shows status · title · host · location, and the card remains reachable from the Deck / list — `<DetailModal />` stays mounted in `page-shell` + `home-client` (Deck and Tracker still open it).

## Verification
- [x] `tsc --noEmit` clean · `eslint` clean
- [x] `vitest run` — 51 passed
- [x] `python -m unittest discover` — 48 passed
- [x] `util.check_schema` — 59 listings valid; README regenerated
- [x] `/globe` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)