### PR TITLE
feat(globe): marker details + live filters + virtual panel (#17, #18)

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -68,6 +68,17 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
+/* Same family as .glass-dark, but for a surface carrying real content over a
+   busy map (the globe's detail sheet). At 0.55 alpha the map and the page title
+   read straight through the text; this is opaque enough to be legible and still
+   feel like glass. */
+.glass-sheet {
+  background: rgba(12, 10, 8, 0.93);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 /* Mono kicker - the "built by devs" label */
 .kicker {
   font-family: var(--font-mono);

--- a/web/app/globe/page.tsx
+++ b/web/app/globe/page.tsx
@@ -1,6 +1,6 @@
 import { loadHackathons } from "@/lib/listings";
 import { PageShell } from "@/components/hq/page-shell";
-import { GlobeMap } from "@/components/hq/globe-map";
+import { GlobeClient } from "@/components/hq/globe-client";
 
 // ISR: keep deadline-derived status/countdowns fresh without a rebuild (#47).
 export const revalidate = 3600;
@@ -8,14 +8,14 @@ export const revalidate = 3600;
 export const metadata = {
   title: "The Globe · HackHQ",
   description:
-    "Every hackathon worth joining on one living 3D map. Spin it, tap a marker, fly in.",
+    "Every hackathon worth joining on one living 3D map. Search it, filter it, tap a marker, fly in.",
 };
 
 export default function GlobePage() {
   const hackathons = loadHackathons();
   return (
     <PageShell>
-      <GlobeMap hackathons={hackathons} />
+      <GlobeClient hackathons={hackathons} />
     </PageShell>
   );
 }

--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -4,10 +4,10 @@ import { useMemo, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import type { Hackathon, HackState } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
+import type { FormatFilter, StatusFilter } from "@/lib/filters";
+import { applyFilters } from "@/lib/filters";
 import { useSelection, useTracker } from "./store";
 
-type StatusFilter = "all" | HackState;
-type FormatFilter = "all" | "In-Person" | "Virtual";
 type View = "grid" | "list";
 
 export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
@@ -16,18 +16,12 @@ export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
   const [format, setFormat] = useState<FormatFilter>("all");
   const [view, setView] = useState<View>("grid");
 
-  const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    return hackathons.filter((h) => {
-      if (status !== "all" && h.state !== status) return false;
-      if (format !== "all" && h.format !== format) return false;
-      if (!needle) return true;
-      return [h.title, h.host, h.location, ...h.themes]
-        .join(" ")
-        .toLowerCase()
-        .includes(needle);
-    });
-  }, [hackathons, q, status, format]);
+  // Shared with the globe (lib/filters.ts) so the two surfaces cannot disagree
+  // about what a search or a filter means.
+  const filtered = useMemo(
+    () => applyFilters(hackathons, { q, status, format }),
+    [hackathons, q, status, format],
+  );
 
   return (
     <section id="deck" className="p-2 pt-0">

--- a/web/components/hq/globe-client.tsx
+++ b/web/components/hq/globe-client.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Hackathon } from "@/lib/types-hq";
+import { STATE_META } from "@/lib/types-hq";
+import type { FormatFilter, StatusFilter } from "@/lib/filters";
+import { applyFilters, isFiltering, splitByMappability } from "@/lib/filters";
+import { GlobeMap } from "./globe-map";
+import { GlobeSheet } from "./globe-sheet";
+
+/**
+ * The globe as a browsing surface (#18) as well as an exploring one.
+ *
+ * Owns the filter state and the selection, and hands the map only the listings
+ * it can actually pin. Selection is deliberately local rather than the shared
+ * `useSelection` store: that store drives the deck's centered modal, and the
+ * whole point of the globe's sheet is that it does NOT cover the map (#17).
+ */
+export function GlobeClient({ hackathons }: { hackathons: Hackathon[] }) {
+  const [q, setQ] = useState("");
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [format, setFormat] = useState<FormatFilter>("all");
+  const [selected, setSelected] = useState<Hackathon | null>(null);
+
+  const filters = { q, status, format };
+  const filtering = isFiltering(filters);
+
+  const { onMap, offMap } = useMemo(
+    () => splitByMappability(applyFilters(hackathons, { q, status, format })),
+    [hackathons, q, status, format],
+  );
+
+  const clearAll = () => {
+    setQ("");
+    setStatus("all");
+    setFormat("all");
+  };
+
+  // Drop a selection that the current filters have excluded — otherwise the
+  // sheet keeps describing a hackathon the page no longer shows.
+  //
+  // Checked against onMap AND offMap, not just onMap: an online hackathon is
+  // never on the map, and gating on onMap alone meant picking one from the
+  // off-map list selected it and then immediately discarded it, so the panel
+  // that exists to make virtual events reachable opened nothing at all.
+  const stillShown =
+    selected !== null &&
+    (onMap.some((h) => h.id === selected.id) ||
+      offMap.some((h) => h.id === selected.id));
+  const visibleSelection = stillShown ? selected : null;
+
+  return (
+    <section id="globe" className="p-2 pt-0">
+      <div className="shell bg-ink h-[min(86vh,1000px)] min-h-[560px]">
+        <GlobeMap
+          hackathons={onMap}
+          selected={visibleSelection}
+          onSelect={setSelected}
+        />
+
+        {/* Controls - float over the map, top-left, clear of the sheet */}
+        <div className="pointer-events-none absolute inset-x-0 top-0 z-10 p-4 sm:p-6">
+          <div className="glass-dark pointer-events-auto flex max-w-[min(100%,30rem)] flex-col gap-3 rounded-3xl p-3 sm:p-4">
+            <div className="flex items-center gap-2">
+              <input
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Search name, host, city, theme…"
+                aria-label="Search hackathons"
+                className="w-full rounded-full bg-ink-deep/60 px-4 py-2.5 font-mono text-[12px] text-paper outline-none transition placeholder:text-paper/30 focus:ring-2 focus:ring-coral"
+              />
+              {filtering && (
+                <button
+                  onClick={clearAll}
+                  className="shrink-0 rounded-full px-3 py-2 font-mono text-[10px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral"
+                >
+                  CLEAR
+                </button>
+              )}
+            </div>
+
+            <div className="flex flex-wrap gap-1.5">
+              <Pill active={status === "all"} onClick={() => setStatus("all")}>
+                ALL
+              </Pill>
+              {(["open", "closing_soon", "opens_soon"] as const).map((s) => (
+                <Pill
+                  key={s}
+                  active={status === s}
+                  onClick={() => setStatus(status === s ? "all" : s)}
+                  dot={STATE_META[s].color}
+                >
+                  {STATE_META[s].label}
+                </Pill>
+              ))}
+              {(["In-Person", "Virtual"] as const).map((f) => (
+                <Pill
+                  key={f}
+                  active={format === f}
+                  onClick={() => setFormat(format === f ? "all" : f)}
+                >
+                  {f.toUpperCase()}
+                </Pill>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {visibleSelection && (
+          <GlobeSheet hackathon={visibleSelection} onClose={() => setSelected(null)} />
+        )}
+
+        {/* Title + the listings the map can't show.
+            Hidden on mobile while the sheet is open — there the sheet rises from
+            the bottom and sits right on top of this, so the title bled through
+            the panel behind the hackathon's own details. */}
+        <div
+          className={`pointer-events-none absolute inset-x-0 bottom-0 p-6 sm:p-10 ${
+            visibleSelection ? "hidden sm:block" : ""
+          }`}
+        >
+          <div className="kicker text-coral">Pillar 01 · Explore</div>
+          <h1 className="display mt-3 text-[clamp(1.8rem,4.5vw,3.6rem)] text-paper">
+            The globe
+          </h1>
+          <p className="mt-3 font-mono text-[11px] tracking-[0.12em] text-paper/50">
+            {onMap.length} on the map
+            {filtering ? ` · ${hackathons.length - onMap.length - offMap.length} filtered out` : ""}
+          </p>
+
+          <OffMapPanel listings={offMap} onSelect={setSelected} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The listings the globe cannot pin: online events, and anything we failed to
+ * geocode. Without this they'd simply be absent — which is the #18 complaint
+ * ("online events have no location") and the #111 one (a listing that quietly
+ * vanishes) in the same place.
+ */
+function OffMapPanel({
+  listings,
+  onSelect,
+}: {
+  listings: Hackathon[];
+  onSelect: (h: Hackathon) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (listings.length === 0) return null;
+
+  const virtual = listings.filter((h) => h.format === "Virtual").length;
+
+  return (
+    <div className="pointer-events-auto mt-4 max-w-md">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="hq-offmap"
+        className="glass-dark rounded-full px-4 py-2.5 font-mono text-[11px] tracking-[0.15em] text-paper/80 transition hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral"
+      >
+        🌐 {listings.length} not on the map
+        {virtual > 0 ? ` · ${virtual} online` : ""} {open ? "▾" : "▸"}
+      </button>
+
+      {open && (
+        <ul
+          id="hq-offmap"
+          className="glass-dark rail-scroll mt-2 max-h-56 overflow-y-auto rounded-3xl p-2"
+        >
+          {listings.map((h) => (
+            <li key={h.id}>
+              <button
+                onClick={() => onSelect(h)}
+                className="w-full rounded-2xl px-3 py-2.5 text-left transition hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset"
+              >
+                <span
+                  className="font-mono text-[9px] tracking-[0.2em]"
+                  style={{ color: STATE_META[h.state].color }}
+                >
+                  ● {STATE_META[h.state].label}
+                </span>
+                <span className="mt-1 block text-sm leading-tight text-paper">
+                  {h.title}
+                </span>
+                <span className="text-xs text-paper/50">
+                  {h.host} · {h.format === "Virtual" ? "Online" : h.location}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function Pill({
+  active,
+  onClick,
+  dot,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  dot?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={active}
+      className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 font-mono text-[10px] tracking-[0.15em] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral ${
+        active
+          ? "bg-paper text-ink"
+          : "text-paper/60 hover:bg-white/10 hover:text-paper"
+      }`}
+    >
+      {dot && (
+        <span
+          className="h-1.5 w-1.5 rounded-full"
+          style={{ background: active ? "currentColor" : dot }}
+        />
+      )}
+      {children}
+    </button>
+  );
+}

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -17,26 +17,42 @@ const GLOBE_VIEW = {
 
 const SECONDS_PER_REVOLUTION = 110;
 
-export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
+type GlobeMapProps = {
+  /** Already filtered, and already known to have coordinates. */
+  hackathons: Hackathon[];
+  selected: Hackathon | null;
+  onSelect: (h: Hackathon | null) => void;
+};
+
+export function GlobeMap({ hackathons, selected, onSelect }: GlobeMapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
+  const [ready, setReady] = useState(false);
   const [zoomedIn, setZoomedIn] = useState(false);
   const hasToken = Boolean(mapboxgl.accessToken);
 
-  const located = hackathons.filter((h) => h.lat !== null && h.lng !== null);
+  // Auto-rotation is owned by the map effect but has to be switchable from the
+  // marker effect (a click stops the spin), and the two effects have separate
+  // closures — so it lives in refs rather than in either closure.
+  const spinRef = useRef(true);
+  const interactingRef = useRef(false);
+  // The latest onSelect, so the marker effect doesn't have to tear down and
+  // rebuild every marker just because the parent re-rendered a new callback.
+  // Assigned in an effect, not during render — the markers only read it from an
+  // event handler, which always runs after the effect has committed.
+  const onSelectRef = useRef(onSelect);
+  useEffect(() => {
+    onSelectRef.current = onSelect;
+  }, [onSelect]);
 
-  // Non-virtual listings we could not place. A virtual hackathon isn't missing
-  // from the map — it has nowhere to be — so it doesn't count here.
-  const unmapped = hackathons.filter(
-    (h) => h.format !== "Virtual" && (h.lat === null || h.lng === null),
-  ).length;
-
+  /* ---- The map itself: built once ---- */
   useEffect(() => {
     if (!containerRef.current || !hasToken) return;
 
     const reducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
+    spinRef.current = !reducedMotion;
 
     const map = new mapboxgl.Map({
       container: containerRef.current,
@@ -60,12 +76,8 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       });
     });
 
-    // - Auto-rotate (pause while the user is interacting) -
-    let userInteracting = false;
-    let spinEnabled = !reducedMotion;
-
     function spinGlobe() {
-      if (!spinEnabled || userInteracting) return;
+      if (!spinRef.current || interactingRef.current) return;
       const zoom = map.getZoom();
       if (zoom > 4) return;
       let distancePerSecond = 360 / SECONDS_PER_REVOLUTION;
@@ -75,25 +87,54 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       map.easeTo({ center, duration: 1000, easing: (n) => n });
     }
 
-    map.on("mousedown", () => (userInteracting = true));
-    map.on("touchstart", () => (userInteracting = true));
-    map.on("mouseup", () => {
-      userInteracting = false;
+    const hold = () => (interactingRef.current = true);
+    const release = () => {
+      interactingRef.current = false;
       spinGlobe();
-    });
-    map.on("touchend", () => {
-      userInteracting = false;
-      spinGlobe();
-    });
-    map.on("dragend", () => {
-      userInteracting = false;
-      spinGlobe();
-    });
+    };
+
+    map.on("mousedown", hold);
+    map.on("touchstart", hold);
+    map.on("mouseup", release);
+    map.on("touchend", release);
+    map.on("dragend", release);
     map.on("moveend", spinGlobe);
     map.on("zoom", () => setZoomedIn(map.getZoom() > 3.2));
-    map.on("load", spinGlobe);
+    map.on("load", () => {
+      setReady(true);
+      spinGlobe();
+    });
 
-    // - Markers + shared hover popup -
+    // Clicking the globe itself (not a marker) dismisses the detail sheet — the
+    // "click empty background to deselect" half of #17.
+    map.on("click", () => onSelectRef.current(null));
+
+    const globeEl = containerRef.current;
+    const restoreSpin = () => {
+      spinRef.current = !reducedMotion;
+      spinGlobe();
+    };
+    globeEl.addEventListener("hq:backToGlobe", restoreSpin);
+
+    // Keep the canvas in sync with the container (fonts/CSS can settle after
+    // mount, and mapbox only auto-resizes on window resize).
+    const ro = new ResizeObserver(() => map.resize());
+    ro.observe(globeEl);
+
+    return () => {
+      ro.disconnect();
+      globeEl.removeEventListener("hq:backToGlobe", restoreSpin);
+      map.remove();
+      mapRef.current = null;
+      setReady(false);
+    };
+  }, [hasToken]);
+
+  /* ---- Markers: rebuilt whenever the filtered list changes (#18) ---- */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready) return;
+
     const popup = new mapboxgl.Popup({
       closeButton: false,
       closeOnClick: false,
@@ -102,12 +143,20 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       maxWidth: "280px",
     });
 
-    const markers = located.map((h) => {
-      const el = document.createElement("div");
+    const markers = hackathons.map((h) => {
+      // A button, not a div: markers are the primary way into a hackathon from
+      // this page, so they have to be reachable by keyboard (#17). Mapbox gives
+      // us a bare element; the semantics are ours to add.
+      const el = document.createElement("button");
+      el.type = "button";
       el.className = "hq-marker";
       el.dataset.state = h.state;
+      el.setAttribute(
+        "aria-label",
+        `${h.title}, ${h.host}, ${h.location}. ${STATE_META[h.state].label}.`,
+      );
 
-      el.addEventListener("mouseenter", () => {
+      const showPopup = () => {
         const meta = STATE_META[h.state];
         const cd = countdown(h);
 
@@ -134,112 +183,82 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         metaRow.textContent = `${h.host} · ${h.location}`;
 
         root.append(statusRow, titleRow, metaRow);
+        popup.setLngLat([h.lng!, h.lat!]).setDOMContent(root).addTo(map);
+      };
 
-        popup
-          .setLngLat([h.lng!, h.lat!])
-          .setDOMContent(root)
-          .addTo(map);
-      });
-      el.addEventListener("mouseleave", () => popup.remove());
-      el.addEventListener("click", (e) => {
-        e.stopPropagation();
-        spinEnabled = false;
+      const select = (e: Event) => {
+        e.stopPropagation(); // don't let the map's background click deselect it
+        spinRef.current = false;
         popup.remove();
-        // Clicking a marker only flies the camera in — it deliberately does NOT
-        // open the detail card, which would cover the very map you just zoomed
-        // into. The hover popup carries the quick facts; full details live in
-        // the Deck / hackathons list.
-        map.flyTo({
-          center: [h.lng!, h.lat!],
-          zoom: 9.5,
-          duration: 2600,
-          essential: true,
-        });
-      });
+        onSelectRef.current(h);
+      };
+
+      el.addEventListener("mouseenter", showPopup);
+      el.addEventListener("focus", showPopup);
+      el.addEventListener("mouseleave", () => popup.remove());
+      el.addEventListener("blur", () => popup.remove());
+      el.addEventListener("click", select);
 
       return new mapboxgl.Marker({ element: el })
         .setLngLat([h.lng!, h.lat!])
         .addTo(map);
     });
 
-    const restoreSpin = () => {
-      spinEnabled = !reducedMotion;
-      spinGlobe();
-    };
-    const globeEl = containerRef.current;
-    globeEl.addEventListener("hq:backToGlobe", restoreSpin);
-
-    // Keep the canvas in sync with the container (fonts/CSS can settle after
-    // mount, and mapbox only auto-resizes on window resize).
-    const ro = new ResizeObserver(() => map.resize());
-    ro.observe(globeEl);
-
     return () => {
-      ro.disconnect();
-      globeEl.removeEventListener("hq:backToGlobe", restoreSpin);
       markers.forEach((m) => m.remove());
       popup.remove();
-      map.remove();
-      mapRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasToken]);
+  }, [hackathons, ready]);
+
+  /* ---- Fly to whatever is selected, from a marker or the off-map list ---- */
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !ready || !selected || selected.lat === null) return;
+    spinRef.current = false;
+    map.flyTo({
+      center: [selected.lng!, selected.lat!],
+      // Stops short of street level: the sheet covers part of the map, and the
+      // point is to see WHERE the hackathon is, not which building.
+      zoom: 8,
+      duration: 2200,
+      essential: true,
+    });
+  }, [selected, ready]);
 
   const backToGlobe = () => {
     setZoomedIn(false);
+    onSelect(null);
     mapRef.current?.flyTo({ ...GLOBE_VIEW, duration: 2400, essential: true });
     containerRef.current?.dispatchEvent(new Event("hq:backToGlobe"));
   };
 
   return (
-    <section id="globe" className="p-2 pt-0">
-      <div className="shell bg-ink h-[min(86vh,1000px)] min-h-[560px]">
-        {/* Map canvas - wrapper owns positioning because mapbox-gl forces
-            `position: relative` on the container element itself */}
-        {hasToken ? (
-          <div className="absolute inset-0">
-            <div ref={containerRef} className="h-full w-full" />
-          </div>
-        ) : (
-          <TokenFallback />
-        )}
-
-        {/* Legibility gradient */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%] bg-gradient-to-t from-ink-deep/95 via-ink-deep/40 to-transparent" />
-
-        {/* Back-to-globe (after a marker fly-in) */}
-        {zoomedIn && (
-          <button
-            onClick={backToGlobe}
-            className="glass-dark absolute right-6 top-6 z-10 rounded-full px-5 py-2.5 font-mono text-[11px] tracking-[0.2em] text-paper transition hover:bg-ink/80 sm:right-10 sm:top-9"
-          >
-            ← BACK TO GLOBE
-          </button>
-        )}
-
-        {/* Page title overlay - bottom-left */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 p-6 sm:p-10">
-          <div className="kicker text-coral">Pillar 01 · Explore</div>
-          <h1 className="display mt-3 text-[clamp(1.8rem,4.5vw,3.6rem)] text-paper">
-            The globe
-          </h1>
-          {unmapped > 0 && (
-            // The globe can only show what it has coordinates for. Say so out
-            // loud rather than quietly rendering an incomplete map (#111).
-            //
-            // Deliberately does not state WHY a listing is missing. The cause is
-            // either "no venue announced yet" (TBA) or "we failed to place a real
-            // city" — and this component cannot tell them apart. Naming the first
-            // cause would tell visitors a hackathon has no venue when it may
-            // simply be one we haven't geocoded.
-            <p className="mt-3 font-mono text-[11px] tracking-[0.12em] text-paper/50">
-              {unmapped} {unmapped === 1 ? "hackathon is" : "hackathons are"} not on
-              the map yet. Find {unmapped === 1 ? "it" : "them"} in the deck.
-            </p>
-          )}
+    <>
+      {hasToken ? (
+        <div className="absolute inset-0">
+          <div ref={containerRef} className="h-full w-full" />
         </div>
-      </div>
-    </section>
+      ) : (
+        <TokenFallback />
+      )}
+
+      {/* Legibility gradient */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%] bg-gradient-to-t from-ink-deep/95 via-ink-deep/40 to-transparent" />
+
+      {zoomedIn && (
+        <button
+          onClick={backToGlobe}
+          // Hidden on mobile while a sheet is open: there, the controls run the
+          // full width and this button lands on top of them. Closing the sheet
+          // (✕) brings it back. On desktop the sheet starts below it, so both fit.
+          className={`glass-dark absolute right-6 top-6 z-10 rounded-full px-5 py-2.5 font-mono text-[11px] tracking-[0.2em] text-paper transition hover:bg-ink/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral sm:right-10 sm:top-9 ${
+            selected ? "hidden sm:block" : ""
+          }`}
+        >
+          ← BACK TO GLOBE
+        </button>
+      )}
+    </>
   );
 }
 

--- a/web/components/hq/globe-sheet.tsx
+++ b/web/components/hq/globe-sheet.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Hackathon } from "@/lib/types-hq";
+import { STATE_META, countdown, deadlineDisplay } from "@/lib/types-hq";
+import { useTracker } from "./store";
+
+/**
+ * The detail panel for a hackathon picked on the globe (#17).
+ *
+ * A docked sheet, not the centered modal the deck uses: the whole point of
+ * clicking a marker is that the camera flies to the city, and a centered modal
+ * would cover the very map you just asked to see. It sits beside the globe on
+ * desktop and rises from the bottom on mobile, leaving the pin visible.
+ *
+ * It is NOT a dialog: the map behind it stays live and interactive, so it takes
+ * no focus trap and no aria-modal. Escape and a click on the globe both dismiss.
+ */
+export function GlobeSheet({
+  hackathon,
+  onClose,
+}: {
+  hackathon: Hackathon;
+  onClose: () => void;
+}) {
+  const { isTracked, save, remove } = useTracker();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const tracked = isTracked(hackathon.id);
+  const meta = STATE_META[hackathon.state];
+  const cd = countdown(hackathon);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // Move focus into the sheet when it opens. Selecting a marker with the
+  // keyboard would otherwise leave focus on a marker that the camera has just
+  // flown away from, with the new content announced nowhere.
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, [hackathon.id]);
+
+  return (
+    <aside
+      // A live region: the sheet's content is swapped, not remounted, when you
+      // pick a second marker, so screen readers need telling that it changed.
+      aria-live="polite"
+      aria-label={`Details for ${hackathon.title}`}
+      // glass-sheet, not glass-dark: at 0.55 alpha the map and the page title
+      // read straight through this text.
+      //
+      // sm:top-20 rather than sm:top-6 — the BACK TO GLOBE button lives at
+      // top-6 right-6, and the sheet was landing on top of it.
+      className="glass-sheet pointer-events-auto absolute inset-x-3 bottom-3 z-20 flex flex-col gap-4 rounded-3xl p-5 shadow-[0_16px_48px_rgba(0,0,0,0.55)] sm:inset-x-auto sm:bottom-6 sm:right-6 sm:top-20 sm:w-[22rem] sm:justify-center sm:p-7"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div
+          className="font-mono text-[10px] tracking-[0.22em]"
+          style={{ color: meta.color }}
+        >
+          ● {meta.label}
+          {cd ? ` · ${cd.toUpperCase()}` : ""}
+        </div>
+        <button
+          ref={closeRef}
+          onClick={onClose}
+          aria-label="Close details"
+          className="-mr-1 -mt-1 rounded-full px-2 py-1 font-mono text-[11px] text-paper/50 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div>
+        <h2 className="display text-[clamp(1.1rem,2.2vw,1.5rem)] leading-tight text-paper">
+          {hackathon.title}
+        </h2>
+        <p className="mt-2 text-sm text-paper/60">
+          {hackathon.host} · {hackathon.location}
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-3 border-y border-white/10 py-4">
+        <Fact label="Format" value={hackathon.format} />
+        <Fact label="Prize" value={hackathon.prize ?? "TBA"} />
+        <Fact label="Deadline" value={deadlineDisplay(hackathon) ?? "TBA"} />
+        <Fact
+          label="Themes"
+          value={hackathon.themes.length ? hackathon.themes.join(", ") : "-"}
+        />
+      </dl>
+
+      <div className="flex flex-col gap-2">
+        <a
+          href={hackathon.url}
+          target="_blank"
+          rel="noreferrer"
+          className="rounded-full bg-coral px-6 py-3.5 text-center font-mono text-[12px] font-bold tracking-[0.18em] text-paper transition hover:bg-coral-bright focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-paper"
+        >
+          {hackathon.state === "opens_soon" ? "VISIT WEBSITE ↗" : "REGISTER ↗"}
+        </a>
+        <button
+          onClick={() => (tracked ? remove(hackathon.id) : save(hackathon.id))}
+          aria-pressed={tracked}
+          className={`rounded-full border px-6 py-3 font-mono text-[11px] tracking-[0.18em] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral ${
+            tracked
+              ? "border-coral bg-coral/15 text-coral"
+              : "border-white/15 text-paper/70 hover:border-white/40 hover:text-paper"
+          }`}
+        >
+          {tracked ? "♥ SAVED" : "♡ SAVE TO MY HQ"}
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="font-mono text-[9px] tracking-[0.2em] text-paper/40">
+        {label.toUpperCase()}
+      </dt>
+      <dd className="mt-1 text-sm text-paper/85">{value}</dd>
+    </div>
+  );
+}

--- a/web/lib/filters.test.ts
+++ b/web/lib/filters.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  NO_FILTERS,
+  applyFilters,
+  isFiltering,
+  matches,
+  splitByMappability,
+} from "./filters";
+import type { Hackathon } from "./types-hq";
+
+function hack(over: Partial<Hackathon> = {}): Hackathon {
+  return {
+    id: "1",
+    host: "MIT",
+    title: "HackMIT",
+    tagline: null,
+    url: "https://hackmit.org",
+    location: "Cambridge, MA",
+    format: "In-Person",
+    prize: "$40K",
+    prizeValue: 40000,
+    state: "open",
+    deadline: "2026-09-01",
+    daysLeft: 30,
+    lat: 42.3736,
+    lng: -71.1097,
+    themes: ["AI"],
+    postedAt: 0,
+    ...over,
+  } as Hackathon;
+}
+
+describe("matches", () => {
+  it("passes everything when nothing is set", () => {
+    expect(matches(hack(), NO_FILTERS)).toBe(true);
+  });
+
+  it("filters by status and format", () => {
+    expect(matches(hack({ state: "closed" }), { ...NO_FILTERS, status: "open" })).toBe(false);
+    expect(matches(hack({ format: "Virtual" }), { ...NO_FILTERS, format: "In-Person" })).toBe(false);
+    expect(matches(hack({ format: "Virtual" }), { ...NO_FILTERS, format: "Virtual" })).toBe(true);
+  });
+
+  it("searches title, host, location and themes", () => {
+    const h = hack();
+    for (const q of ["hackmit", "MIT", "cambridge", "ai"]) {
+      expect(matches(h, { ...NO_FILTERS, q }), `should match ${q}`).toBe(true);
+    }
+    expect(matches(h, { ...NO_FILTERS, q: "berlin" })).toBe(false);
+  });
+
+  it("ignores case and surrounding whitespace", () => {
+    expect(matches(hack(), { ...NO_FILTERS, q: "  HaCkMiT  " })).toBe(true);
+  });
+});
+
+describe("isFiltering", () => {
+  it("is false only when nothing narrows the list", () => {
+    expect(isFiltering(NO_FILTERS)).toBe(false);
+    expect(isFiltering({ ...NO_FILTERS, q: "   " })).toBe(false);
+    expect(isFiltering({ ...NO_FILTERS, q: "ai" })).toBe(true);
+    expect(isFiltering({ ...NO_FILTERS, status: "open" })).toBe(true);
+  });
+});
+
+describe("splitByMappability", () => {
+  it("separates what the globe can pin from what it cannot", () => {
+    const inPerson = hack({ id: "a" });
+    const virtual = hack({ id: "b", format: "Virtual", lat: null, lng: null });
+    // An in-person event we failed to geocode: not virtual, still unpinnable.
+    const unplaced = hack({ id: "c", location: "Atlantis, XX", lat: null, lng: null });
+
+    const { onMap, offMap } = splitByMappability([inPerson, virtual, unplaced]);
+    expect(onMap.map((h) => h.id)).toEqual(["a"]);
+    expect(offMap.map((h) => h.id)).toEqual(["b", "c"]);
+  });
+
+  it("keeps virtual events reachable once the list is filtered", () => {
+    // The point of the panel (#18): filtering the globe must not make an online
+    // hackathon disappear from the page — it never had a pin to lose.
+    const list = [hack({ id: "a" }), hack({ id: "b", format: "Virtual", lat: null, lng: null })];
+    const filtered = applyFilters(list, { ...NO_FILTERS, q: "hackmit" });
+    expect(splitByMappability(filtered).offMap.map((h) => h.id)).toEqual(["b"]);
+  });
+});

--- a/web/lib/filters.ts
+++ b/web/lib/filters.ts
@@ -1,0 +1,67 @@
+import type { Hackathon, HackState } from "./types-hq";
+
+/**
+ * The one filter the site runs on.
+ *
+ * The deck had this logic inline. The globe (#18) needs exactly the same rules —
+ * and a second copy would quietly drift: a theme added to the deck's search but
+ * not the globe's is a hackathon a visitor can find on one surface and not the
+ * other, with nothing to tell them the two disagree.
+ */
+
+export type StatusFilter = "all" | HackState;
+export type FormatFilter = "all" | "In-Person" | "Virtual" | "Hybrid";
+
+export type Filters = {
+  q: string;
+  status: StatusFilter;
+  format: FormatFilter;
+};
+
+export const NO_FILTERS: Filters = { q: "", status: "all", format: "all" };
+
+/** Is anything actually narrowing the list? Drives the "clear all" affordance. */
+export function isFiltering({ q, status, format }: Filters): boolean {
+  return q.trim() !== "" || status !== "all" || format !== "all";
+}
+
+export function matches(h: Hackathon, { q, status, format }: Filters): boolean {
+  if (status !== "all" && h.state !== status) return false;
+  if (format !== "all" && h.format !== format) return false;
+
+  const needle = q.trim().toLowerCase();
+  if (!needle) return true;
+
+  // Searchable text = everything a person might plausibly type: the event, who
+  // runs it, where it is, and what it's about.
+  return [h.title, h.host, h.location, ...h.themes]
+    .join(" ")
+    .toLowerCase()
+    .includes(needle);
+}
+
+export function applyFilters(list: Hackathon[], filters: Filters): Hackathon[] {
+  return list.filter((h) => matches(h, filters));
+}
+
+/**
+ * Split a filtered list into what the globe can pin and what it cannot.
+ *
+ * `offMap` is the answer to "online events have no location" (#18): a Virtual
+ * hackathon can never have a marker, so without somewhere to list it, filtering
+ * the globe would make it vanish entirely rather than merely lose its pin.
+ * `offMap` also catches an in-person event we simply failed to geocode, so the
+ * globe never quietly drops a listing (#111).
+ */
+export function splitByMappability(list: Hackathon[]): {
+  onMap: Hackathon[];
+  offMap: Hackathon[];
+} {
+  const onMap: Hackathon[] = [];
+  const offMap: Hackathon[] = [];
+  for (const h of list) {
+    if (h.lat !== null && h.lng !== null) onMap.push(h);
+    else offMap.push(h);
+  }
+  return { onMap, offMap };
+}


### PR DESCRIPTION
Closes #17
Closes #18

Both issues were written against react-globe.gl and Supabase, neither of which exists — the globe is Mapbox and the data comes from `listings.json`. This delivers what they actually asked for, on the stack we have.

## #17 — Marker interactions

Clicking a marker used to fly the camera and **open nothing**. The detail card existed, but it's a centered modal, and opening it on marker click would cover the very map you just zoomed into — so it was wired to the deck only.

Now a marker click flies the camera **and** opens a **docked sheet**: beside the map on desktop, rising from the bottom on mobile. The pin stays visible next to its own details.

- [x] Hover tooltip: name + city (also on focus, so keyboard users get it too)
- [x] Click opens details with host / title / format / prize / deadline + REGISTER (open) or VISIT WEBSITE (opens_soon)
- [x] Escape **and** a click on empty globe both deselect
- [x] Keyboard accessible — markers are real `<button>`s with accessible names, and focus moves into the sheet when it opens
- [x] Flies/zooms the globe to the selected point

Bonus: SAVE TO MY HQ, so a hackathon found on the globe goes straight into the tracker.

## #18 — Search, filters, and the off-map panel

- [x] Search by name / host / city / theme, filtering **globe markers live**
- [x] Status + format pills, multi-select toggle, clear-all
- [x] A panel listing everything the globe **cannot pin** — online events, which never had a marker to lose, and anything we failed to geocode (#111). Each opens the same sheet.

The filter logic is now **one shared module** (`lib/filters.ts`), used by the deck and the globe. A second copy would drift: a theme added to one surface's search and not the other's is a hackathon you can find in the deck and not on the globe, with nothing to tell you they disagree.

## Three defects my own test caught while building this

Recording them because each was a real bug, not a polish item:

1. **Picking a virtual event from the off-map panel opened nothing.** The selection guard checked membership in `onMap` — and an online hackathon is *never* on the map. So the panel that exists to make virtual events reachable selected one and immediately discarded it. That is the entire point of #18, and it was broken.
2. **`BACK TO GLOBE` sat exactly where the sheet lands** (`top-6 right-6`). The sheet now starts below it on desktop; on mobile the controls run full width, so the button hides while the sheet is open.
3. **The sheet was translucent** (`glass-dark`, 0.55 alpha) and the map and page title read straight through the hackathon's own details. Added a `glass-sheet` surface.

## Verification

Driven with Playwright at 1280px and 375px:

```
markers on load: 42            marker is a real <button>: yes
search "boston" -> markers: 1  after CLEAR -> markers: 42
filter VIRTUAL -> markers: 0   (online events can never have a pin)
off-map panel: "🌐 19 not on the map · 19 online"  -> 19 entries
sheet opens from the virtual list: true
marker keyboard-focusable: true -> Enter opens the sheet
sheet docked at x=896 of 1280  (map still visible to its left)
focus moves into the sheet: "Close details"
Escape dismisses: true
page errors: none
horizontal overflow: none at 1280px or 375px
```

`npm run test` (87 pass, incl. 7 new filter tests), `npm run build`, `npx tsc --noEmit`, `npm run lint` all clean.