### PR TITLE
fix(submit): website submissions now reach the pipeline (#19)

### DIFF
--- a/web/lib/types-hq.test.ts
+++ b/web/lib/types-hq.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { submitIssueUrl } from "./types-hq";
+
+const TEMPLATE_PATH = path.join(
+  process.cwd(),
+  "..",
+  ".github",
+  "ISSUE_TEMPLATE",
+  "link_only.yaml",
+);
+
+describe("submitIssueUrl", () => {
+  it("targets the link_only issue form", () => {
+    // Not a free-text issue: the form is what applies the auto_extract label and
+    // produces the fields the pipeline parses. Without it, approving a website
+    // submission fails with "Missing required field: URL" (#19).
+    const u = new URL(submitIssueUrl("HackMIT", "https://hackmit.org"));
+    expect(u.pathname).toMatch(/\/issues\/new$/);
+    expect(u.searchParams.get("template")).toBe("link_only.yaml");
+  });
+
+  it("prefills the hackathon link and title", () => {
+    const u = new URL(submitIssueUrl("HackMIT", "https://hackmit.org"));
+    expect(u.searchParams.get("url")).toBe("https://hackmit.org");
+    expect(u.searchParams.get("title")).toBe("Add: HackMIT");
+  });
+
+  it("omits empty fields rather than prefilling blanks", () => {
+    const u = new URL(submitIssueUrl("", "  "));
+    expect(u.searchParams.has("url")).toBe(false);
+    expect(u.searchParams.has("title")).toBe(false);
+    expect(u.searchParams.get("template")).toBe("link_only.yaml");
+  });
+
+  it("escapes values instead of breaking the query string", () => {
+    const u = new URL(submitIssueUrl("A&B Hack", "https://x.dev/?a=1&b=2"));
+    expect(u.searchParams.get("title")).toBe("Add: A&B Hack");
+    expect(u.searchParams.get("url")).toBe("https://x.dev/?a=1&b=2");
+  });
+
+  it("uses a field id the template actually declares", () => {
+    // GitHub prefills a form field by its `id:`. If the template renames the
+    // input, the query param silently stops filling anything and the submitter
+    // lands on a blank form — no error, just a worse experience. Pin them.
+    const template = fs.readFileSync(TEMPLATE_PATH, "utf8");
+    const ids = [...template.matchAll(/^\s*id:\s*(\S+)/gm)].map((m) => m[1]);
+
+    const params = new URL(submitIssueUrl("X", "https://x.dev")).searchParams;
+    for (const key of params.keys()) {
+      if (key === "template" || key === "title") continue;
+      expect(ids, `link_only.yaml has no field id "${key}"`).toContain(key);
+    }
+  });
+});

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -60,15 +60,27 @@ export function deadlineDisplay(h: Hackathon): string | null {
   });
 }
 
-/** Prefilled GitHub issue for the Submit flow - keeps the engine, new surface. */
+/**
+ * Prefilled GitHub issue for the Submit flow - keeps the engine, new surface.
+ *
+ * Targets the `link_only` issue FORM, not a free-text issue. That is the whole
+ * point: the form applies the `auto_extract` + `community` labels and produces
+ * the structured fields the pipeline reads. A free-text issue has neither, so a
+ * maintainer approving one used to fall through to contribution_approved.py,
+ * which looks for a form field that isn't there and fails with "Missing
+ * required field: URL". Every submission made from the website died that way.
+ *
+ * `url` matches the `id:` of the input in .github/ISSUE_TEMPLATE/link_only.yaml
+ * — GitHub prefills a form field by its id. Renaming that id silently stops the
+ * prefill, so lib/types-hq.test.ts pins the two together.
+ */
 export function submitIssueUrl(name = "", url = ""): string {
-  const title = encodeURIComponent(
-    name ? `[Hackathon] ${name}` : "[Hackathon] Add a new event",
-  );
-  const body = encodeURIComponent(
-    `**Hackathon name:** ${name || "…"}\n**URL:** ${url || "…"}\n**Location (City, ST or Online):** …\n**Deadline:** …\n**Prize pool:** …\n\n_Submitted via hackhq.dev - the pipeline will extract the rest._`,
-  );
-  return `${REPO_URL}/issues/new?title=${title}&body=${body}`;
+  const params = new URLSearchParams({ template: "link_only.yaml" });
+  // The template's own title prefix is "Add: ", so match it rather than
+  // fighting it — a maintainer scanning the issue list sees one consistent shape.
+  if (name.trim()) params.set("title", `Add: ${name.trim()}`);
+  if (url.trim()) params.set("url", url.trim());
+  return `${REPO_URL}/issues/new?${params.toString()}`;
 }
 
 export { REPO_URL };


### PR DESCRIPTION
Closes #19

## This is not the cosmetic fix the issue described

#19 asked for the Submit button to use the `link_only.yaml` template instead of a hand-built `issues/new?title=&body=` URL. Looking at what the automation actually reads, that's not a polish item — **every hackathon submitted through the website was dead on arrival.**

The pipeline does not read free text:

- `contribution_approved.py` looks up issue-**form** fields by id (`link_to_hackathon_page`, …). A free-text body has none, so it raises `Missing required field: URL`.
- `auto_extract.yml` only runs on issues carrying the `auto_extract` label — which only the issue form applies.

So the button appeared to work, opened a nice prefilled issue, and handed the pipeline something it cannot digest. A maintainer approving one got an error comment.

## The fix

`submitIssueUrl()` now targets `?template=link_only.yaml` and prefills the form's own `url` field, matching the `Add: ` title prefix the template already uses.

Verified against the real GitHub form — the template loads, the title is prefilled `Add: HackMIT 2026`, and the "Link to Hackathon" input carries the URL. (I loaded the page only; nothing was submitted.)

The test pins the query param to a field id the template **actually declares**: GitHub prefills by `id:`, so renaming the input would silently stop the prefill and drop submitters onto a blank form — the same class of quiet failure this PR is fixing.

## ⚠️ This fix is necessary but NOT sufficient — please read

While verifying, I found the repo has **only one label: `community`**. `auto_extract`, `new_opportunity`, and `approved` do not exist.

GitHub silently drops template labels that don't exist. So an issue created from `link_only.yaml` gets `community` and nothing else — which means:

- `auto_extract.yml` requires `approved` **and** `auto_extract` → **can never fire**
- `contribution_approved.yml` requires `approved` → **can never fire**

The entire documented contribution flow in CONTRIBUTING ("paste a link → maintainer adds `approved` → AI extracts → automation adds it") is currently dormant, regardless of this PR. That would explain why recent hackathons have been landing via hand-written PRs.

**Creating those three labels is a repo-settings change, so I have not done it.** Say the word and I'll add `auto_extract`, `new_opportunity`, and `approved` — after that this PR's fix actually completes the loop.

## Verification

`npm run test` (85 pass, 5 new), `npm run build`, `npx tsc --noEmit`, `npm run lint` all clean.