### PR TITLE
fix(globe): stop listings silently disappearing from the map (#111)

### DIFF
--- a/.github/scripts/check_geo_coverage.py
+++ b/.github/scripts/check_geo_coverage.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Report listings the globe cannot place (#111).
+
+The site refuses to render a listing without coordinates, so a hackathon in a
+city that `geocodes.json` doesn't know is live in the README and the deck while
+being absent from the globe.
+
+`web/lib/geo-coverage.test.ts` catches that on pull requests. It cannot catch it
+on the path that actually adds most listings: `auto_extract` and
+`contribution_approved` push straight to `main` with the default GITHUB_TOKEN,
+and GitHub does not start workflow runs for commits pushed with that token — so
+Web CI never sees them. This script is the same check, in the language those
+workflows already speak, so they can say something on the issue instead.
+
+It never fails the job. A missing city should not block a contribution: the
+listing still lands, the globe says how many hackathons it isn't showing, and
+this comment tells a maintainer which city to add.
+
+Usage:
+    python .github/scripts/check_geo_coverage.py
+
+Writes `missing` (a human-readable summary, empty when all is well) to
+$GITHUB_OUTPUT when running in Actions.
+"""
+
+import json
+import os
+import sys
+
+HERE = os.path.dirname(__file__)
+GEOCODES = os.path.join(HERE, "geocodes.json")
+LISTINGS = os.path.join(HERE, "listings.json")
+
+# Kept in lockstep with COUNTRY_SUFFIXES in web/lib/geo.ts. test_scripts.py
+# asserts the two agree on the listings we actually have.
+COUNTRY_SUFFIXES = {"usa", "u.s.a.", "us", "u.s.", "united states", "canada"}
+
+
+def normalize_location(location):
+    """The Python twin of normalizeLocation() in web/lib/geo.ts."""
+    parts = [p.strip() for p in " ".join(location.lower().split()).split(",")]
+    parts = [p for p in parts if p]
+    while len(parts) > 1 and parts[-1] in COUNTRY_SUFFIXES:
+        parts.pop()
+    return ", ".join(parts)
+
+
+def load_geocodes():
+    with open(GEOCODES, encoding="utf-8") as f:
+        data = json.load(f)
+    coords = data["coordinates"]
+    # The bare-city fallback from geo.ts: a city name resolves when exactly one
+    # city in the table carries it.
+    cities = {}
+    for key in coords:
+        city = key.split(",")[0].strip()
+        cities.setdefault(city, []).append(key)
+    unique = {c: keys[0] for c, keys in cities.items() if len(keys) == 1}
+    return coords, unique, {u.lower() for u in data["unmappable"]}
+
+
+def unplaceable(listings, coords, cities, unmappable):
+    """Visible, non-virtual listings the globe has no coordinates for."""
+    out = []
+    for r in listings:
+        if r.get("is_visible") is False or r.get("format") == "Virtual":
+            continue
+        raw = (r.get("locations") or [""])[0].strip() or "TBA"
+        key = normalize_location(raw)
+        if key in coords or key in cities or key in unmappable:
+            continue
+        out.append((raw, r.get("title", "?")))
+    return out
+
+
+def main():
+    coords, cities, unmappable = load_geocodes()
+    with open(LISTINGS, encoding="utf-8") as f:
+        listings = json.load(f)
+
+    missing = unplaceable(listings, coords, cities, unmappable)
+
+    if missing:
+        lines = [
+            f"{len(missing)} listing(s) have no coordinates and will not appear "
+            f"on the globe:",
+        ]
+        for location, title in missing:
+            lines.append(f"  - {location}  ({title})")
+        lines.append("")
+        lines.append(
+            "Add the location to `coordinates` in .github/scripts/geocodes.json "
+            "(or to `unmappable` if it genuinely has no place on a map)."
+        )
+        summary = "\n".join(lines)
+        print(summary)
+    else:
+        summary = ""
+        print("All visible non-virtual listings can be placed on the globe.")
+
+    out_path = os.environ.get("GITHUB_OUTPUT")
+    if out_path:
+        with open(out_path, "a", encoding="utf-8") as f:
+            f.write("missing<<EOF\n")
+            f.write(summary + "\n")
+            f.write("EOF\n")
+
+    # Deliberately always 0: a city we cannot place must not block a listing.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/geocodes.json
+++ b/.github/scripts/geocodes.json
@@ -1,0 +1,140 @@
+{
+  "$comment": "Single source of truth for globe coordinates. Read by web/lib/geo.ts AND .github/scripts/check_geo_coverage.py. Keys are normalized: lowercase, no trailing country.",
+  "coordinates": {
+    "amherst, ma": [
+      42.3732,
+      -72.5199
+    ],
+    "ann arbor, mi": [
+      42.2808,
+      -83.743
+    ],
+    "atlanta, ga": [
+      33.749,
+      -84.388
+    ],
+    "austin, tx": [
+      30.2672,
+      -97.7431
+    ],
+    "berkeley / san francisco, ca": [
+      37.8715,
+      -122.273
+    ],
+    "blacksburg, va": [
+      37.2296,
+      -80.4139
+    ],
+    "boston, ma": [
+      42.3601,
+      -71.0589
+    ],
+    "cambridge, ma": [
+      42.3736,
+      -71.1097
+    ],
+    "chapel hill, nc": [
+      35.9132,
+      -79.0558
+    ],
+    "college park, md": [
+      38.9897,
+      -76.9378
+    ],
+    "dearborn, mi": [
+      42.3223,
+      -83.1763
+    ],
+    "greensboro, nc": [
+      36.0726,
+      -79.792
+    ],
+    "hamilton, on": [
+      43.2557,
+      -79.8711
+    ],
+    "ho chi minh city, vietnam": [
+      10.7769,
+      106.7009
+    ],
+    "houston, tx": [
+      29.7604,
+      -95.3698
+    ],
+    "ithaca, ny": [
+      42.444,
+      -76.5019
+    ],
+    "kolkata, india": [
+      22.5726,
+      88.3639
+    ],
+    "los angeles, ca": [
+      34.0522,
+      -118.2437
+    ],
+    "miami, fl": [
+      25.7617,
+      -80.1918
+    ],
+    "new york, ny": [
+      40.7128,
+      -74.006
+    ],
+    "newark, nj": [
+      40.7357,
+      -74.1724
+    ],
+    "orlando, fl": [
+      28.5384,
+      -81.3789
+    ],
+    "ottawa, on": [
+      45.4215,
+      -75.6972
+    ],
+    "philadelphia, pa": [
+      39.9526,
+      -75.1652
+    ],
+    "pittsburgh, pa": [
+      40.4406,
+      -79.9959
+    ],
+    "providence, ri": [
+      41.824,
+      -71.4128
+    ],
+    "san francisco, ca": [
+      37.7749,
+      -122.4194
+    ],
+    "santa clara, ca": [
+      37.3541,
+      -121.9552
+    ],
+    "seattle, wa": [
+      47.6062,
+      -122.3321
+    ],
+    "stony brook, ny": [
+      40.9257,
+      -73.1409
+    ],
+    "toronto, on": [
+      43.6532,
+      -79.3832
+    ],
+    "troy, ny": [
+      42.7284,
+      -73.6918
+    ],
+    "vancouver, bc": [
+      49.2827,
+      -123.1207
+    ]
+  },
+  "unmappable": [
+    "tba"
+  ]
+}

--- a/.github/scripts/test_geo_coverage.py
+++ b/.github/scripts/test_geo_coverage.py
@@ -1,0 +1,105 @@
+"""Tests for check_geo_coverage.py, the globe's guard on the automation path.
+
+The interesting risk here is drift: `check_geo_coverage.normalize_location` is a
+Python twin of `normalizeLocation` in web/lib/geo.ts, and two implementations of
+one rule will wander apart unless something holds them together. So the country
+list is read out of the TypeScript and compared, rather than trusted.
+"""
+
+import json
+import os
+import re
+import unittest
+
+import check_geo_coverage as cgc
+
+GEO_TS = os.path.join(
+    os.path.dirname(__file__), "..", "..", "web", "lib", "geo.ts"
+)
+
+
+class Normalization(unittest.TestCase):
+    def test_matches_the_typescript_rules(self):
+        self.assertEqual(cgc.normalize_location("  Boston, MA  "), "boston, ma")
+        self.assertEqual(cgc.normalize_location("New  York ,NY"), "new york, ny")
+        self.assertEqual(
+            cgc.normalize_location("Toronto, ON, Canada"),
+            cgc.normalize_location("Toronto, ON"),
+        )
+        # A bare country survives rather than normalizing to nothing.
+        self.assertEqual(cgc.normalize_location("Canada"), "canada")
+
+    def test_country_list_has_not_drifted_from_geo_ts(self):
+        """The two normalizers must strip the same countries.
+
+        If someone teaches geo.ts about a new country suffix and not this file,
+        the site would place a listing that the automation reports as missing -
+        an issue comment nagging a maintainer about a city already on the map.
+        """
+        with open(GEO_TS, encoding="utf-8") as f:
+            src = f.read()
+        block = re.search(
+            r"const COUNTRY_SUFFIXES = \[(.*?)\];", src, re.S
+        )
+        self.assertIsNotNone(block, "COUNTRY_SUFFIXES not found in web/lib/geo.ts")
+        in_ts = set(re.findall(r'"([^"]+)"', block.group(1)))
+        self.assertEqual(
+            in_ts,
+            cgc.COUNTRY_SUFFIXES,
+            "COUNTRY_SUFFIXES in web/lib/geo.ts and check_geo_coverage.py have "
+            "drifted apart - the site and the automation would disagree about "
+            "which listings are on the globe",
+        )
+
+
+class Coverage(unittest.TestCase):
+    def setUp(self):
+        self.coords, self.cities, self.unmappable = cgc.load_geocodes()
+
+    def test_the_real_listings_are_all_placeable(self):
+        with open(cgc.LISTINGS, encoding="utf-8") as f:
+            listings = json.load(f)
+        missing = cgc.unplaceable(
+            listings, self.coords, self.cities, self.unmappable
+        )
+        self.assertEqual(
+            [],
+            missing,
+            "listings.json has locations the globe cannot place: "
+            + ", ".join(loc for loc, _ in missing),
+        )
+
+    def test_an_unknown_city_is_reported(self):
+        listings = [
+            {"title": "Ghost Hack", "locations": ["Atlantis, XX"], "format": "In-Person"}
+        ]
+        missing = cgc.unplaceable(
+            listings, self.coords, self.cities, self.unmappable
+        )
+        self.assertEqual([("Atlantis, XX", "Ghost Hack")], missing)
+
+    def test_virtual_and_tba_are_not_reported(self):
+        listings = [
+            {"title": "Online", "locations": ["Atlantis, XX"], "format": "Virtual"},
+            {"title": "No venue", "locations": ["TBA"], "format": "In-Person"},
+            {"title": "Blank", "locations": [""], "format": "In-Person"},
+            {"title": "Hidden", "locations": ["Atlantis, XX"], "is_visible": False},
+        ]
+        self.assertEqual(
+            [],
+            cgc.unplaceable(listings, self.coords, self.cities, self.unmappable),
+        )
+
+    def test_the_bare_city_fallback_works_here_too(self):
+        # geo.ts resolves "Toronto, Canada" -> "toronto" -> the one Toronto.
+        listings = [
+            {"title": "T", "locations": ["Toronto, Canada"], "format": "In-Person"}
+        ]
+        self.assertEqual(
+            [],
+            cgc.unplaceable(listings, self.coords, self.cities, self.unmappable),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -46,6 +46,18 @@ jobs:
         run: |
           python .github/scripts/update_readmes.py
 
+      # A listing whose city has no coordinates is live in the README and the
+      # deck but absent from the globe (#111). geo-coverage.test.ts catches that
+      # on pull requests, but this job pushes straight to main with the default
+      # GITHUB_TOKEN, and GitHub starts no workflow runs for such pushes — so Web
+      # CI never sees these commits. Ask the same question here instead.
+      #
+      # Never blocks: the listing still lands, and this only names the city a
+      # maintainer needs to add.
+      - name: Check globe coverage
+        id: geo
+        run: python .github/scripts/check_geo_coverage.py
+
       - name: Commit and push changes
         if: steps.extract.outputs.is_duplicate != 'true' && steps.extract.outputs.commit_message != ''
         env:
@@ -115,6 +127,15 @@ jobs:
               body += `> Note: ${warning}\n\n`;
             }
 
+            // Named, not silent: this listing is live everywhere except the
+            // globe until someone adds the city (#111).
+            const missingGeo = (process.env.MISSING_GEO || '').trim();
+            if (missingGeo) {
+              body += `> **Not on the globe yet.**\n`;
+              body += `> \`\`\`\n${missingGeo.split('\n').map(l => `> ${l}`).join('\n')}\n> \`\`\`\n`;
+              body += `> The listing is live in the README and the deck. A maintainer can put it on the map by adding the location to \`.github/scripts/geocodes.json\`.\n\n`;
+            }
+
             body += `The opportunity has been added to the README. Thank you for contributing!`;
 
             await github.rest.issues.createComment({
@@ -126,6 +147,7 @@ jobs:
         env:
           EXTRACTED_DATA: ${{ steps.extract.outputs.extracted_data }}
           WARNING_MSG: ${{ steps.extract.outputs.warning }}
+          MISSING_GEO: ${{ steps.geo.outputs.missing }}
 
       - name: Close issue
         if: success() && steps.extract.outputs.is_duplicate != 'true'

--- a/.github/workflows/contribution_approved.yml
+++ b/.github/workflows/contribution_approved.yml
@@ -40,6 +40,13 @@ jobs:
         run: |
           python .github/scripts/update_readmes.py
 
+      # Same reason as auto_extract: this job pushes to main with the default
+      # GITHUB_TOKEN, so no workflow run is created and Web CI's coverage test
+      # never sees the new listing. Ask here instead. Never blocks the add (#111).
+      - name: Check globe coverage
+        id: geo
+        run: python .github/scripts/check_geo_coverage.py
+
       - name: Configure Git
         env:
           CONTRIBUTOR_NAME: ${{ steps.process.outputs.contributor_name }}
@@ -73,11 +80,22 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
+            let body = '✅ Your contribution has been added to the repository! Thank you for contributing!\n\nYour changes should now be visible in the README.';
+
+            // Named, not silent: live everywhere except the globe until someone
+            // adds the city (#111).
+            const missingGeo = (process.env.MISSING_GEO || '').trim();
+            if (missingGeo) {
+              body += `\n\n> **Not on the globe yet.**\n`;
+              body += `> \`\`\`\n${missingGeo.split('\n').map(l => `> ${l}`).join('\n')}\n> \`\`\`\n`;
+              body += `> A maintainer can put it on the map by adding the location to \`.github/scripts/geocodes.json\`.`;
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '✅ Your contribution has been added to the repository! Thank you for contributing!\n\nYour changes should now be visible in the README.'
+              body: body
             });
             await github.rest.issues.update({
               owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,17 @@ Keep the featured set small so it stays meaningful.
 4. **Automation adds** the hackathon to the table
 5. **Issue is closed** with a summary of what was added
 
+### Hackathons in a new city (maintainers)
+
+The globe places a listing using the coordinate table in
+[`web/lib/geo.ts`](web/lib/geo.ts). When an approved hackathon is the first one
+in a given city, Web CI fails with the location string that has no coordinates —
+add the city to `GEO` (or to `UNMAPPABLE` if the venue genuinely has no place on
+a map, like `TBA`).
+
+That check exists so a listing can't be live in the README and the deck while
+being silently absent from the globe.
+
 ---
 
 ## Guidelines

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,13 +126,13 @@ Keep the featured set small so it stays meaningful.
 ### Hackathons in a new city (maintainers)
 
 The globe places a listing using the coordinate table in
-[`web/lib/geo.ts`](web/lib/geo.ts). When an approved hackathon is the first one
-in a given city, Web CI fails with the location string that has no coordinates —
-add the city to `GEO` (or to `UNMAPPABLE` if the venue genuinely has no place on
-a map, like `TBA`).
+[`.github/scripts/geocodes.json`](.github/scripts/geocodes.json). When an
+approved hackathon is the first one in a given city, the automation adds the
+listing as normal and then **comments on the issue** saying it isn't on the globe
+yet. Add the city to `coordinates` (or to `unmappable` if the venue genuinely has
+no place on a map, like `TBA`) and it appears on the next deploy.
 
-That check exists so a listing can't be live in the README and the deck while
-being silently absent from the globe.
+A missing city never blocks a contribution — it just can't do so quietly.
 
 ---
 

--- a/web/README.md
+++ b/web/README.md
@@ -31,6 +31,25 @@ disk when pages are generated.
 README table between `<!-- HACKATHONS_TABLE_START -->` and
 `<!-- HACKATHONS_TABLE_END -->`.
 
+### Putting a listing on the globe
+
+The globe can only render a listing it has coordinates for, so `lib/geo.ts`
+maps each location string to a lat/lng. Lookups normalize first — case,
+whitespace, and a trailing country are all ignored, so `Toronto, ON` and
+`Toronto, ON, Canada` resolve to the same city rather than needing two entries.
+
+**If CI fails with "N listing(s) would silently disappear from the globe":** a
+listing arrived with a location that isn't in the table. The failure names it.
+Either
+
+- add it to `GEO` in `lib/geo.ts` (city coordinates, normalized key), or
+- add it to `UNMAPPABLE` if it genuinely has no place on a map (e.g. `TBA`).
+
+That guard is `lib/geo-coverage.test.ts`, which reads the real `listings.json`.
+It exists because a missing coordinate used to drop the listing from the map in
+silence — visible in the deck and the README, absent from the globe (#111).
+Virtual listings are excluded from the map on purpose and never fail the check.
+
 ### Render model
 
 Production pages are **statically generated at build time** (`next build`).

--- a/web/README.md
+++ b/web/README.md
@@ -33,22 +33,26 @@ README table between `<!-- HACKATHONS_TABLE_START -->` and
 
 ### Putting a listing on the globe
 
-The globe can only render a listing it has coordinates for, so `lib/geo.ts`
-maps each location string to a lat/lng. Lookups normalize first — case,
-whitespace, and a trailing country are all ignored, so `Toronto, ON` and
-`Toronto, ON, Canada` resolve to the same city rather than needing two entries.
+The globe can only render a listing it has coordinates for. The table lives in
+[`.github/scripts/geocodes.json`](../.github/scripts/geocodes.json) and is read
+by two things that must never disagree: `lib/geo.ts` (the site) and
+`.github/scripts/check_geo_coverage.py` (the listing automation).
 
-**If CI fails with "N listing(s) would silently disappear from the globe":** a
-listing arrived with a location that isn't in the table. The failure names it.
-Either
+Lookups normalize first — case, whitespace, and a trailing country are all
+ignored, so `Toronto, ON`, `Toronto, ON, Canada`, and `Toronto, Canada` all
+resolve to one Toronto rather than needing three entries.
 
-- add it to `GEO` in `lib/geo.ts` (city coordinates, normalized key), or
-- add it to `UNMAPPABLE` if it genuinely has no place on a map (e.g. `TBA`).
+**A listing in a city we can't place is reported, never dropped in silence** (#111):
 
-That guard is `lib/geo-coverage.test.ts`, which reads the real `listings.json`.
-It exists because a missing coordinate used to drop the listing from the map in
-silence — visible in the deck and the README, absent from the globe (#111).
-Virtual listings are excluded from the map on purpose and never fail the check.
+| Path | What happens |
+| ---- | ------------ |
+| Pull request | `lib/geo-coverage.test.ts` fails CI, naming the location |
+| Automated add (issue → `approved`) | The workflow comments on the issue naming the location. It does **not** block the add — those jobs push to `main` with the default `GITHUB_TOKEN`, so no Web CI run is created for them |
+| Either way | `loadHackathons()` warns, and the globe states how many listings it isn't showing |
+
+To fix a report, add the location to `coordinates` in `geocodes.json` — or to
+`unmappable` if it genuinely has no place on a map (e.g. `TBA`). Virtual
+listings are excluded from the map on purpose and never trip the check.
 
 ### Render model
 

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -25,6 +25,12 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
 
   const located = hackathons.filter((h) => h.lat !== null && h.lng !== null);
 
+  // Non-virtual listings we could not place. A virtual hackathon isn't missing
+  // from the map — it has nowhere to be — so it doesn't count here.
+  const unmapped = hackathons.filter(
+    (h) => h.format !== "Virtual" && (h.lat === null || h.lng === null),
+  ).length;
+
   useEffect(() => {
     if (!containerRef.current || !hasToken) return;
 
@@ -217,6 +223,15 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
           <h1 className="display mt-3 text-[clamp(1.8rem,4.5vw,3.6rem)] text-paper">
             The globe
           </h1>
+          {unmapped > 0 && (
+            // The globe can only show what it has coordinates for. Say so out
+            // loud rather than quietly rendering an incomplete map (#111).
+            <p className="mt-3 font-mono text-[11px] tracking-[0.12em] text-paper/50">
+              {unmapped} {unmapped === 1 ? "hackathon has" : "hackathons have"} no
+              announced venue yet and {unmapped === 1 ? "is" : "are"} not on the
+              map. Find {unmapped === 1 ? "it" : "them"} in the deck.
+            </p>
+          )}
         </div>
       </div>
     </section>

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -226,10 +226,15 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
           {unmapped > 0 && (
             // The globe can only show what it has coordinates for. Say so out
             // loud rather than quietly rendering an incomplete map (#111).
+            //
+            // Deliberately does not state WHY a listing is missing. The cause is
+            // either "no venue announced yet" (TBA) or "we failed to place a real
+            // city" — and this component cannot tell them apart. Naming the first
+            // cause would tell visitors a hackathon has no venue when it may
+            // simply be one we haven't geocoded.
             <p className="mt-3 font-mono text-[11px] tracking-[0.12em] text-paper/50">
-              {unmapped} {unmapped === 1 ? "hackathon has" : "hackathons have"} no
-              announced venue yet and {unmapped === 1 ? "is" : "are"} not on the
-              map. Find {unmapped === 1 ? "it" : "them"} in the deck.
+              {unmapped} {unmapped === 1 ? "hackathon is" : "hackathons are"} not on
+              the map yet. Find {unmapped === 1 ? "it" : "them"} in the deck.
             </p>
           )}
         </div>

--- a/web/lib/geo-coverage.test.ts
+++ b/web/lib/geo-coverage.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { coordsFor, isUnmappable } from "./geo";
+
+/**
+ * The guard for #111.
+ *
+ * The globe renders only listings that carry coordinates, so a location string
+ * the table doesn't know simply vanishes from the map — no error, no gap in the
+ * UI, nothing in the logs. That is a silent failure, and silent failures need a
+ * loud test.
+ *
+ * This reads the real listings.json (not a fixture): the moment a contribution
+ * introduces a city we can't place, CI fails here with the exact string to add
+ * to GEO. It needs no network and no API key, so it is deterministic.
+ */
+
+type RawListing = {
+  title: string;
+  locations?: string[];
+  format?: string;
+  is_visible?: boolean;
+};
+
+const LISTINGS_PATH = path.join(
+  process.cwd(),
+  "..",
+  ".github",
+  "scripts",
+  "listings.json",
+);
+
+function visibleNonVirtual(): RawListing[] {
+  const raw: RawListing[] = JSON.parse(fs.readFileSync(LISTINGS_PATH, "utf8"));
+  return raw.filter((r) => r.is_visible !== false && r.format !== "Virtual");
+}
+
+describe("globe coordinate coverage", () => {
+  it("places every visible non-virtual listing, or names it un-mappable", () => {
+    const unplaceable = visibleNonVirtual()
+      .map((r) => ({ title: r.title, location: r.locations?.[0] ?? "TBA" }))
+      .filter((r) => coordsFor(r.location) === null && !isUnmappable(r.location));
+
+    // Printed rather than asserted as a bare count so the failure message is
+    // the fix: it names the location strings to add to GEO in lib/geo.ts.
+    expect(
+      unplaceable,
+      `${unplaceable.length} listing(s) would silently disappear from the globe. ` +
+        `Add these locations to GEO in web/lib/geo.ts (or to UNMAPPABLE if they ` +
+        `genuinely have no place on a map):\n` +
+        unplaceable.map((r) => `  - ${r.location}  (${r.title})`).join("\n"),
+    ).toEqual([]);
+  });
+
+  it("keeps virtual listings off the map on purpose", () => {
+    const raw: RawListing[] = JSON.parse(fs.readFileSync(LISTINGS_PATH, "utf8"));
+    const virtual = raw.filter((r) => r.format === "Virtual");
+
+    // Not a coverage gap: a virtual hackathon has nowhere to be. This asserts
+    // the exclusion is deliberate, so a future "fix" for the test above can't
+    // start scattering online events across the globe.
+    expect(virtual.length).toBeGreaterThan(0);
+  });
+});

--- a/web/lib/geo-coverage.test.ts
+++ b/web/lib/geo-coverage.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { coordsFor, isUnmappable } from "./geo";
+import { loadHackathons } from "./listings";
 
 /**
  * The guard for #111.
@@ -53,13 +54,22 @@ describe("globe coordinate coverage", () => {
     ).toEqual([]);
   });
 
-  it("keeps virtual listings off the map on purpose", () => {
-    const raw: RawListing[] = JSON.parse(fs.readFileSync(LISTINGS_PATH, "utf8"));
-    const virtual = raw.filter((r) => r.format === "Virtual");
+  it("keeps virtual listings off the map even when their location is known", () => {
+    // Not a coverage gap: a virtual hackathon has nowhere to be. But "Virtual"
+    // and a real city are not mutually exclusive in the data — a listing can be
+    // Virtual and still carry "Boston, MA" — so the exclusion has to hold on
+    // *behaviour*, not on the current shape of listings.json.
+    //
+    // Asserting merely that some virtual listings exist would be a fact about
+    // the data, not about the code, and would start failing the day the repo
+    // happens to have none.
+    const virtual = loadHackathons().filter((h) => h.format === "Virtual");
 
-    // Not a coverage gap: a virtual hackathon has nowhere to be. This asserts
-    // the exclusion is deliberate, so a future "fix" for the test above can't
-    // start scattering online events across the globe.
-    expect(virtual.length).toBeGreaterThan(0);
+    for (const h of virtual) {
+      expect(
+        [h.lat, h.lng],
+        `${h.title} is Virtual but was given coordinates from "${h.location}"`,
+      ).toEqual([null, null]);
+    }
   });
 });

--- a/web/lib/geo.test.ts
+++ b/web/lib/geo.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeLocation } from "./geo";
+
+describe("normalizeLocation", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeLocation("  Boston, MA  ")).toBe("boston, ma");
+  });
+
+  it("collapses whitespace and spacing around the separator", () => {
+    expect(normalizeLocation("New  York ,NY")).toBe("new york, ny");
+  });
+
+  it("treats a trailing country as noise", () => {
+    // The bug in #111: these two spellings were separate table keys.
+    expect(normalizeLocation("Toronto, ON, Canada")).toBe(
+      normalizeLocation("Toronto, ON"),
+    );
+    expect(normalizeLocation("Austin, TX, USA")).toBe(
+      normalizeLocation("Austin, TX"),
+    );
+  });
+
+  it("strips only trailing countries, never the whole string", () => {
+    // A bare country is all we have — keep it rather than normalizing to "".
+    expect(normalizeLocation("Canada")).toBe("canada");
+  });
+
+  it("keeps a foreign city intact", () => {
+    expect(normalizeLocation("Ho Chi Minh City, Vietnam")).toBe(
+      "ho chi minh city, vietnam",
+    );
+  });
+
+  it("is idempotent", () => {
+    const once = normalizeLocation("Toronto, ON, Canada");
+    expect(normalizeLocation(once)).toBe(once);
+  });
+});

--- a/web/lib/geo.test.ts
+++ b/web/lib/geo.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   coordsFor,
+  coordsForListing,
   isUnmappable,
   knownLocations,
   normalizeLocation,
@@ -55,6 +56,21 @@ describe("coordsFor", () => {
 
   it("returns null for a location it has never seen", () => {
     expect(coordsFor("Atlantis, XX")).toBeNull();
+  });
+});
+
+describe("coordsForListing", () => {
+  it("places a non-virtual listing", () => {
+    expect(coordsForListing("Boston, MA", "In-Person")).toEqual([
+      42.3601, -71.0589,
+    ]);
+    expect(coordsForListing("Boston, MA", "Hybrid")).not.toBeNull();
+  });
+
+  it("keeps a virtual listing off the map even when its city is known", () => {
+    // The case listings.json does not currently contain, and exactly the one
+    // that would scatter online events across the globe if the rule were lost.
+    expect(coordsForListing("Boston, MA", "Virtual")).toBeNull();
   });
 });
 

--- a/web/lib/geo.test.ts
+++ b/web/lib/geo.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { normalizeLocation } from "./geo";
+import {
+  coordsFor,
+  isUnmappable,
+  knownLocations,
+  normalizeLocation,
+} from "./geo";
 
 describe("normalizeLocation", () => {
   it("lowercases and trims", () => {
@@ -34,5 +39,41 @@ describe("normalizeLocation", () => {
   it("is idempotent", () => {
     const once = normalizeLocation("Toronto, ON, Canada");
     expect(normalizeLocation(once)).toBe(once);
+  });
+});
+
+describe("coordsFor", () => {
+  it("resolves a plain location", () => {
+    expect(coordsFor("Boston, MA")).toEqual([42.3601, -71.0589]);
+  });
+
+  it("resolves the aliases that used to miss the table", () => {
+    // The regression from #111: both spellings must land on one Toronto.
+    expect(coordsFor("Toronto, ON, Canada")).toEqual(coordsFor("Toronto, ON"));
+    expect(coordsFor("  seattle , wa ")).toEqual(coordsFor("Seattle, WA"));
+  });
+
+  it("returns null for a location it has never seen", () => {
+    expect(coordsFor("Atlantis, XX")).toBeNull();
+  });
+});
+
+describe("isUnmappable", () => {
+  it("recognizes TBA regardless of spelling", () => {
+    expect(isUnmappable("TBA")).toBe(true);
+    expect(isUnmappable(" tba ")).toBe(true);
+  });
+
+  it("does not excuse a real city that is merely missing", () => {
+    expect(isUnmappable("Atlantis, XX")).toBe(false);
+  });
+});
+
+describe("the table itself", () => {
+  it("is stored in normalized form", () => {
+    // A key that isn't already normalized is unreachable through coordsFor.
+    for (const key of knownLocations()) {
+      expect(normalizeLocation(key)).toBe(key);
+    }
   });
 });

--- a/web/lib/geo.test.ts
+++ b/web/lib/geo.test.ts
@@ -57,6 +57,27 @@ describe("coordsFor", () => {
   it("returns null for a location it has never seen", () => {
     expect(coordsFor("Atlantis, XX")).toBeNull();
   });
+
+  it("does not hand back inherited object properties", () => {
+    // A plain-object lookup returns Object for "constructor" and
+    // Object.prototype for "__proto__" — both truthy, neither an array. That
+    // survives a `?? null` guard, makes lat/lng NaN, passes the globe's
+    // `!== null` filter, and mapbox then throws on setLngLat([NaN, NaN]),
+    // taking the entire map down. Location strings are LLM-extracted from
+    // user-filed issues, so these are reachable inputs.
+    expect(coordsFor("constructor")).toBeNull();
+    expect(coordsFor("__proto__")).toBeNull();
+    expect(coordsFor("toString")).toBeNull();
+    expect(coordsFor("hasOwnProperty")).toBeNull();
+  });
+
+  it("resolves a city named without its region", () => {
+    // "Toronto, Canada" normalizes to "toronto" once the country is stripped,
+    // which matches no key — the table stores "toronto, on". Resolve the bare
+    // city rather than adding a second Toronto row.
+    expect(coordsFor("Toronto, Canada")).toEqual(coordsFor("Toronto, ON"));
+    expect(coordsFor("Boston")).toEqual(coordsFor("Boston, MA"));
+  });
 });
 
 describe("coordsForListing", () => {

--- a/web/lib/geo.ts
+++ b/web/lib/geo.ts
@@ -109,6 +109,23 @@ export function coordsFor(location: string): [number, number] | null {
   return GEO[normalizeLocation(location)] ?? null;
 }
 
+/**
+ * Coordinates for a listing — the rule the globe actually runs on.
+ *
+ * Virtual is not merely "a listing that happens to have no city": a Virtual
+ * listing can still carry a real location string, and it must *still* stay off
+ * the map. Keeping that rule here, rather than inline at the call site, is what
+ * lets it be tested without depending on today's listings.json happening to
+ * contain such a listing.
+ */
+export function coordsForListing(
+  location: string,
+  format?: string,
+): [number, number] | null {
+  if (format === "Virtual") return null;
+  return coordsFor(location);
+}
+
 /** Every location string the globe knows how to place. Used by the tests. */
 export function knownLocations(): string[] {
   return Object.keys(GEO);

--- a/web/lib/geo.ts
+++ b/web/lib/geo.ts
@@ -104,9 +104,47 @@ export function isUnmappable(location: string): boolean {
   return UNMAPPABLE.has(normalizeLocation(location));
 }
 
+/**
+ * The table as a Map, plus a city-only index.
+ *
+ * A Map, not the object literal, because `GEO["constructor"]` walks the
+ * prototype chain and hands back `Object` — truthy, not an array. That sails
+ * through a `?? null` check, `lat = geo[0] + 0` becomes NaN, `NaN !== null`
+ * passes the globe's filter, and mapbox throws on setLngLat([NaN, NaN]),
+ * taking the whole map down. Location strings are LLM-extracted from
+ * user-filed issues, so "constructor" is not a hypothetical input.
+ */
+const TABLE = new Map<string, [number, number]>(Object.entries(GEO));
+
+/**
+ * City name -> coordinates, for the cities whose name is unambiguous in TABLE.
+ *
+ * Stripping the country off "Toronto, Canada" leaves "toronto", which matches
+ * no key ("toronto, on" has the province). Rather than re-introducing the
+ * duplicate entries this module exists to delete, resolve a bare city name when
+ * exactly one city in the table carries it. Two cities sharing a name (a
+ * Cambridge, MA and a Cambridge, UK) make the name ambiguous, so it resolves to
+ * nothing and the coverage test speaks up — a loud miss beats a confident pin
+ * in the wrong country.
+ */
+const CITY_INDEX = (() => {
+  const byCity = new Map<string, [number, number][]>();
+  for (const [key, coords] of TABLE) {
+    const city = key.split(",")[0]?.trim() ?? "";
+    if (!city) continue;
+    byCity.set(city, [...(byCity.get(city) ?? []), coords]);
+  }
+  const unique = new Map<string, [number, number]>();
+  for (const [city, hits] of byCity) {
+    if (hits.length === 1 && hits[0]) unique.set(city, hits[0]);
+  }
+  return unique;
+})();
+
 /** Coordinates for a location, or null when the table has no entry. */
 export function coordsFor(location: string): [number, number] | null {
-  return GEO[normalizeLocation(location)] ?? null;
+  const key = normalizeLocation(location);
+  return TABLE.get(key) ?? CITY_INDEX.get(key) ?? null;
 }
 
 /**
@@ -128,5 +166,5 @@ export function coordsForListing(
 
 /** Every location string the globe knows how to place. Used by the tests. */
 export function knownLocations(): string[] {
-  return Object.keys(GEO);
+  return [...TABLE.keys()];
 }

--- a/web/lib/geo.ts
+++ b/web/lib/geo.ts
@@ -1,0 +1,49 @@
+/**
+ * Location -> coordinates for the globe.
+ *
+ * The globe can only render a listing it has coordinates for, so a location
+ * string that misses the table silently disappears from the map (#111). Two
+ * things keep that from happening quietly:
+ *
+ *  - Lookups normalize first, so "Toronto, ON" and "Toronto, ON, Canada" are
+ *    the same key rather than two entries that must both be remembered.
+ *  - Anything that still misses is a *reported* miss: loadHackathons warns,
+ *    the globe surfaces a count, and a coverage test fails CI. Only the
+ *    locations listed in UNMAPPABLE are allowed to have no coordinates.
+ */
+
+/** Country suffixes we drop: the city + region prefix already disambiguates. */
+const COUNTRY_SUFFIXES = [
+  "usa",
+  "u.s.a.",
+  "us",
+  "u.s.",
+  "united states",
+  "canada",
+];
+
+/**
+ * Fold a raw location string into a stable lookup key.
+ *
+ * Case, surrounding whitespace, doubled spaces, spacing around separators, and
+ * a trailing country all stop mattering — "  toronto ,ON , Canada " and
+ * "Toronto, ON" both become "toronto, on".
+ */
+export function normalizeLocation(location: string): string {
+  const parts = location
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  while (
+    parts.length > 1 &&
+    COUNTRY_SUFFIXES.includes(parts[parts.length - 1] ?? "")
+  ) {
+    parts.pop();
+  }
+
+  return parts.join(", ");
+}

--- a/web/lib/geo.ts
+++ b/web/lib/geo.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 /**
  * Location -> coordinates for the globe.
  *
@@ -8,9 +11,30 @@
  *  - Lookups normalize first, so "Toronto, ON" and "Toronto, ON, Canada" are
  *    the same key rather than two entries that must both be remembered.
  *  - Anything that still misses is a *reported* miss: loadHackathons warns,
- *    the globe surfaces a count, and a coverage test fails CI. Only the
- *    locations listed in UNMAPPABLE are allowed to have no coordinates.
+ *    the globe surfaces a count, a coverage test fails CI on pull requests, and
+ *    the listing automation comments on the issue. Only the locations named in
+ *    `unmappable` are allowed to have no coordinates.
+ *
+ * The table itself lives in .github/scripts/geocodes.json because the listing
+ * automation (Python) has to answer the same question this module does, and the
+ * two must not drift. Server-side only — like lib/listings.ts, this reads from
+ * disk at build/render time and must not be pulled into a client component.
  */
+
+const GEOCODES_PATH = path.join(
+  process.cwd(),
+  "..",
+  ".github",
+  "scripts",
+  "geocodes.json",
+);
+
+type GeocodeFile = {
+  coordinates: Record<string, [number, number]>;
+  unmappable: string[];
+};
+
+const FILE: GeocodeFile = JSON.parse(fs.readFileSync(GEOCODES_PATH, "utf8"));
 
 /** Country suffixes we drop: the city + region prefix already disambiguates. */
 const COUNTRY_SUFFIXES = [
@@ -49,55 +73,17 @@ export function normalizeLocation(location: string): string {
 }
 
 /**
- * Coordinates for every location we place on the globe, keyed by the
- * normalized form. Add a city here the moment a listing introduces it — the
- * coverage test in geo-coverage.test.ts fails CI until you do.
+ * Coordinates for every location we place on the globe, keyed by the normalized
+ * form. Add a city here the moment a listing introduces one — the coverage test
+ * fails CI until you do.
  */
-const GEO: Record<string, [number, number]> = {
-  "amherst, ma": [42.3732, -72.5199],
-  "ann arbor, mi": [42.2808, -83.743],
-  "atlanta, ga": [33.749, -84.388],
-  "austin, tx": [30.2672, -97.7431],
-  "berkeley / san francisco, ca": [37.8715, -122.273],
-  "blacksburg, va": [37.2296, -80.4139],
-  "boston, ma": [42.3601, -71.0589],
-  "cambridge, ma": [42.3736, -71.1097],
-  "chapel hill, nc": [35.9132, -79.0558],
-  "college park, md": [38.9897, -76.9378],
-  "dearborn, mi": [42.3223, -83.1763],
-  "greensboro, nc": [36.0726, -79.792],
-  "hamilton, on": [43.2557, -79.8711],
-  "ho chi minh city, vietnam": [10.7769, 106.7009],
-  "houston, tx": [29.7604, -95.3698],
-  "ithaca, ny": [42.444, -76.5019],
-  "kolkata, india": [22.5726, 88.3639],
-  "los angeles, ca": [34.0522, -118.2437],
-  "miami, fl": [25.7617, -80.1918],
-  "new york, ny": [40.7128, -74.006],
-  "newark, nj": [40.7357, -74.1724],
-  "orlando, fl": [28.5384, -81.3789],
-  "ottawa, on": [45.4215, -75.6972],
-  "philadelphia, pa": [39.9526, -75.1652],
-  "pittsburgh, pa": [40.4406, -79.9959],
-  "providence, ri": [41.824, -71.4128],
-  "san francisco, ca": [37.7749, -122.4194],
-  "santa clara, ca": [37.3541, -121.9552],
-  "seattle, wa": [47.6062, -122.3321],
-  "stony brook, ny": [40.9257, -73.1409],
-  "toronto, on": [43.6532, -79.3832],
-  "troy, ny": [42.7284, -73.6918],
-  "vancouver, bc": [49.2827, -123.1207],
-};
+const GEO = FILE.coordinates;
 
 /**
- * Locations that legitimately have no point on a map. These are *allowed* to
- * be coordinate-less; everything else that misses GEO is a bug, not a shrug.
- *
- * Keep this list to locations that actually appear in listings.json. A venue
- * name nobody has submitted yet belongs here only once it shows up — until
- * then the coverage test is the thing that tells us it arrived.
+ * Locations that legitimately have no point on a map. These are *allowed* to be
+ * coordinate-less; everything else that misses the table is a bug, not a shrug.
  */
-const UNMAPPABLE = new Set(["tba"]);
+const UNMAPPABLE = new Set(FILE.unmappable);
 
 /** True when a location is knowingly un-mappable rather than merely missing. */
 export function isUnmappable(location: string): boolean {

--- a/web/lib/geo.ts
+++ b/web/lib/geo.ts
@@ -47,3 +47,69 @@ export function normalizeLocation(location: string): string {
 
   return parts.join(", ");
 }
+
+/**
+ * Coordinates for every location we place on the globe, keyed by the
+ * normalized form. Add a city here the moment a listing introduces it — the
+ * coverage test in geo-coverage.test.ts fails CI until you do.
+ */
+const GEO: Record<string, [number, number]> = {
+  "amherst, ma": [42.3732, -72.5199],
+  "ann arbor, mi": [42.2808, -83.743],
+  "atlanta, ga": [33.749, -84.388],
+  "austin, tx": [30.2672, -97.7431],
+  "berkeley / san francisco, ca": [37.8715, -122.273],
+  "blacksburg, va": [37.2296, -80.4139],
+  "boston, ma": [42.3601, -71.0589],
+  "cambridge, ma": [42.3736, -71.1097],
+  "chapel hill, nc": [35.9132, -79.0558],
+  "college park, md": [38.9897, -76.9378],
+  "dearborn, mi": [42.3223, -83.1763],
+  "greensboro, nc": [36.0726, -79.792],
+  "hamilton, on": [43.2557, -79.8711],
+  "ho chi minh city, vietnam": [10.7769, 106.7009],
+  "houston, tx": [29.7604, -95.3698],
+  "ithaca, ny": [42.444, -76.5019],
+  "kolkata, india": [22.5726, 88.3639],
+  "los angeles, ca": [34.0522, -118.2437],
+  "miami, fl": [25.7617, -80.1918],
+  "new york, ny": [40.7128, -74.006],
+  "newark, nj": [40.7357, -74.1724],
+  "orlando, fl": [28.5384, -81.3789],
+  "ottawa, on": [45.4215, -75.6972],
+  "philadelphia, pa": [39.9526, -75.1652],
+  "pittsburgh, pa": [40.4406, -79.9959],
+  "providence, ri": [41.824, -71.4128],
+  "san francisco, ca": [37.7749, -122.4194],
+  "santa clara, ca": [37.3541, -121.9552],
+  "seattle, wa": [47.6062, -122.3321],
+  "stony brook, ny": [40.9257, -73.1409],
+  "toronto, on": [43.6532, -79.3832],
+  "troy, ny": [42.7284, -73.6918],
+  "vancouver, bc": [49.2827, -123.1207],
+};
+
+/**
+ * Locations that legitimately have no point on a map. These are *allowed* to
+ * be coordinate-less; everything else that misses GEO is a bug, not a shrug.
+ *
+ * Keep this list to locations that actually appear in listings.json. A venue
+ * name nobody has submitted yet belongs here only once it shows up — until
+ * then the coverage test is the thing that tells us it arrived.
+ */
+const UNMAPPABLE = new Set(["tba"]);
+
+/** True when a location is knowingly un-mappable rather than merely missing. */
+export function isUnmappable(location: string): boolean {
+  return UNMAPPABLE.has(normalizeLocation(location));
+}
+
+/** Coordinates for a location, or null when the table has no entry. */
+export function coordsFor(location: string): [number, number] | null {
+  return GEO[normalizeLocation(location)] ?? null;
+}
+
+/** Every location string the globe knows how to place. Used by the tests. */
+export function knownLocations(): string[] {
+  return Object.keys(GEO);
+}

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -136,14 +136,18 @@ export function loadHackathons(): Hackathon[] {
   // Deterministic jitter so co-located markers don't stack exactly.
   const seen: Record<string, number> = {};
 
-  // Locations we could not place. Collected while mapping and reported once
+  // Locations we could not place, keyed by their normalized form so one city
+  // spelled two ways is reported once. Collected while mapping and reported
   // below — a listing dropping off the globe should never be silent (#111).
-  const unplaceable: string[] = [];
+  const unplaceable = new Map<string, string>();
 
   const hackathons = raw
     .filter((r) => r.is_visible !== false)
     .map((r) => {
-      const location = r.locations?.[0] ?? "TBA";
+      // `||`, not `??`: a listing with locations: [""] has a location that is
+      // present but empty, and an empty string is no more mappable than a
+      // missing one. `??` would let it through and report a blank name.
+      const location = r.locations?.[0]?.trim() || "TBA";
       let daysLeft: number | null = null;
       if (r.deadline) {
         daysLeft = daysUntilDeadline(r.deadline, today);
@@ -168,13 +172,11 @@ export function loadHackathons(): Hackathon[] {
         const angle = n * 2.4;
         lat = geo[0] + (n > 1 ? 0.01 * Math.sin(angle) : 0);
         lng = geo[1] + (n > 1 ? 0.01 * Math.cos(angle) : 0);
-      } else if (
-        !geo &&
-        r.format !== "Virtual" &&
-        !isUnmappable(location) &&
-        !unplaceable.includes(location)
-      ) {
-        unplaceable.push(location);
+      } else if (r.format !== "Virtual" && !isUnmappable(location)) {
+        // Dedupe on the normalized key, not the raw string: otherwise
+        // "Atlantis, XX" and "atlantis, xx" are reported as two missing places.
+        const key = normalizeLocation(location);
+        if (!unplaceable.has(key)) unplaceable.set(key, location);
       }
 
       const format =
@@ -210,10 +212,10 @@ export function loadHackathons(): Hackathon[] {
       return (a.daysLeft ?? 9999) - (b.daysLeft ?? 9999);
     });
 
-  if (unplaceable.length > 0) {
+  if (unplaceable.size > 0) {
     console.warn(
-      `[listings] ${unplaceable.length} location(s) have no coordinates and will ` +
-        `not appear on the globe: ${unplaceable.join(", ")}. ` +
+      `[listings] ${unplaceable.size} location(s) have no coordinates and will ` +
+        `not appear on the globe: ${[...unplaceable.values()].join(", ")}. ` +
         `Add them to GEO in lib/geo.ts.`,
     );
   }
@@ -237,6 +239,14 @@ export function siteStats(list: Hackathon[]): SiteStats {
     open: live.filter((h) => h.state === "open" || h.state === "closing_soon").length,
     closingSoon: list.filter((h) => h.state === "closing_soon").length,
     prizeDisplay,
-    cities: new Set(list.filter((h) => h.lat !== null).map((h) => h.location)).size,
+    // Count distinct *places*, not distinct strings. "Toronto, ON, Canada" and
+    // "Toronto, ON" are both in the data and both land on the same pin, so the
+    // raw-string version of this counted Toronto twice and the site advertised
+    // one more city than it shows.
+    cities: new Set(
+      list
+        .filter((h) => h.lat !== null)
+        .map((h) => normalizeLocation(h.location)),
+    ).size,
   };
 }

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -9,6 +9,7 @@ import path from "node:path";
  *  - days-until-deadline, cleaned titles, theme tags, prize parsing
  */
 
+import { coordsFor, isUnmappable, normalizeLocation } from "./geo";
 import type { HackState, Hackathon, SiteStats } from "./types-hq";
 
 export type { HackState, Hackathon, SiteStats };
@@ -34,45 +35,6 @@ type RawListing = {
   is_visible?: boolean;
   date_posted?: number;
   deadline?: string;
-};
-
-/** Static geocode table - one entry per unique location string in listings.json. */
-const GEO: Record<string, [number, number]> = {
-  "Amherst, MA": [42.3732, -72.5199],
-  "Ann Arbor, MI": [42.2808, -83.743],
-  "Atlanta, GA": [33.749, -84.388],
-  "Austin, TX": [30.2672, -97.7431],
-  "Berkeley / San Francisco, CA": [37.8715, -122.273],
-  "Blacksburg, VA": [37.2296, -80.4139],
-  "Boston, MA": [42.3601, -71.0589],
-  "Cambridge, MA": [42.3736, -71.1097],
-  "Chapel Hill, NC": [35.9132, -79.0558],
-  "College Park, MD": [38.9897, -76.9378],
-  "Dearborn, MI": [42.3223, -83.1763],
-  "Greensboro, NC": [36.0726, -79.792],
-  "Hamilton, ON": [43.2557, -79.8711],
-  "Ho Chi Minh City, Vietnam": [10.7769, 106.7009],
-  "Houston, TX": [29.7604, -95.3698],
-  "Ithaca, NY": [42.444, -76.5019],
-  "Kolkata, India": [22.5726, 88.3639],
-  "Los Angeles, CA": [34.0522, -118.2437],
-  "Miami, FL": [25.7617, -80.1918],
-  "New York, NY": [40.7128, -74.006],
-  "Newark, NJ": [40.7357, -74.1724],
-  "Orlando, FL": [28.5384, -81.3789],
-  "Ottawa, ON": [45.4215, -75.6972],
-  "Philadelphia, PA": [39.9526, -75.1652],
-  "Pittsburgh, PA": [40.4406, -79.9959],
-  "Providence, RI": [41.824, -71.4128],
-  "San Francisco, CA": [37.7749, -122.4194],
-  "Santa Clara, CA": [37.3541, -121.9552],
-  "Seattle, WA": [47.6062, -122.3321],
-  "Stony Brook, NY": [40.9257, -73.1409],
-  "Toronto, ON": [43.6532, -79.3832],
-  // Legacy key — older listings spell Toronto with the country suffix.
-  "Toronto, ON, Canada": [43.6532, -79.3832],
-  "Troy, NY": [42.7284, -73.6918],
-  "Vancouver, BC": [49.2827, -123.1207],
 };
 
 const THEME_RULES: [RegExp, string][] = [
@@ -186,9 +148,14 @@ export function loadHackathons(): Hackathon[] {
 
       let lat: number | null = null;
       let lng: number | null = null;
-      const geo = GEO[location];
+      const geo = coordsFor(location);
       if (geo && r.format !== "Virtual") {
-        const n = (seen[location] = (seen[location] ?? 0) + 1);
+        // Count co-located listings by the *normalized* key. Keying this on the
+        // raw string would restart the count for every spelling ("Toronto, ON"
+        // vs "Toronto, ON, Canada"), so two listings now sharing one set of
+        // coordinates would both take the n=1 zero-offset and stack exactly.
+        const key = normalizeLocation(location);
+        const n = (seen[key] = (seen[key] ?? 0) + 1);
         // Spiral-offset co-located markers just enough to stay individually
         // clickable when zoomed into a city. Keep this SMALL: 0.01° is ~1.1km,
         // which separates pins at city zoom while keeping every marker inside

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -136,7 +136,11 @@ export function loadHackathons(): Hackathon[] {
   // Deterministic jitter so co-located markers don't stack exactly.
   const seen: Record<string, number> = {};
 
-  return raw
+  // Locations we could not place. Collected while mapping and reported once
+  // below — a listing dropping off the globe should never be silent (#111).
+  const unplaceable: string[] = [];
+
+  const hackathons = raw
     .filter((r) => r.is_visible !== false)
     .map((r) => {
       const location = r.locations?.[0] ?? "TBA";
@@ -164,6 +168,13 @@ export function loadHackathons(): Hackathon[] {
         const angle = n * 2.4;
         lat = geo[0] + (n > 1 ? 0.01 * Math.sin(angle) : 0);
         lng = geo[1] + (n > 1 ? 0.01 * Math.cos(angle) : 0);
+      } else if (
+        !geo &&
+        r.format !== "Virtual" &&
+        !isUnmappable(location) &&
+        !unplaceable.includes(location)
+      ) {
+        unplaceable.push(location);
       }
 
       const format =
@@ -198,6 +209,16 @@ export function loadHackathons(): Hackathon[] {
       if (order[a.state] !== order[b.state]) return order[a.state] - order[b.state];
       return (a.daysLeft ?? 9999) - (b.daysLeft ?? 9999);
     });
+
+  if (unplaceable.length > 0) {
+    console.warn(
+      `[listings] ${unplaceable.length} location(s) have no coordinates and will ` +
+        `not appear on the globe: ${unplaceable.join(", ")}. ` +
+        `Add them to GEO in lib/geo.ts.`,
+    );
+  }
+
+  return hackathons;
 }
 
 export function siteStats(list: Hackathon[]): SiteStats {

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -9,7 +9,7 @@ import path from "node:path";
  *  - days-until-deadline, cleaned titles, theme tags, prize parsing
  */
 
-import { coordsFor, isUnmappable, normalizeLocation } from "./geo";
+import { coordsForListing, isUnmappable, normalizeLocation } from "./geo";
 import type { HackState, Hackathon, SiteStats } from "./types-hq";
 
 export type { HackState, Hackathon, SiteStats };
@@ -152,8 +152,8 @@ export function loadHackathons(): Hackathon[] {
 
       let lat: number | null = null;
       let lng: number | null = null;
-      const geo = coordsFor(location);
-      if (geo && r.format !== "Virtual") {
+      const geo = coordsForListing(location, r.format);
+      if (geo) {
         // Count co-located listings by the *normalized* key. Keying this on the
         // raw string would restart the count for every spelling ("Toronto, ON"
         // vs "Toronto, ON, Canada"), so two listings now sharing one set of

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -7,15 +7,24 @@ const REPO_SLUG =
   process.env.NEXT_PUBLIC_REPO_SLUG ?? "Hack-HQ/hackhq";
 
 const nextConfig: NextConfig = {
-  // The data pages read the repo-root README.md and .github/scripts/listings.json
-  // at request time (hourly ISR revalidation). Those files live outside web/, so
-  // Next's serverless file tracing must be told to bundle them or the runtime
-  // read fails with ENOENT. Set the tracing root to the repo root — there's no
-  // lockfile there, so it would otherwise default to web/ and exclude the parent
-  // files — and explicitly include the two data files for every route.
+  // The data pages read repo-root files at request time (hourly ISR
+  // revalidation). Those files live outside web/, so Next's serverless file
+  // tracing must be told to bundle them or the runtime read fails with ENOENT.
+  // Set the tracing root to the repo root — there's no lockfile there, so it
+  // would otherwise default to web/ and exclude the parent files — and
+  // explicitly include every data file we read, for every route.
+  //
+  // ANY new fs.readFileSync of a repo-root file must be added here. A build
+  // won't catch the omission: the file is on disk at build time, so it only
+  // fails later, on the first ISR regeneration in production.
   outputFileTracingRoot: path.join(process.cwd(), ".."),
   outputFileTracingIncludes: {
-    "/**": ["../README.md", "../.github/scripts/listings.json"],
+    "/**": [
+      "../README.md",
+      "../.github/scripts/listings.json",
+      // Read by lib/geo.ts to place listings on the globe.
+      "../.github/scripts/geocodes.json",
+    ],
   },
   logging: {
     browserToTerminal: false,


### PR DESCRIPTION
Closes #111

## The bug

The globe renders only listings that carry coordinates, and coordinates were assigned by exact string match against a static table. A location string that missed the table got `null` coordinates and was filtered out of the map — no error, no gap in the UI, nothing in the logs. The listing stayed visible in the README and the deck, so nothing looked wrong.

**The issue's numbers are stale.** The table has been expanded since #111 was filed, so today only 1 of 43 non-virtual listings lacks coordinates, and it's a genuine `TBA`. The counts are fixed; the structural defect that produced them is not, and that's what this PR is about. The hand-added `"Toronto, ON, Canada"` legacy alias sitting beside `"Toronto, ON"` is the tell — with exact matching, every spelling of a city is a separate row someone has to remember.

## The fix

**Normalize before lookup.** Case, whitespace, separator spacing, and a trailing country fold into one key, so `Toronto, ON`, `Toronto, ON, Canada`, and `Toronto, Canada` all resolve to one Toronto. The legacy alias row is deleted.

**Make a miss loud, on every path a listing can arrive by.** The failure mode is silence, so:

| Path | What now happens |
| ---- | ---------------- |
| Pull request | `geo-coverage.test.ts` reads the real `listings.json` and fails CI, naming the location to add |
| Automated add (issue → `approved`) | The workflow comments on the issue naming the location. It does **not** block the add |
| Either way | `loadHackathons()` warns, and the globe states how many listings it isn't showing |

**One source of truth.** The table moved to `.github/scripts/geocodes.json`, read by both the site (`lib/geo.ts`) and the automation (`check_geo_coverage.py`) — see below for why the automation needs it.

No runtime geocoding service, per the issue's guidance.

## What review caught (and I got wrong)

This PR was reviewed adversarially and the first version had real defects. Recording them because they shaped the design:

1. **The guard was aimed at the wrong door.** `auto_extract` and `contribution_approved` push to `main` with the default `GITHUB_TOKEN`, and GitHub **creates no workflow run for such pushes**. So Web CI — and the coverage test — never ran on the primary way listings are added. My original "honest caveat" said the failure was loud but late. It was neither: it did not run. Hence the Python checker and the shared JSON table.
2. **`GEO["constructor"]` returned `Object`.** An object-literal lookup walks the prototype chain: truthy, not an array, sails past `?? null`, `lat = geo[0] + 0` becomes `NaN`, `NaN !== null` passes the globe's filter, and mapbox throws on `setLngLat([NaN, NaN])` — taking the whole map down. Location strings are LLM-extracted from user-filed issues, so this is a reachable input. Lookups now go through a `Map`.
3. **`"Toronto, Canada"` resolved to nothing** — stripping the country leaves `"toronto"`, and the table stores `"toronto, on"`. A bare city name now resolves via a city index, but only when exactly one city in the table carries that name; two Cambridges stay a loud miss rather than a confident pin in the wrong country.
4. **`siteStats.cities` counted distinct strings**, so Toronto (present under two spellings, both now on one pin) made the site advertise one more city than it shows. I built the normalizer and didn't apply it.
5. **The globe notice lied.** It said "N hackathons have no announced venue yet" — but the count includes real cities we simply failed to place, which is exactly the state between an automated add and someone adding the city. It now claims only what it can know: the listing isn't on the map.
6. **The "virtual listings stay off the map" test couldn't fail.** It asserted the *data* contains virtual listings — deleting the exclusion rule would not have failed it. The rule now lives in `coordsForListing()` and is tested with a Virtual listing in a known city.

## Acceptance criteria

- [x] Every visible non-virtual listing has valid coordinates or an explicit surfaced error
- [x] Missing coordinates fail a deterministic CI validation (PRs) and are reported on the issue (automated adds)
- [x] Equivalent location strings normalize consistently
- [x] New listings cannot silently disappear from the globe
- [x] Virtual listings remain intentionally excluded from map markers

## One thing that is *not* a fix

`geocodes.json` is listed in `next.config.ts`'s `outputFileTracingIncludes`. I added that believing the new file would otherwise be missing from the serverless bundle and ENOENT on the first ISR regeneration — the same trap the config's comment describes for `listings.json`.

I checked before claiming it, and I was wrong: a clean build *without* the entry still traces `geocodes.json` into every route that reads it (`/`, `/globe`, `/my`, `/deck`), because Next resolves the read statically. The entry stays because it makes the dependency explicit and matches the existing convention, but it fixes nothing.

## Verification

- `npm run test` — 74 pass; `python -m unittest discover -s .github/scripts` — 65 pass
- Guards proven to fire, not just to pass: pointing a listing at `Atlantis, XX` fails the vitest guard; adding a listing in `Reykjavik, Iceland` makes the Python checker name it and exit 0 (does not block); deleting the Virtual rule fails its test.
- `npm run build`, `npx tsc --noEmit`, `npm run lint` clean. `/globe` renders and the notice reads "1 hackathon is not on the map yet."
