### PR TITLE
fix(ci): stop discarding the regenerated stats banner (#112)

### DIFF
--- a/.github/scripts/generate_banner.py
+++ b/.github/scripts/generate_banner.py
@@ -8,6 +8,14 @@ Stats shown:
   - total hackathons tracked
   - open / opens-soon / closing-soon counts
   - in-person / virtual / hybrid format mix (animated stacked bar)
+
+NOTE FOR WORKFLOW AUTHORS: the banner carries an "as of {today}" date, so this
+script rewrites the SVG on *every* run — including days when the README table
+is byte-for-byte unchanged. Any workflow that regenerates the banner must
+therefore gate its commit on what is staged (`git add ...` then
+`git diff --cached --quiet`), never on the README diff alone: a README-only gate
+throws the fresh banner away and lets the committed date go stale (#112).
+test_workflows.py enforces this.
 """
 
 import os

--- a/.github/scripts/test_workflows.py
+++ b/.github/scripts/test_workflows.py
@@ -1,0 +1,90 @@
+"""Regression coverage for how the banner-regenerating workflows gate commits.
+
+Issue #112: `generate_banner.py` stamps `assets/hackathons-banner.svg` with an
+"as of {today}" date on every run, but the commit step was gated on
+`git diff --quiet README.md`. On a day when no table row flips status the README
+is unchanged, so the freshly regenerated banner was staged, skipped, and thrown
+away — and the committed banner date went stale.
+
+The rule these tests pin down: **any workflow that stages the banner must gate on
+what is staged, not on the README alone.** That is `git add ...` followed by
+`git diff --cached --quiet`, which commits a banner-only change and still commits
+nothing when nothing changed.
+
+Deliberately text-based rather than YAML-parsed: the gating lives inside a shell
+`run:` block, so a YAML parse would hand us the same string to search anyway, and
+this keeps the scripts' dependency list untouched.
+"""
+
+import os
+import unittest
+
+WORKFLOW_DIR = os.path.join(os.path.dirname(__file__), "..", "workflows")
+
+BANNER = "assets/hackathons-banner.svg"
+STAGED_GATE = "git diff --cached --quiet"
+README_ONLY_GATE = "git diff --quiet README.md"
+
+# Every workflow that regenerates and stages the banner today. Listed explicitly
+# so that deleting or renaming one fails loudly here instead of quietly reducing
+# what this test covers.
+BANNER_WORKFLOWS = [
+    "auto_extract.yml",
+    "closing_soon.yml",
+    "contribution_approved.yml",
+    "update_readmes.yml",
+]
+
+
+def read(name):
+    with open(os.path.join(WORKFLOW_DIR, name), encoding="utf-8") as f:
+        return f.read()
+
+
+class BannerWorkflowsExist(unittest.TestCase):
+    def test_every_listed_workflow_is_present_and_stages_the_banner(self):
+        for name in BANNER_WORKFLOWS:
+            with self.subTest(workflow=name):
+                self.assertIn(
+                    BANNER,
+                    read(name),
+                    f"{name} no longer stages the banner - update BANNER_WORKFLOWS",
+                )
+
+    def test_no_banner_workflow_is_missing_from_the_list(self):
+        # Guards the inverse: a new workflow that stages the banner must be added
+        # to BANNER_WORKFLOWS so the gating rules below apply to it too.
+        staging = [
+            f
+            for f in sorted(os.listdir(WORKFLOW_DIR))
+            if f.endswith(".yml") and BANNER in read(f)
+        ]
+        self.assertEqual(sorted(BANNER_WORKFLOWS), staging)
+
+
+class CommitGating(unittest.TestCase):
+    def test_banner_workflows_gate_on_staged_changes(self):
+        for name in BANNER_WORKFLOWS:
+            with self.subTest(workflow=name):
+                self.assertIn(
+                    STAGED_GATE,
+                    read(name),
+                    f"{name} must gate its commit on `{STAGED_GATE}` so a "
+                    f"banner-only change is still committed (#112)",
+                )
+
+    def test_no_workflow_gates_on_the_readme_alone(self):
+        for name in BANNER_WORKFLOWS:
+            with self.subTest(workflow=name):
+                self.assertNotIn(
+                    README_ONLY_GATE,
+                    read(name),
+                    f"{name} gates on the README alone. The banner is rewritten "
+                    f"with today's date on every run, so on a quiet README day "
+                    f"that gate discards it and the 'as of' date goes stale "
+                    f"(#112). Gate on `{STAGED_GATE}` instead.",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_workflows.py
+++ b/.github/scripts/test_workflows.py
@@ -1,33 +1,43 @@
-"""Regression coverage for how the banner-regenerating workflows gate commits.
+"""Regression coverage for how the automation workflows gate their commits.
 
 Issue #112: `generate_banner.py` stamps `assets/hackathons-banner.svg` with an
-"as of {today}" date on every run, but the commit step was gated on
+"as of {today}" date on every run, but the commit was gated on
 `git diff --quiet README.md`. On a day when no table row flips status the README
 is unchanged, so the freshly regenerated banner was staged, skipped, and thrown
 away — and the committed banner date went stale.
 
-The rule these tests pin down: **any workflow that stages the banner must gate on
-what is staged, not on the README alone.** That is `git add ...` followed by
-`git diff --cached --quiet`, which commits a banner-only change and still commits
-nothing when nothing changed.
+The rule these tests pin down:
+
+    **A workflow must gate its commit on what it has staged.**
+    That is `git add <paths>` and then `git diff --cached --quiet`,
+    *in that order, in the same shell block.*
+
+The ordering is not a detail — it is the whole fix. `git diff --cached --quiet`
+against an empty index is always true, so a workflow that gates on `--cached`
+*before* it runs `git add` reports "nothing changed" on every run, forever, and
+silently stops committing anything at all. That is strictly worse than the bug
+this file exists to prevent, and pushing `git add` back down into the commit step
+is the most tempting future tidy-up. So it is tested.
 
 Deliberately text-based rather than YAML-parsed: the gating lives inside a shell
-`run:` block, so a YAML parse would hand us the same string to search anyway, and
-this keeps the scripts' dependency list untouched.
+`run:` block, so a YAML parse would hand back the same string to search anyway,
+and this keeps the scripts' dependency list untouched.
 """
 
 import os
+import re
 import unittest
 
 WORKFLOW_DIR = os.path.join(os.path.dirname(__file__), "..", "workflows")
 
 BANNER = "assets/hackathons-banner.svg"
 STAGED_GATE = "git diff --cached --quiet"
-README_ONLY_GATE = "git diff --quiet README.md"
+# The gate that caused #112: it asks about the working tree, and about a single
+# path, while the commit stages several files.
+PATH_GATE = re.compile(r"git diff --quiet (?!--cached)\S")
 
-# Every workflow that regenerates and stages the banner today. Listed explicitly
-# so that deleting or renaming one fails loudly here instead of quietly reducing
-# what this test covers.
+# Workflows that stage the banner. Listed explicitly so renaming or deleting one
+# fails loudly here rather than quietly shrinking what is covered.
 BANNER_WORKFLOWS = [
     "auto_extract.yml",
     "closing_soon.yml",
@@ -36,53 +46,109 @@ BANNER_WORKFLOWS = [
 ]
 
 
+def workflow_files():
+    """Every workflow file. GitHub accepts `.yaml` as readily as `.yml`."""
+    return sorted(
+        f
+        for f in os.listdir(WORKFLOW_DIR)
+        if f.endswith((".yml", ".yaml"))
+        and os.path.isfile(os.path.join(WORKFLOW_DIR, f))
+    )
+
+
 def read(name):
     with open(os.path.join(WORKFLOW_DIR, name), encoding="utf-8") as f:
         return f.read()
 
 
-class BannerWorkflowsExist(unittest.TestCase):
-    def test_every_listed_workflow_is_present_and_stages_the_banner(self):
-        for name in BANNER_WORKFLOWS:
-            with self.subTest(workflow=name):
-                self.assertIn(
-                    BANNER,
-                    read(name),
-                    f"{name} no longer stages the banner - update BANNER_WORKFLOWS",
-                )
+def run_blocks(text):
+    """The body of every `run:` block, as a list of strings.
 
-    def test_no_banner_workflow_is_missing_from_the_list(self):
-        # Guards the inverse: a new workflow that stages the banner must be added
-        # to BANNER_WORKFLOWS so the gating rules below apply to it too.
-        staging = [
-            f
-            for f in sorted(os.listdir(WORKFLOW_DIR))
-            if f.endswith(".yml") and BANNER in read(f)
-        ]
-        self.assertEqual(sorted(BANNER_WORKFLOWS), staging)
+    A block is every line indented further than its `run:` key. Two blocks are
+    two different shells — but they share one git index, which is exactly the
+    trap: staging in one block and gating in another still "works", right up
+    until someone moves the `git add`. The tests below therefore reason per
+    block, not per file.
+    """
+    blocks = []
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        m = re.match(r"^(\s*)run:\s*[|>]", line)
+        if not m:
+            continue
+        indent = len(m.group(1))
+        body = []
+        for follow in lines[i + 1 :]:
+            if follow.strip() and (len(follow) - len(follow.lstrip())) <= indent:
+                break
+            body.append(follow)
+        blocks.append("\n".join(body))
+    return blocks
+
+
+class Coverage(unittest.TestCase):
+    def test_the_banner_workflow_list_is_accurate(self):
+        staging = [f for f in workflow_files() if BANNER in read(f)]
+        self.assertEqual(
+            sorted(BANNER_WORKFLOWS),
+            staging,
+            "a workflow started or stopped staging the banner - update "
+            "BANNER_WORKFLOWS so the gating rules still apply to it",
+        )
 
 
 class CommitGating(unittest.TestCase):
-    def test_banner_workflows_gate_on_staged_changes(self):
+    def test_staging_happens_before_the_staged_gate(self):
+        for name in workflow_files():
+            for block in run_blocks(read(name)):
+                if STAGED_GATE not in block:
+                    continue
+                with self.subTest(workflow=name):
+                    add = block.find("git add")
+                    gate = block.find(STAGED_GATE)
+                    self.assertNotEqual(
+                        add,
+                        -1,
+                        f"{name} gates on `{STAGED_GATE}` but stages nothing in "
+                        f"that same block. An empty index always reports 'no "
+                        f"changes', so the workflow would stop committing "
+                        f"entirely (#112).",
+                    )
+                    self.assertLess(
+                        add,
+                        gate,
+                        f"{name} runs `{STAGED_GATE}` before `git add`. The gate "
+                        f"sees an empty index and reports 'no changes' on every "
+                        f"run (#112).",
+                    )
+
+    def test_no_workflow_gates_on_a_working_tree_path(self):
+        """Nobody may gate a commit on `git diff --quiet <path>`.
+
+        It asks about the working tree, and about one path, while the commit
+        stages several — which is what discarded the regenerated banner in #112.
+
+        Applied to *every* workflow, not only today's banner workflows: the rule
+        should already be in place on the day a script starts regenerating the
+        banner, rather than being one import away from a silent regression.
+        """
+        for name in workflow_files():
+            with self.subTest(workflow=name):
+                self.assertIsNone(
+                    PATH_GATE.search(read(name)),
+                    f"{name} gates a commit on a working-tree path. Stage the "
+                    f"files and gate on `{STAGED_GATE}`, so the gate always "
+                    f"covers everything the commit will include (#112).",
+                )
+
+    def test_banner_workflows_use_the_staged_gate(self):
         for name in BANNER_WORKFLOWS:
             with self.subTest(workflow=name):
                 self.assertIn(
                     STAGED_GATE,
                     read(name),
-                    f"{name} must gate its commit on `{STAGED_GATE}` so a "
-                    f"banner-only change is still committed (#112)",
-                )
-
-    def test_no_workflow_gates_on_the_readme_alone(self):
-        for name in BANNER_WORKFLOWS:
-            with self.subTest(workflow=name):
-                self.assertNotIn(
-                    README_ONLY_GATE,
-                    read(name),
-                    f"{name} gates on the README alone. The banner is rewritten "
-                    f"with today's date on every run, so on a quiet README day "
-                    f"that gate discards it and the 'as of' date goes stale "
-                    f"(#112). Gate on `{STAGED_GATE}` instead.",
+                    f"{name} regenerates the banner on every run, so it must "
+                    f"gate on the staged index or it will discard it (#112)",
                 )
 
 

--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -54,7 +54,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/scripts/listings.json README.md assets/hackathons-banner.svg
-          git commit -m "$COMMIT_MSG" || echo "No changes to commit"
+          # Same stage-then-`--cached` gate as the other banner workflows (#112).
+          # `git commit || echo` used to swallow *any* commit failure as "nothing
+          # to commit", so a real error looked like a quiet no-op run.
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "$COMMIT_MSG"
           # Rebase and retry push up to 3 times
           ok=false
           for i in 1 2 3; do

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -42,15 +42,30 @@ jobs:
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
+          # Which of the two actually changed? The banner carries today's date, so
+          # it changes on every run - meaning this job now commits daily. Without
+          # this, a day with no badge flips would land a commit reading "update
+          # closing-soon badges (0 changes)", which describes work it didn't do.
+          if git diff --cached --quiet -- README.md; then
+            echo "readme_changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "readme_changed=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit and push
         if: steps.check.outputs.has_changes == 'true'
         env:
           CHANGES: ${{ steps.run.outputs.changes }}
+          README_CHANGED: ${{ steps.check.outputs.readme_changed }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore: update closing-soon badges (${CHANGES:-0} changes)"
+          if [ "$README_CHANGED" = "true" ]; then
+            MSG="chore: update closing-soon badges (${CHANGES:-0} changes)"
+          else
+            MSG="chore: refresh stats banner"
+          fi
+          git commit -m "$MSG"
           ok=false
           for i in 1 2 3; do
             git fetch origin main || { sleep 2; continue; }

--- a/.github/workflows/closing_soon.yml
+++ b/.github/workflows/closing_soon.yml
@@ -30,7 +30,14 @@ jobs:
       - name: Check for changes
         id: check
         run: |
-          if git diff --quiet README.md; then
+          # Gate on everything we are about to commit, not just the README.
+          # closing_soon.py always regenerates the banner with today's date, so
+          # on a day when no row flips status the SVG is still rewritten. Gating
+          # on README alone threw that away and let the committed "as of" date
+          # go stale (#112). Staging first and asking `--cached` also means a run
+          # that changed nothing at all still commits nothing.
+          git add README.md assets/hackathons-banner.svg
+          if git diff --cached --quiet; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -43,7 +50,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md assets/hackathons-banner.svg
           git commit -m "chore: update closing-soon badges (${CHANGES:-0} changes)"
           ok=false
           for i in 1 2 3; do

--- a/.github/workflows/gallery.yml
+++ b/.github/workflows/gallery.yml
@@ -33,7 +33,14 @@ jobs:
       - name: Check for changes
         id: check
         run: |
-          if git diff --quiet README.md; then
+          # Gate on the staged set, like every other committing workflow (#112).
+          # generate_gallery.py does not touch the banner today, so a README-only
+          # gate happens to be correct here - but update_readmes.py already calls
+          # both generators, so that is one import away from silently discarding
+          # a regenerated banner. Gate on what is staged and the question never
+          # comes up again.
+          git add README.md
+          if git diff --cached --quiet; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -44,7 +51,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
           git commit -m "chore: rebuild photo gallery"
           ok=false
           for i in 1 2 3; do

--- a/.github/workflows/update_readmes.yml
+++ b/.github/workflows/update_readmes.yml
@@ -37,7 +37,13 @@ jobs:
       - name: Check for changes
         id: check
         run: |
-          if git diff --quiet README.md; then
+          # Gate on everything we are about to commit, not just the README.
+          # update_readmes.py always regenerates the banner with today's date, so
+          # gating on the README alone discarded a banner-only change and let the
+          # committed "as of" date go stale (#112). Staging first and asking
+          # `--cached` also means a run that changed nothing commits nothing.
+          git add README.md assets/hackathons-banner.svg
+          if git diff --cached --quiet; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -50,7 +56,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md assets/hackathons-banner.svg
           git commit -m "${COMMIT_MSG:-chore: update README}"
           ok=false
           for i in 1 2 3; do

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -6,12 +6,18 @@ on:
     paths:
       - 'web/**'
       - '.github/scripts/**'
-      - '.github/workflows/web-ci.yml'
+      # The scripts job runs test_workflows.py, which asserts how the workflows
+      # gate their commits (#112). Without this path it would not run on the very
+      # PRs that change those workflows - exactly when it needs to.
+      - '.github/workflows/**'
   pull_request:
     paths:
       - 'web/**'
       - '.github/scripts/**'
-      - '.github/workflows/web-ci.yml'
+      # The scripts job runs test_workflows.py, which asserts how the workflows
+      # gate their commits (#112). Without this path it would not run on the very
+      # PRs that change those workflows - exactly when it needs to.
+      - '.github/workflows/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #112

## The bug, reproduced

`generate_banner.py` stamps the SVG with an "as of {today}" date, so it rewrites `assets/hackathons-banner.svg` on **every** run — including days when no table row flips status and the README comes out byte-for-byte identical. But `closing_soon.yml` and `update_readmes.yml` gated their commit on `git diff --quiet README.md` while still staging the banner. On a quiet README day the gate says "nothing changed", the commit is skipped, and the fresh banner is thrown away.

Reproduced against the current tree by asking the generator what tomorrow's run would produce:

```
committed banner says : July 13, 2026
tomorrow's run writes : July 14, 2026
banner SVG changes    : True
README changed        : False
=> has_changes=false => commit SKIPPED => the regenerated banner is discarded.
```

## The fix

Gate on **what is staged**. `contribution_approved.yml` already did this, so this standardizes the others on a pattern that was already in the repo:

```yaml
git add README.md assets/hackathons-banner.svg
if git diff --cached --quiet; then ...
```

A banner-only change now commits; a run where nothing changed still commits nothing.

`auto_extract.yml` never had the stale-banner bug, but used `git commit || echo "No changes to commit"`, which reports *any* commit failure as an empty run. It now uses the same explicit gate.

## What review caught (and I got wrong)

The regression test — the artifact this PR leans on hardest — **did not guard the thing it claimed to**:

1. **It never asserted that `git add` runs *before* the gate**, which is the entire fix. Moving `git add` back into the commit step (the pre-PR layout, and the single most likely future "tidy-up") left `git diff --cached --quiet` gating an **empty index** — which is *always* "no changes". All four tests passed. That regression is strictly worse than #112: it silently stops committing README *and* banner, every run, forever. The guard now parses the `run:` blocks and asserts the ordering within one block.
2. **`.yaml` workflows were invisible.** A new `.yaml` workflow reintroducing the old gate passed cleanly — including the very test whose stated purpose was "coverage can't silently shrink".
3. **`gallery.yml` sat on a fault line.** It still used the README-only gate, and was excluded because the test defined "banner workflow" as "the file mentions the banner path". It's safe today only because `generate_gallery.py` doesn't import `generate_banner` — but `update_readmes.py` already imports both, so it was one import away from a silent regression. The rule now applies to every workflow, and `gallery.yml` uses the staged gate.
4. **The daily commit message lied.** Post-fix, the banner date changes every day, so this job now commits daily — and on a day with no badge flips it landed `chore: update closing-soon badges (0 changes)`, describing work it didn't do. It now says `chore: refresh stats banner` when only the date moved.

## Also fixed

Web CI (which runs the Python tests) only triggered on `web/**` and `.github/scripts/**` — so a PR editing `closing_soon.yml` alone would not have run the very test that checks it. The trigger now includes `.github/workflows/**`. (Side effect: the `web` job also runs on workflow-only PRs. GitHub has no per-job path filters; splitting `scripts` into its own workflow would fix that, and I'm happy to do it if the runner minutes matter.)

## Acceptance criteria

- [x] Banner regeneration on a quiet README day still commits when only the SVG changed
- [x] No duplicate empty commits when neither file changed
- [x] Behavior is consistent across all banner-regenerating workflows — all four, plus `gallery.yml`
- [x] Regression coverage documents the expected diff gating

## Verification

- `python -m unittest discover -s .github/scripts -p 'test_*.py'` — **63 pass**
- Guards proven to fire, not merely to pass. Each of these mutations now fails the suite: restoring the README-only gate; moving `git add` below the gate; adding a `.yaml` workflow with the old gate.