### PR TITLE
fix(nav): restore the primary sections on mobile (#113)

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -73,9 +73,12 @@ web/
 │   └── repo-assets/[...path]/route.ts # Serves files from ../assets
 ├── components/
 │   ├── hq/                            # Current HackHQ UI (globe, deck, nav, …)
+│   │   ├── nav.tsx                    # Nav pill; inline links at sm and up
+│   │   └── mobile-menu.tsx            # The same sections below 640px
 │   └── legacy/                        # README-driven browser, gallery, cards
 ├── lib/
 │   ├── listings.ts                    # Reads listings.json, enriches for frontend
+│   ├── nav.ts                         # Nav sections + active-route matching
 │   ├── parse-readme.ts                # Parses ../README.md (legacy /hackathons)
 │   ├── types-hq.ts                    # Hackathon types and display helpers
 │   └── types.ts                       # Legacy opportunity types

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { NAV_LINKS, isActiveRoute } from "@/lib/nav";
 import { REPO_URL } from "@/lib/types-hq";
 
@@ -19,10 +19,25 @@ import { REPO_URL } from "@/lib/types-hq";
 export function MobileMenu() {
   const pathname = usePathname() ?? "/";
   const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Escape closes and hands focus back to the button that opened the panel —
+  // without the restore, a keyboard user is dumped at the top of the document.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      setOpen(false);
+      buttonRef.current?.focus();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
 
   return (
     <div className="relative sm:hidden">
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -17,7 +17,7 @@ import { REPO_URL } from "@/lib/types-hq";
  * links take over.
  */
 export function MobileMenu() {
-  const pathname = usePathname() ?? "/";
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -46,16 +46,52 @@ export function MobileMenu() {
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [open]);
 
+  // The panel stops existing at `sm` and up, but `sm:hidden` is CSS — the state
+  // stays true. Rotating a phone to landscape therefore hid the panel with focus
+  // still inside it (focus fell to <body>), left this component's document-level
+  // key handler live on desktop, and popped the panel back open on rotating
+  // back. Close it when the breakpoint is crossed so the state matches reality.
+  useEffect(() => {
+    if (!open) return;
+    const desktop = window.matchMedia("(min-width: 640px)");
+    const onChange = () => {
+      if (desktop.matches) setOpen(false);
+    };
+    onChange();
+    desktop.addEventListener("change", onChange);
+    return () => desktop.removeEventListener("change", onChange);
+  }, [open]);
+
+  // Close when focus leaves the menu entirely.
+  //
+  // A disclosure needs no focus trap — but it does need focus *management*.
+  // Without this, a keyboard user could tab out of the open panel, activate a
+  // hackathon card, and end up with the detail modal stacked on top of a still
+  // open nav panel: two overlays at once, one Escape tearing down both.
+  const onBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    if (!rootRef.current?.contains(e.relatedTarget as Node | null)) {
+      setOpen(false);
+    }
+  };
 
   return (
-    <div ref={rootRef} className="relative sm:hidden">
+    // Not `relative`: with no positioned ancestor here, the panel below resolves
+    // against the fixed <nav>, whose height IS the pill's height.
+    <div
+      ref={rootRef}
+      onBlur={onBlur}
+      className="sm:hidden"
+    >
       <button
         ref={buttonRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-controls="hq-mobile-menu"
-        aria-label={open ? "Close menu" : "Open menu"}
+        // A stable name. Flipping it to "Close menu" while open would break
+        // voice control ("click Open menu" stops matching the thing it opened),
+        // and aria-expanded already carries the state.
+        aria-label="Menu"
         className="flex items-center rounded-2xl px-3.5 py-3.5 text-paper/80 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
       >
         <MenuIcon open={open} />
@@ -64,11 +100,15 @@ export function MobileMenu() {
       {open && (
         <div
           id="hq-mobile-menu"
-          // Pinned to the viewport rather than the button: anchored to the
-          // button, a 13rem panel hangs off the left edge of a 375px screen,
-          // because the pill is centred and the button sits near its right.
-          // inset-x-3 matches the nav's own px-3 gutter.
-          className="glass-dark fixed inset-x-3 top-[5.5rem] flex flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
+          // Anchored to the <nav>, not to a magic offset. `top-[5.5rem]` was a
+          // guess at where the pill ends, and it only held while the pill's
+          // height happened to match: the pill is sized by px-based text, so a
+          // browser minimum-font-size setting (Chrome and Firefox both go to
+          // 24px) grew the pill past the offset and the panel landed ON TOP of
+          // it — for exactly the users who set larger text. `top-full` tracks
+          // the real height instead. inset-x-3 matches the nav's px-3 gutter,
+          // which keeps the panel on screen at 375px.
+          className="glass-dark absolute inset-x-3 top-full mt-3 flex flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
         >
           {NAV_LINKS.map(([label, href]) => {
             const active = isActiveRoute(pathname, href);
@@ -76,10 +116,11 @@ export function MobileMenu() {
               <Link
                 key={label}
                 href={href}
-                // Navigating doesn't unmount the nav, so the panel has to be
-                // dismissed here or it stays open over the new page. Closing on
-                // the press (rather than reacting to the route) also covers a
-                // tap on the section you're already in, which changes nothing.
+                // Dismiss on the press. A route change does remount the nav (each
+                // page renders its own PageShell), but that lands after the
+                // navigation resolves — and it never happens at all for GITHUB
+                // below, which opens a new tab. Closing here covers both, plus a
+                // tap on the section you are already in.
                 onClick={() => setOpen(false)}
                 aria-current={active ? "page" : undefined}
                 className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset ${

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -56,7 +56,7 @@ export function MobileMenu() {
         aria-expanded={open}
         aria-controls="hq-mobile-menu"
         aria-label={open ? "Close menu" : "Open menu"}
-        className="flex items-center rounded-2xl px-3.5 py-3.5 text-paper/80 transition hover:bg-white/10 hover:text-paper"
+        className="flex items-center rounded-2xl px-3.5 py-3.5 text-paper/80 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 focus-visible:ring-offset-ink"
       >
         <MenuIcon open={open} />
       </button>
@@ -82,7 +82,7 @@ export function MobileMenu() {
                 // tap on the section you're already in, which changes nothing.
                 onClick={() => setOpen(false)}
                 aria-current={active ? "page" : undefined}
-                className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper ${
+                className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset ${
                   active ? "bg-white/10 text-paper" : "text-paper/80"
                 }`}
               >
@@ -96,7 +96,7 @@ export function MobileMenu() {
             target="_blank"
             rel="noreferrer"
             onClick={() => setOpen(false)}
-            className="rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper"
+            className="rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset"
           >
             ★ GITHUB
           </a>

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -46,6 +46,7 @@ export function MobileMenu() {
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [open]);
 
+
   return (
     <div ref={rootRef} className="relative sm:hidden">
       <button
@@ -71,6 +72,11 @@ export function MobileMenu() {
               <Link
                 key={label}
                 href={href}
+                // Navigating doesn't unmount the nav, so the panel has to be
+                // dismissed here or it stays open over the new page. Closing on
+                // the press (rather than reacting to the route) also covers a
+                // tap on the section you're already in, which changes nothing.
+                onClick={() => setOpen(false)}
                 aria-current={active ? "page" : undefined}
                 className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper ${
                   active ? "bg-white/10 text-paper" : "text-paper/80"
@@ -85,6 +91,7 @@ export function MobileMenu() {
             href={REPO_URL}
             target="_blank"
             rel="noreferrer"
+            onClick={() => setOpen(false)}
             className="rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper"
           >
             ★ GITHUB

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -20,6 +20,7 @@ export function MobileMenu() {
   const pathname = usePathname() ?? "/";
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
 
   // Escape closes and hands focus back to the button that opened the panel —
   // without the restore, a keyboard user is dumped at the top of the document.
@@ -34,8 +35,19 @@ export function MobileMenu() {
     return () => document.removeEventListener("keydown", onKey);
   }, [open]);
 
+  // A tap anywhere outside the menu dismisses it. Focus is not moved here: the
+  // pointer has already gone where the user wants it, unlike the Escape case.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
   return (
-    <div className="relative sm:hidden">
+    <div ref={rootRef} className="relative sm:hidden">
       <button
         ref={buttonRef}
         type="button"

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -64,7 +64,11 @@ export function MobileMenu() {
       {open && (
         <div
           id="hq-mobile-menu"
-          className="glass-dark absolute right-0 top-[calc(100%+0.6rem)] flex w-52 flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
+          // Pinned to the viewport rather than the button: anchored to the
+          // button, a 13rem panel hangs off the left edge of a 375px screen,
+          // because the pill is centred and the button sits near its right.
+          // inset-x-3 matches the nav's own px-3 gutter.
+          className="glass-dark fixed inset-x-3 top-[5.5rem] flex flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
         >
           {NAV_LINKS.map(([label, href]) => {
             const active = isActiveRoute(pathname, href);

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { NAV_LINKS, isActiveRoute } from "@/lib/nav";
+import { REPO_URL } from "@/lib/types-hq";
+
+/**
+ * The primary sections below 640px.
+ *
+ * The desktop links are `hidden sm:flex`, which left mobile visitors on /globe,
+ * /deck, or /my with no way to reach the other sections at all (#113). This is
+ * a disclosure button plus a panel carrying the same links.
+ *
+ * Rendered inside the nav pill and hidden at `sm` and up, where the inline
+ * links take over.
+ */
+export function MobileMenu() {
+  const pathname = usePathname() ?? "/";
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative sm:hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="hq-mobile-menu"
+        aria-label={open ? "Close menu" : "Open menu"}
+        className="flex items-center rounded-2xl px-3.5 py-3.5 text-paper/80 transition hover:bg-white/10 hover:text-paper"
+      >
+        <MenuIcon open={open} />
+      </button>
+
+      {open && (
+        <div
+          id="hq-mobile-menu"
+          className="glass-dark absolute right-0 top-[calc(100%+0.6rem)] flex w-52 flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
+        >
+          {NAV_LINKS.map(([label, href]) => {
+            const active = isActiveRoute(pathname, href);
+            return (
+              <Link
+                key={label}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper ${
+                  active ? "bg-white/10 text-paper" : "text-paper/80"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
+
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper"
+          >
+            ★ GITHUB
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Hamburger that becomes a close glyph while the panel is open. */
+function MenuIcon({ open }: { open: boolean }) {
+  return (
+    <span aria-hidden="true" className="flex h-4 w-4 flex-col justify-center gap-[3px]">
+      <span
+        className={`h-[1.5px] w-full bg-current transition ${
+          open ? "translate-y-[4.5px] rotate-45" : ""
+        }`}
+      />
+      <span className={`h-[1.5px] w-full bg-current transition ${open ? "opacity-0" : ""}`} />
+      <span
+        className={`h-[1.5px] w-full bg-current transition ${
+          open ? "-translate-y-[4.5px] -rotate-45" : ""
+        }`}
+      />
+    </span>
+  );
+}

--- a/web/components/hq/nav.tsx
+++ b/web/components/hq/nav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { NAV_LINKS, isActiveRoute } from "@/lib/nav";
+import { MobileMenu } from "./mobile-menu";
 import { REPO_URL } from "@/lib/types-hq";
 
 export function NavPill() {
@@ -46,6 +47,9 @@ export function NavPill() {
             ★ GITHUB
           </a>
         </div>
+
+        {/* Links - below sm, where the row above is hidden */}
+        <MobileMenu />
 
         {/* Submit CTA */}
         <Link

--- a/web/components/hq/nav.tsx
+++ b/web/components/hq/nav.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NAV_LINKS, isActiveRoute } from "@/lib/nav";
 import { REPO_URL } from "@/lib/types-hq";
 
-const LINKS: [string, string][] = [
-  ["GLOBE", "/globe"],
-  ["DECK", "/deck"],
-  ["MY HQ", "/my"],
-];
-
 export function NavPill() {
+  const pathname = usePathname() ?? "/";
+
   return (
     <nav className="fixed inset-x-0 top-4 z-50 flex justify-center px-3">
       <div className="glass-dark flex items-center gap-1 rounded-3xl p-2 pl-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.45)]">
@@ -22,17 +20,23 @@ export function NavPill() {
           <img src="/hackhq-monogram.svg" alt="HackHQ" className="h-4 w-auto" />
         </Link>
 
-        {/* Links */}
+        {/* Links - desktop (sm and up). Below that they live in the menu. */}
         <div className="hidden items-center sm:flex">
-          {LINKS.map(([label, href]) => (
-            <Link
-              key={label}
-              href={href}
-              className="rounded-full px-4 py-2.5 font-mono text-[11px] tracking-[0.18em] text-paper/80 transition hover:bg-white/10 hover:text-paper"
-            >
-              {label}
-            </Link>
-          ))}
+          {NAV_LINKS.map(([label, href]) => {
+            const active = isActiveRoute(pathname, href);
+            return (
+              <Link
+                key={label}
+                href={href}
+                aria-current={active ? "page" : undefined}
+                className={`rounded-full px-4 py-2.5 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper ${
+                  active ? "bg-white/10 text-paper" : "text-paper/80"
+                }`}
+              >
+                {label}
+              </Link>
+            );
+          })}
           <a
             href={REPO_URL}
             target="_blank"

--- a/web/components/hq/nav.tsx
+++ b/web/components/hq/nav.tsx
@@ -7,7 +7,7 @@ import { MobileMenu } from "./mobile-menu";
 import { REPO_URL } from "@/lib/types-hq";
 
 export function NavPill() {
-  const pathname = usePathname() ?? "/";
+  const pathname = usePathname();
 
   return (
     <nav className="fixed inset-x-0 top-4 z-50 flex justify-center px-3">

--- a/web/lib/nav.test.ts
+++ b/web/lib/nav.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { NAV_LINKS, isActiveRoute } from "./nav";
+
+describe("isActiveRoute", () => {
+  it("matches the section itself", () => {
+    expect(isActiveRoute("/globe", "/globe")).toBe(true);
+  });
+
+  it("matches a subpath of the section", () => {
+    expect(isActiveRoute("/deck/some-hackathon", "/deck")).toBe(true);
+  });
+
+  it("does not match a different section", () => {
+    expect(isActiveRoute("/deck", "/globe")).toBe(false);
+  });
+
+  it("does not match on a shared prefix", () => {
+    // "/my" must not light up on "/mystery" — the boundary is the slash.
+    expect(isActiveRoute("/mystery", "/my")).toBe(false);
+  });
+
+  it("matches home only exactly", () => {
+    expect(isActiveRoute("/", "/")).toBe(true);
+    expect(isActiveRoute("/globe", "/")).toBe(false);
+  });
+});
+
+describe("NAV_LINKS", () => {
+  it("carries the primary sections", () => {
+    expect(NAV_LINKS.map(([, href]) => href)).toEqual([
+      "/globe",
+      "/deck",
+      "/my",
+    ]);
+  });
+});

--- a/web/lib/nav.ts
+++ b/web/lib/nav.ts
@@ -1,0 +1,17 @@
+/** The primary sections, shared by the desktop links and the mobile menu. */
+export const NAV_LINKS: [string, string][] = [
+  ["GLOBE", "/globe"],
+  ["DECK", "/deck"],
+  ["MY HQ", "/my"],
+];
+
+/**
+ * Is `href` the section the visitor is currently in?
+ *
+ * A section owns its subpaths (/deck/anything is still the deck), but "/" is
+ * matched exactly — otherwise the home link would light up on every route.
+ */
+export function isActiveRoute(pathname: string, href: string): boolean {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(`${href}/`);
+}


### PR DESCRIPTION
Closes #113

## The bug

The nav links live in a `hidden items-center sm:flex` container, so below 640px GLOBE, DECK, MY HQ, and GITHUB are removed from the DOM entirely with nothing in their place. A mobile visitor landing on `/globe`, `/deck`, or `/my` from a link or bookmark could reach no other section without editing the URL by hand.

## The fix

A disclosure menu in the nav pill, shown only below `sm`, carrying the same four destinations. The sections come from one shared list (`lib/nav.ts`), so the desktop row and the mobile panel can't drift apart.

## What review caught (and I got wrong)

Reviewed adversarially; the first version had a real layout bug and two a11y gaps:

1. **The panel overlapped the pill for anyone using larger text.** `top-[5.5rem]` was a guess at where the pill ends — but the offset is `rem`-based while the pill is sized by px-based text, so a browser minimum-font-size setting (Chrome and Firefox both go to 24px) grows the pill and not the offset. Measured at 375px: the panel overlapped by 3px at 22px text, 6px at 24px. It broke for precisely the people who enlarge text. The panel is now a child of the fixed `<nav>` using `top-full`, so it tracks the pill's real height — a constant 12px gap at 16/20/22/24px.
2. **Nothing closed the panel when focus left it.** A keyboard user could tab out of the open panel, activate a hackathon card, and end up with the detail modal stacked on a still-open nav panel — two overlays at once, one Escape tearing down both. A disclosure needs no focus *trap*, but it does need focus *management*; it now closes on `focusout`.
3. **`open` survived the breakpoint.** `sm:hidden` is CSS, so rotating a phone to landscape hid the panel with focus still inside it (focus fell to `<body>`), left the document-level key handler live on desktop, and popped the panel back open on rotating back.
4. **The accessible name flipped with state** (`"Open menu"` → `"Close menu"`), which breaks voice-control retargeting. It's now a stable `"Menu"`; `aria-expanded` already carries the state.
5. A comment claiming "navigating doesn't unmount the nav" was **false** — every page renders its own `PageShell`. The `onClick` close stays (it's load-bearing for GITHUB, which opens a new tab and never navigates), but the reasoning is now correct.

## Acceptance criteria

- [x] All primary section links reachable below 640px — GLOBE, DECK, MY HQ, ★ GITHUB
- [x] Keyboard and screen-reader users can operate it
- [x] Desktop at `sm` and above unchanged — verified: the pill's box is byte-identical with and without the menu node
- [x] Active route visually indicated — `aria-current="page"` plus a filled pill, so the state isn't carried by colour alone

## Verification

Driven with Playwright at a real 375px viewport (the browser window wouldn't shrink, so I scripted it rather than eyeballing a resized tab):

```
desktop DECK link visible at 375px: false   <- the bug
opened via Enter key: links reachable: ["GLOBE","DECK","MY HQ","★ GITHUB"]
active route marked: GLOBE
Escape: panel closed + focus returned to the button
Tab out of the panel: closes (no modal stacking on an open menu)
Tab within the panel: stays open
Enter on the section you're already in: still closes
Tab Tab -> Enter: navigated to /deck, panel closed
outside tap closes: true
crossing to 1280px: closes, and does not pop back open on return
panel vs pill gap at min-font 16/20/22/24px: 12px, 12px, 12px, 12px (was -3px, -6px)
at 1280px: menu button hidden, desktop links visible
```

`npm run test` (**62** pass — my earlier claim of 72 was wrong), `npm run build`, `npx tsc --noEmit`, `npm run lint` all clean.

## Not included

No component test. The app has no DOM-testing setup (the suite is pure-logic vitest), and adding Playwright plus a browser download to CI is a bigger call than this issue warrants — happy to do it as a follow-up. The pure part (`isActiveRoute`, including the `/my` vs `/mystery` boundary) *is* unit-tested.