### PR TITLE
feat: globe filters and detail drawer

### DIFF
--- a/web/components/hq/globe-detail-drawer.tsx
+++ b/web/components/hq/globe-detail-drawer.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useRef, type CSSProperties } from "react";
+import {
+  STATE_META,
+  countdown,
+  deadlineDisplay,
+  type Hackathon,
+} from "@/lib/types-hq";
+import { useTracker } from "./store";
+
+type GlobeDetailDrawerProps = {
+  hackathon: Hackathon | null;
+  onClose: () => void;
+};
+
+export function GlobeDetailDrawer({
+  hackathon,
+  onClose,
+}: GlobeDetailDrawerProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!hackathon) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+    return () => window.removeEventListener("keydown", onKey);
+  }, [hackathon, onClose]);
+
+  if (!hackathon) return null;
+
+  const h = hackathon;
+  const meta = STATE_META[h.state];
+  const cd = countdown(h);
+  const deadline = deadlineDisplay(h);
+  const detailTitleId = `globe-detail-title-${h.id}`;
+
+  return (
+    <aside
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={detailTitleId}
+      className="absolute inset-x-2 bottom-36 top-auto z-10 flex max-h-[calc(100%-12rem)] flex-col overflow-hidden rounded-3xl border border-white/15 bg-[rgba(23,19,15,0.92)] text-paper shadow-[0_20px_70px_rgba(0,0,0,0.55)] backdrop-blur-xl md:inset-x-auto md:right-6 md:bottom-auto md:top-24 md:max-h-[calc(100%-7.5rem)] md:w-[min(26rem,calc(100%-2rem))] md:rounded-[1.75rem]"
+      style={{ borderColor: `${meta.color}55` }}
+    >
+      <div className="flex shrink-0 justify-center pt-2.5 md:hidden">
+        <span className="h-1.5 w-10 rounded-full bg-white/25" />
+      </div>
+
+      <div className="flex items-start justify-between gap-4 px-4 py-3 md:border-b md:border-white/10 md:px-5 md:py-4">
+        <div>
+          <div
+            className="font-mono text-[10px] tracking-[0.22em]"
+            style={{ color: meta.color }}
+          >
+            ● {meta.label}
+            {cd ? ` · ${cd.toUpperCase()}` : ""}
+          </div>
+          <div className="mt-2 font-mono text-[10px] tracking-[0.2em] text-paper/45">
+            {h.format.toUpperCase()}
+          </div>
+        </div>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close hackathon details"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-paper/70 transition hover:bg-white/10 hover:text-paper focus:outline-none focus:ring-2 md:h-9 md:w-9"
+          style={{ "--tw-ring-color": meta.color } as CSSProperties}
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="rail-scroll flex-1 overflow-y-auto px-4 py-4 md:px-5 md:py-5">
+        <div className="kicker text-paper/45">{h.host}</div>
+        <h2
+          id={detailTitleId}
+          className="mt-2 text-xl font-semibold leading-tight text-paper md:text-2xl"
+        >
+          {h.title}
+        </h2>
+        {h.tagline && (
+          <p className="mt-3 hidden text-sm leading-relaxed text-paper/60 md:block">
+            {h.tagline}
+          </p>
+        )}
+
+        <div className="mt-4 grid grid-cols-2 gap-2 md:hidden">
+          <DetailRow label="City" value={h.location} />
+          <DetailRow label="Format" value={h.format} />
+          <DetailRow label="Prize" value={h.prize ?? "See website"} />
+          {deadline && <DetailRow label="Deadline" value={deadline} />}
+        </div>
+
+        <div className="mt-5 hidden gap-3 md:grid">
+          <DetailRow label="City" value={h.location} />
+          <DetailRow label="Format" value={h.format} />
+          <DetailRow label="Prize" value={h.prize ?? "See website"} />
+          {deadline && <DetailRow label="Deadline" value={deadline} />}
+        </div>
+
+        {h.themes.length > 0 && (
+          <div className="mt-5 hidden flex-wrap gap-2 sm:flex">
+            {h.themes.map((theme) => (
+              <span
+                key={theme}
+                className="rounded-full border border-white/12 bg-white/5 px-3 py-1.5 font-mono text-[10px] tracking-[0.12em] text-paper/65"
+              >
+                {theme}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 border-t border-white/10 p-4 sm:p-5">
+        <ActionButton hackathon={h} />
+        <SaveHeart hackathon={h} />
+      </div>
+    </aside>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  className = "",
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`rounded-2xl border border-white/10 bg-white/5 px-4 py-2 ${className}`}
+    >
+      <div className="font-mono text-[9px] tracking-[0.2em] text-paper/40">
+        {label.toUpperCase()}
+      </div>
+      <div className="mt-1 text-sm font-medium text-paper/85">{value}</div>
+    </div>
+  );
+}
+
+function ActionButton({ hackathon }: { hackathon: Hackathon }) {
+  const isRegister =
+    hackathon.state === "open" || hackathon.state === "closing_soon";
+
+  return (
+    <a
+      href={hackathon.url}
+      target="_blank"
+      rel="noreferrer"
+      className={`block flex-1 rounded-full px-6 py-4 text-center font-mono text-[12px] font-bold tracking-[0.18em] transition focus:outline-none focus:ring-2 ${
+        isRegister
+          ? "bg-register text-paper hover:bg-register/85 focus:ring-register"
+          : "border border-white/15 bg-white/12 text-paper hover:bg-white/18 focus:ring-muted"
+      }`}
+    >
+      {isRegister ? "REGISTER" : "WEBSITE"}
+    </a>
+  );
+}
+
+function SaveHeart({ hackathon }: { hackathon: Hackathon }) {
+  const { isTracked, save, remove } = useTracker();
+  const tracked = isTracked(hackathon.id);
+  return (
+    <button
+      type="button"
+      onClick={() => (tracked ? remove(hackathon.id) : save(hackathon.id))}
+      aria-label={tracked ? "Remove from tracker" : "Save to tracker"}
+      title={tracked ? "Remove from My HackHQ" : "Save to My HackHQ"}
+      className={`flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full border-2 text-[18px] transition focus:outline-none focus:ring-2 focus:ring-coral ${
+        tracked
+          ? "border-coral bg-coral text-paper"
+          : "border-white/20 text-paper/70 hover:border-coral hover:text-coral"
+      }`}
+    >
+      {tracked ? "♥" : "♡"}
+    </button>
+  );
+}

--- a/web/components/hq/globe-detail-drawer.tsx
+++ b/web/components/hq/globe-detail-drawer.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useRef, type CSSProperties } from "react";
+import { useRef, type CSSProperties } from "react";
 import {
   STATE_META,
   countdown,
   deadlineDisplay,
   type Hackathon,
 } from "@/lib/types-hq";
+import { useDialogDismiss } from "./use-dialog-dismiss";
 import { useTracker } from "./store";
 
 type GlobeDetailDrawerProps = {
@@ -20,17 +21,12 @@ export function GlobeDetailDrawer({
 }: GlobeDetailDrawerProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (!hackathon) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    window.requestAnimationFrame(() => {
-      closeButtonRef.current?.focus();
-    });
-    return () => window.removeEventListener("keydown", onKey);
-  }, [hackathon, onClose]);
+  // Escape closes and focus lands on the close button. Focus *return* on close
+  // is owned by the opener in globe-map (it points focus back at the map pin or
+  // the 🌐 VIRTUAL trigger), so restoreFocus stays off here.
+  useDialogDismiss(Boolean(hackathon), onClose, {
+    initialFocusRef: closeButtonRef,
+  });
 
   if (!hackathon) return null;
 

--- a/web/components/hq/globe-detail-drawer.tsx
+++ b/web/components/hq/globe-detail-drawer.tsx
@@ -87,14 +87,8 @@ export function GlobeDetailDrawer({
           </p>
         )}
 
-        <div className="mt-4 grid grid-cols-2 gap-2 md:hidden">
-          <DetailRow label="City" value={h.location} />
-          <DetailRow label="Format" value={h.format} />
-          <DetailRow label="Prize" value={h.prize ?? "See website"} />
-          {deadline && <DetailRow label="Deadline" value={deadline} />}
-        </div>
-
-        <div className="mt-5 hidden gap-3 md:grid">
+        {/* Two columns on mobile, a single stacked column from md up. */}
+        <div className="mt-4 grid grid-cols-2 gap-2 md:mt-5 md:grid-cols-1 md:gap-3">
           <DetailRow label="City" value={h.location} />
           <DetailRow label="Format" value={h.format} />
           <DetailRow label="Prize" value={h.prize ?? "See website"} />
@@ -123,19 +117,9 @@ export function GlobeDetailDrawer({
   );
 }
 
-function DetailRow({
-  label,
-  value,
-  className = "",
-}: {
-  label: string;
-  value: string;
-  className?: string;
-}) {
+function DetailRow({ label, value }: { label: string; value: string }) {
   return (
-    <div
-      className={`rounded-2xl border border-white/10 bg-white/5 px-4 py-2 ${className}`}
-    >
+    <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-2">
       <div className="font-mono text-[9px] tracking-[0.2em] text-paper/40">
         {label.toUpperCase()}
       </div>

--- a/web/components/hq/globe-filter-bar.tsx
+++ b/web/components/hq/globe-filter-bar.tsx
@@ -108,13 +108,11 @@ export function GlobeFilterBar({
 function FilterPill({
   children,
   active,
-  dim = false,
   onClick,
   dotColor,
 }: {
   children: React.ReactNode;
   active: boolean;
-  dim?: boolean;
   onClick: () => void;
   dotColor?: string;
 }) {
@@ -126,9 +124,7 @@ function FilterPill({
       className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5 font-mono text-[10px] tracking-[0.12em] transition focus:outline-none focus:ring-2 focus:ring-coral ${
         active
           ? "bg-paper text-ink"
-          : `glass-dark border border-white/15 text-paper/70 hover:text-paper ${
-              dim ? "opacity-50" : ""
-            }`
+          : "glass-dark border border-white/15 text-paper/70 hover:text-paper"
       }`}
     >
       {dotColor && (

--- a/web/components/hq/globe-filter-bar.tsx
+++ b/web/components/hq/globe-filter-bar.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { STATE_META, type HackState, type Hackathon } from "@/lib/types-hq";
+
+type Format = Hackathon["format"];
+
+const STATUS_PILLS: HackState[] = ["open", "opens_soon", "closing_soon"];
+// Only these two narrow the map pins. "Virtual" isn't a pin filter (virtual
+// events have no coordinates) - it opens the online-events drawer instead.
+const FORMAT_PILLS: Format[] = ["In-Person", "Hybrid"];
+
+type GlobeFilterBarProps = {
+  // Pin-eligible events (have coordinates). Counts are based on these so the
+  // numbers match what actually appears on the map.
+  located: Hackathon[];
+  query: string;
+  onQueryChange: (q: string) => void;
+  activeStatuses: Set<HackState>;
+  onToggleStatus: (s: HackState) => void;
+  activeFormats: Set<Format>;
+  onToggleFormat: (f: Format) => void;
+  virtualCount: number;
+  onOpenVirtual: () => void;
+  onClearAll: () => void;
+};
+
+export function GlobeFilterBar({
+  query,
+  onQueryChange,
+  activeStatuses,
+  onToggleStatus,
+  activeFormats,
+  onToggleFormat,
+  onOpenVirtual,
+  onClearAll,
+}: GlobeFilterBarProps) {
+
+  const anyActive =
+    query.trim().length > 0 || activeStatuses.size > 0 || activeFormats.size > 0;
+
+  const rowClass =
+    "flex flex-nowrap gap-1.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden";
+
+  return (
+    <div className="absolute left-2 top-2 z-10 flex max-w-[calc(100%-1rem)] flex-col gap-1.5 sm:left-4 sm:top-4">
+      <div className="flex items-center gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search hackathon, location…"
+          aria-label="Search hackathons"
+          className="glass-dark w-56 rounded-full border border-white/15 px-4 py-2 text-sm text-paper placeholder:text-paper/40 focus:outline-none focus:ring-2 focus:ring-coral sm:w-72"
+        />
+        {anyActive && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            className="shrink-0 whitespace-nowrap rounded-full px-2.5 py-1.5 font-mono text-[10px] tracking-[0.12em] text-paper/70 underline-offset-2 transition hover:text-paper hover:underline focus:outline-none focus:ring-2 focus:ring-coral"
+          >
+            CLEAR
+          </button>
+        )}
+      </div>
+
+      {/* Row 1 - status */}
+      <div className={rowClass}>
+        {STATUS_PILLS.map((s) => (
+          <FilterPill
+            key={s}
+            active={activeStatuses.has(s)}
+            onClick={() => onToggleStatus(s)}
+            dotColor={STATE_META[s].color}
+          >
+            {STATE_META[s].label}
+          </FilterPill>
+        ))}
+      </div>
+
+      {/* Row 2 - format (In-Person / Hybrid) + the Virtual drawer opener */}
+      <div className={rowClass}>
+        {FORMAT_PILLS.map((f) => (
+          <FilterPill
+            key={f}
+            active={activeFormats.has(f)}
+            onClick={() => onToggleFormat(f)}
+          >
+            {f.toUpperCase()}
+          </FilterPill>
+        ))}
+
+        {/* Virtual isn't a pin filter - it opens the online-events drawer. */}
+        <button
+          type="button"
+          onClick={onOpenVirtual}
+          className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-coral/40 bg-coral/10 px-3 py-1.5 font-mono text-[10px] tracking-[0.12em] text-paper/80 transition hover:bg-coral/20 hover:text-paper focus:outline-none focus:ring-2 focus:ring-coral"
+        >
+          🌐 VIRTUAL
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function FilterPill({
+  children,
+  active,
+  dim = false,
+  onClick,
+  dotColor,
+}: {
+  children: React.ReactNode;
+  active: boolean;
+  dim?: boolean;
+  onClick: () => void;
+  dotColor?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5 font-mono text-[10px] tracking-[0.12em] transition focus:outline-none focus:ring-2 focus:ring-coral ${
+        active
+          ? "bg-paper text-ink"
+          : `glass-dark border border-white/15 text-paper/70 hover:text-paper ${
+              dim ? "opacity-50" : ""
+            }`
+      }`}
+    >
+      {dotColor && (
+        <span
+          className="h-1.5 w-1.5 rounded-full"
+          style={{ background: dotColor }}
+          aria-hidden
+        />
+      )}
+      {children}
+    </button>
+  );
+}

--- a/web/components/hq/globe-filter-bar.tsx
+++ b/web/components/hq/globe-filter-bar.tsx
@@ -10,16 +10,16 @@ const STATUS_PILLS: HackState[] = ["open", "opens_soon", "closing_soon"];
 const FORMAT_PILLS: Format[] = ["In-Person", "Hybrid"];
 
 type GlobeFilterBarProps = {
-  // Pin-eligible events (have coordinates). Counts are based on these so the
-  // numbers match what actually appears on the map.
-  located: Hackathon[];
   query: string;
   onQueryChange: (q: string) => void;
   activeStatuses: Set<HackState>;
   onToggleStatus: (s: HackState) => void;
   activeFormats: Set<Format>;
   onToggleFormat: (f: Format) => void;
+  // Online events matching the current search/status filters. Shown on the
+  // VIRTUAL pill so a zero count is visible before the drawer is opened.
   virtualCount: number;
+  virtualButtonRef?: React.Ref<HTMLButtonElement>;
   onOpenVirtual: () => void;
   onClearAll: () => void;
 };
@@ -31,6 +31,8 @@ export function GlobeFilterBar({
   onToggleStatus,
   activeFormats,
   onToggleFormat,
+  virtualCount,
+  virtualButtonRef,
   onOpenVirtual,
   onClearAll,
 }: GlobeFilterBarProps) {
@@ -91,11 +93,12 @@ export function GlobeFilterBar({
 
         {/* Virtual isn't a pin filter - it opens the online-events drawer. */}
         <button
+          ref={virtualButtonRef}
           type="button"
           onClick={onOpenVirtual}
           className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border border-coral/40 bg-coral/10 px-3 py-1.5 font-mono text-[10px] tracking-[0.12em] text-paper/80 transition hover:bg-coral/20 hover:text-paper focus:outline-none focus:ring-2 focus:ring-coral"
         >
-          🌐 VIRTUAL
+          🌐 VIRTUAL ({virtualCount})
         </button>
       </div>
     </div>

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -207,7 +207,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       metaRow.style.fontSize = "12px";
       metaRow.style.color = "#9ba1a5";
       metaRow.style.marginTop = "3px";
-      metaRow.textContent = h.location;
+      metaRow.textContent = `${h.host} · ${h.location}`;
 
       root.append(statusRow, titleRow, metaRow);
 

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -34,6 +34,14 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   // Latest close handler, so the map-created "click" listener (bound once in
   // the effect) always calls the current one instead of a stale closure.
   const closeDrawerRef = useRef<() => void>(() => {});
+  // Freeze/resume the auto-spin from outside the map effect. The effect owns the
+  // wiring; these let the drawer callbacks pause it (marker + virtual paths) and
+  // resume it on close.
+  const spinEnabledRef = useRef(true);
+  const resumeSpinRef = useRef<() => void>(() => {});
+  // The "🌐 VIRTUAL" trigger, so a detail opened from the virtual list can hand
+  // focus back to it on close (WCAG 2.4.3) — the marker path uses markerRefs.
+  const virtualTriggerRef = useRef<HTMLButtonElement>(null);
   const [zoomedIn, setZoomedIn] = useState(false);
   const [selectedHackathon, setSelectedHackathon] = useState<Hackathon | null>(
     null,
@@ -132,10 +140,10 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
 
     // - Auto-rotate (pause while the user is interacting) -
     let userInteracting = false;
-    let spinEnabled = !reducedMotion;
+    spinEnabledRef.current = !reducedMotion;
 
     function spinGlobe() {
-      if (!spinEnabled || userInteracting) return;
+      if (!spinEnabledRef.current || userInteracting) return;
       const zoom = map.getZoom();
       if (zoom > 4) return;
       let distancePerSecond = 360 / SECONDS_PER_REVOLUTION;
@@ -213,8 +221,13 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       selectedMarkerIdRef.current = h.id;
       setSelectedHackathon(h);
       setVirtualOpen(false);
-      spinEnabled = false;
+      spinEnabledRef.current = false;
       popup.remove();
+      // Re-query at click time (not the mount-captured value) so a reduced-motion
+      // preference toggled mid-session is honored, matching backToGlobe/closeDrawer.
+      const reduced = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
       // On small screens the detail card is a bottom sheet, so reserve the
       // lower ~55% of the map with camera padding. flyTo then centers the pin
       // in the remaining upper band, keeping it clear of the card. (offset is
@@ -223,10 +236,9 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       map.flyTo({
         center: [h.lng!, h.lat!],
         zoom: 9.5,
-        // Respect prefers-reduced-motion: jump instead of a 2.6s fly. (The
-        // auto-spin is already disabled for these users; essential:true would
-        // otherwise force this animation to play regardless.)
-        duration: reducedMotion ? 0 : 2600,
+        // Respect prefers-reduced-motion: jump instead of a 2.6s fly. (essential:
+        // true would otherwise force this animation to play regardless.)
+        duration: reduced ? 0 : 2600,
         essential: true,
         padding: smallScreen
           ? {
@@ -273,9 +285,10 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
     });
 
     const restoreSpin = () => {
-      spinEnabled = !reducedMotion;
+      spinEnabledRef.current = !reducedMotion;
       spinGlobe();
     };
+    resumeSpinRef.current = restoreSpin;
     const globeEl = containerRef.current;
     globeEl.addEventListener("hq:backToGlobe", restoreSpin);
 
@@ -292,6 +305,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       markerInstanceMap.clear();
       popup.remove();
       popupRef.current = null;
+      resumeSpinRef.current = () => {};
       map.remove();
       mapRef.current = null;
     };
@@ -300,6 +314,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
 
   const backToGlobe = () => {
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const markerId = selectedMarkerIdRef.current;
     setZoomedIn(false);
     setSelectedHackathon(null);
     selectedMarkerIdRef.current = null;
@@ -310,41 +325,73 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       padding: { top: 0, right: 0, bottom: 0, left: 0 },
     });
     containerRef.current?.dispatchEvent(new Event("hq:backToGlobe"));
+    // The Back-to-globe button unmounts with zoomedIn, so return focus to the
+    // pin that started the fly-in instead of letting it drop to <body>.
+    if (markerId) {
+      window.requestAnimationFrame(() => {
+        markerRefs.current.get(markerId)?.focus({ preventScroll: true });
+      });
+    }
   };
 
-  // Every dismiss path (Escape, close button, background click) routes here so
-  // focus always returns to the marker that opened the drawer (WCAG 2.4.3). If
-  // nothing is open the markerId is null and this is a no-op.
+  // Close the detail card. Both entry points (marker fly-in and virtual list)
+  // route here, and focus always returns to whatever opened it (WCAG 2.4.3).
   const closeDrawer = useCallback(() => {
     const markerId = selectedMarkerIdRef.current;
     selectedMarkerIdRef.current = null;
     setSelectedHackathon(null);
-    // On mobile, opening the detail card set a persistent 55% bottom padding
-    // (so the pin cleared the bottom sheet). If we leave it on close, the pin
-    // stays off-center and subsequent manual zoom/pan — especially zooming back
-    // out — is thrown off. Recenter by clearing the padding when the card goes.
-    const map = mapRef.current;
-    if (map) {
-      const reduced = window.matchMedia(
-        "(prefers-reduced-motion: reduce)",
-      ).matches;
-      map.easeTo({
-        padding: { top: 0, right: 0, bottom: 0, left: 0 },
-        duration: reduced ? 0 : 300,
-        essential: true,
+    if (markerId) {
+      // Marker path: opening flew the camera in and (on mobile) reserved a 55%
+      // bottom padding so the pin cleared the bottom sheet. Clear it on close so
+      // the pin recenters and later manual zoom/pan isn't thrown off, then hand
+      // focus back to the pin that opened the card.
+      const map = mapRef.current;
+      if (map) {
+        const reduced = window.matchMedia(
+          "(prefers-reduced-motion: reduce)",
+        ).matches;
+        map.easeTo({
+          padding: { top: 0, right: 0, bottom: 0, left: 0 },
+          duration: reduced ? 0 : 300,
+          essential: true,
+        });
+      }
+      window.requestAnimationFrame(() => {
+        markerRefs.current.get(markerId)?.focus({ preventScroll: true });
       });
+      return;
     }
-    if (!markerId) return;
+    // Virtual path: no pin and no camera padding was set. Resume the auto-spin
+    // the virtual flow paused, and return focus to the 🌐 VIRTUAL trigger, which
+    // reappears in the filter bar once the detail closes.
+    resumeSpinRef.current();
     window.requestAnimationFrame(() => {
-      markerRefs.current.get(markerId)?.focus({ preventScroll: true });
+      virtualTriggerRef.current?.focus({ preventScroll: true });
     });
   }, []);
 
+  // The virtual drawer's own onClose. Stable identity (useCallback) so the
+  // drawer's [open, onClose] focus effect doesn't tear down and re-run on every
+  // parent re-render — otherwise typing in the filter search would yank focus
+  // out of the input after every keystroke.
+  const closeVirtual = useCallback(() => {
+    setVirtualOpen(false);
+    resumeSpinRef.current();
+  }, []);
+
+  // Background map click: dismiss whichever drawer is open, and nothing else.
+  // Clicking the bare globe must not start a camera move — that would stutter
+  // the auto-spin.
+  const dismissActive = useCallback(() => {
+    if (selectedHackathon) closeDrawer();
+    else if (virtualOpen) closeVirtual();
+  }, [selectedHackathon, virtualOpen, closeDrawer, closeVirtual]);
+
   // The map's "click" listener is bound once in the effect; keep the ref it
-  // calls pointed at the latest handler.
+  // calls pointed at the latest dismiss handler.
   useEffect(() => {
-    closeDrawerRef.current = closeDrawer;
-  }, [closeDrawer]);
+    closeDrawerRef.current = dismissActive;
+  }, [dismissActive]);
 
   // Show/hide markers live as filters change. The creation effect binds markers
   // once; here we just add/remove each instance from the map by the visible set.
@@ -388,19 +435,23 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   }, []);
 
   // Opening the virtual list closes any open detail (they share the same slot),
-  // and vice versa, so at most one drawer is ever visible.
+  // and vice versa, so at most one drawer is ever visible. Freeze the spin so
+  // the globe holds still behind the reading surface, matching a marker detail.
   const openVirtualList = useCallback(() => {
     selectedMarkerIdRef.current = null;
     setSelectedHackathon(null);
     setVirtualOpen(true);
+    spinEnabledRef.current = false;
   }, []);
 
   // Virtual events have no coordinates, so they must NOT go through the marker
-  // fly-in path (which would fly to [null, null]). Just open the detail drawer.
+  // fly-in path (which would fly to [null, null]). Just open the detail drawer,
+  // keeping the spin frozen behind it (closeDrawer resumes it).
   const openVirtual = useCallback((h: Hackathon) => {
     selectedMarkerIdRef.current = null;
     setVirtualOpen(false);
     setSelectedHackathon(h);
+    spinEnabledRef.current = false;
   }, []);
 
   return (
@@ -424,7 +475,6 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
             it never fights the detail card or the Back-to-globe button. */}
         {hasToken && !selectedHackathon && !zoomedIn && (
           <GlobeFilterBar
-            located={located}
             query={query}
             onQueryChange={setQuery}
             activeStatuses={activeStatuses}
@@ -432,6 +482,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
             activeFormats={activeFormats}
             onToggleFormat={toggleFormat}
             virtualCount={visibleVirtual.length}
+            virtualButtonRef={virtualTriggerRef}
             onOpenVirtual={openVirtualList}
             onClearAll={clearAll}
           />
@@ -455,7 +506,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         <GlobeVirtualDrawer
           open={virtualOpen}
           hackathons={visibleVirtual}
-          onClose={() => setVirtualOpen(false)}
+          onClose={closeVirtual}
           onSelect={openVirtual}
         />
 

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { STATE_META, countdown, type Hackathon } from "@/lib/types-hq";
+import {
+  STATE_META,
+  countdown,
+  type HackState,
+  type Hackathon,
+} from "@/lib/types-hq";
 import { GlobeDetailDrawer } from "./globe-detail-drawer";
+import { GlobeFilterBar } from "./globe-filter-bar";
+import { GlobeVirtualDrawer } from "./globe-virtual-drawer";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
 
@@ -21,6 +28,8 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markerRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const markerInstances = useRef<Map<string, mapboxgl.Marker>>(new Map());
+  const popupRef = useRef<mapboxgl.Popup | null>(null);
   const selectedMarkerIdRef = useRef<string | null>(null);
   // Latest close handler, so the map-created "click" listener (bound once in
   // the effect) always calls the current one instead of a stale closure.
@@ -29,15 +38,68 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const [selectedHackathon, setSelectedHackathon] = useState<Hackathon | null>(
     null,
   );
+  const [query, setQuery] = useState("");
+  const [activeStatuses, setActiveStatuses] = useState<Set<HackState>>(
+    new Set(),
+  );
+  const [activeFormats, setActiveFormats] = useState<Set<Hackathon["format"]>>(
+    new Set(),
+  );
+  const [virtualOpen, setVirtualOpen] = useState(false);
   const hasToken = Boolean(mapboxgl.accessToken);
 
-  const located = hackathons.filter((h) => h.lat !== null && h.lng !== null);
+  const located = useMemo(
+    () => hackathons.filter((h) => h.lat !== null && h.lng !== null),
+    [hackathons],
+  );
 
   // Non-virtual listings we could not place. A virtual hackathon isn't missing
   // from the map — it has nowhere to be — so it doesn't count here.
   const unmapped = hackathons.filter(
     (h) => h.format !== "Virtual" && (h.lat === null || h.lng === null),
   ).length;
+
+  // Search + status apply everywhere (map pins and the virtual list). The
+  // format pills (In-Person / Hybrid) only narrow the map pins — "Virtual" is
+  // not a pin filter, it's the control that opens the online-events drawer.
+  const matchesQueryStatus = useCallback(
+    (h: Hackathon) => {
+      const q = query.toLowerCase().trim();
+      const okQuery =
+        !q ||
+        h.host.toLowerCase().includes(q) ||
+        h.title.toLowerCase().includes(q) ||
+        h.location.toLowerCase().includes(q);
+      const okStatus = activeStatuses.size === 0 || activeStatuses.has(h.state);
+      return okQuery && okStatus;
+    },
+    [query, activeStatuses],
+  );
+
+  const visibleIds = useMemo(
+    () =>
+      new Set(
+        located
+          .filter(matchesQueryStatus)
+          .filter(
+            (h) => activeFormats.size === 0 || activeFormats.has(h.format),
+          )
+          .map((h) => h.id),
+      ),
+    [located, matchesQueryStatus, activeFormats],
+  );
+
+  // Virtual events never get a marker (no coordinates), so they live in a
+  // dedicated drawer instead — this is how online-only events stay
+  // discoverable. They ignore the pin-only format filters.
+  const virtualList = useMemo(
+    () => hackathons.filter((h) => h.format === "Virtual" && h.state !== "closed"),
+    [hackathons],
+  );
+  const visibleVirtual = useMemo(
+    () => virtualList.filter(matchesQueryStatus),
+    [virtualList, matchesQueryStatus],
+  );
 
   useEffect(() => {
     if (!containerRef.current || !hasToken) return;
@@ -109,7 +171,9 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       className: "hq-popup",
       maxWidth: "280px",
     });
+    popupRef.current = popup;
     const markerMap = markerRefs.current;
+    const markerInstanceMap = markerInstances.current;
 
     function showPopup(h: Hackathon) {
       const meta = STATE_META[h.state];
@@ -148,6 +212,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
     function openHackathon(h: Hackathon) {
       selectedMarkerIdRef.current = h.id;
       setSelectedHackathon(h);
+      setVirtualOpen(false);
       spinEnabled = false;
       popup.remove();
       // On small screens the detail card is a bottom sheet, so reserve the
@@ -200,9 +265,11 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         openHackathon(h);
       });
 
-      return new mapboxgl.Marker({ element: el })
+      const marker = new mapboxgl.Marker({ element: el })
         .setLngLat([h.lng!, h.lat!])
         .addTo(map);
+      markerInstanceMap.set(h.id, marker);
+      return marker;
     });
 
     const restoreSpin = () => {
@@ -222,7 +289,9 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       globeEl.removeEventListener("hq:backToGlobe", restoreSpin);
       markers.forEach((m) => m.remove());
       markerMap.clear();
+      markerInstanceMap.clear();
       popup.remove();
+      popupRef.current = null;
       map.remove();
       mapRef.current = null;
     };
@@ -250,6 +319,21 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
     const markerId = selectedMarkerIdRef.current;
     selectedMarkerIdRef.current = null;
     setSelectedHackathon(null);
+    // On mobile, opening the detail card set a persistent 55% bottom padding
+    // (so the pin cleared the bottom sheet). If we leave it on close, the pin
+    // stays off-center and subsequent manual zoom/pan — especially zooming back
+    // out — is thrown off. Recenter by clearing the padding when the card goes.
+    const map = mapRef.current;
+    if (map) {
+      const reduced = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+      ).matches;
+      map.easeTo({
+        padding: { top: 0, right: 0, bottom: 0, left: 0 },
+        duration: reduced ? 0 : 300,
+        essential: true,
+      });
+    }
     if (!markerId) return;
     window.requestAnimationFrame(() => {
       markerRefs.current.get(markerId)?.focus({ preventScroll: true });
@@ -261,6 +345,63 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   useEffect(() => {
     closeDrawerRef.current = closeDrawer;
   }, [closeDrawer]);
+
+  // Show/hide markers live as filters change. The creation effect binds markers
+  // once; here we just add/remove each instance from the map by the visible set.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    markerInstances.current.forEach((marker, id) => {
+      if (visibleIds.has(id)) marker.addTo(map);
+      else marker.remove();
+    });
+    // A tooltip could be pinned to a marker we just hid.
+    popupRef.current?.remove();
+    // If the open detail belongs to a marker that no longer passes the filter,
+    // dismiss it so the drawer never describes a hidden pin.
+    const selId = selectedMarkerIdRef.current;
+    if (selId && !visibleIds.has(selId)) closeDrawer();
+  }, [visibleIds, closeDrawer]);
+
+  const toggleStatus = useCallback((s: HackState) => {
+    setActiveStatuses((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  }, []);
+
+  const toggleFormat = useCallback((f: Hackathon["format"]) => {
+    setActiveFormats((prev) => {
+      const next = new Set(prev);
+      if (next.has(f)) next.delete(f);
+      else next.add(f);
+      return next;
+    });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setQuery("");
+    setActiveStatuses(new Set());
+    setActiveFormats(new Set());
+  }, []);
+
+  // Opening the virtual list closes any open detail (they share the same slot),
+  // and vice versa, so at most one drawer is ever visible.
+  const openVirtualList = useCallback(() => {
+    selectedMarkerIdRef.current = null;
+    setSelectedHackathon(null);
+    setVirtualOpen(true);
+  }, []);
+
+  // Virtual events have no coordinates, so they must NOT go through the marker
+  // fly-in path (which would fly to [null, null]). Just open the detail drawer.
+  const openVirtual = useCallback((h: Hackathon) => {
+    selectedMarkerIdRef.current = null;
+    setVirtualOpen(false);
+    setSelectedHackathon(h);
+  }, []);
 
   return (
     <section id="globe" className="p-2 pt-0">
@@ -278,6 +419,24 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         {/* Legibility gradient */}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%] bg-gradient-to-t from-ink-deep/95 via-ink-deep/40 to-transparent" />
 
+        {/* Browsing tools - search + status/format filters + virtual list.
+            Hidden while a detail drawer is open or the camera is zoomed in, so
+            it never fights the detail card or the Back-to-globe button. */}
+        {hasToken && !selectedHackathon && !zoomedIn && (
+          <GlobeFilterBar
+            located={located}
+            query={query}
+            onQueryChange={setQuery}
+            activeStatuses={activeStatuses}
+            onToggleStatus={toggleStatus}
+            activeFormats={activeFormats}
+            onToggleFormat={toggleFormat}
+            virtualCount={visibleVirtual.length}
+            onOpenVirtual={openVirtualList}
+            onClearAll={clearAll}
+          />
+        )}
+
         {/* Back-to-globe (after a marker fly-in) */}
         {zoomedIn && (
           <button
@@ -291,6 +450,13 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         <GlobeDetailDrawer
           hackathon={selectedHackathon}
           onClose={closeDrawer}
+        />
+
+        <GlobeVirtualDrawer
+          open={virtualOpen}
+          hackathons={visibleVirtual}
+          onClose={() => setVirtualOpen(false)}
+          onSelect={openVirtual}
         />
 
         {/* Page title overlay - bottom-left */}

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -410,8 +410,11 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
     });
     // A tooltip could be pinned to a marker we just hid.
     popupRef.current?.remove();
-    // If the open detail belongs to a marker that no longer passes the filter,
-    // dismiss it so the drawer never describes a hidden pin.
+    // If the selected pin is no longer in the visible set, dismiss its detail so
+    // the drawer never describes a hidden pin. Filters can't change while a
+    // detail is open (the bar is hidden then), so this fires only when the
+    // `hackathons` data itself changes underneath an open card — defensive, but
+    // cheap.
     const selId = selectedMarkerIdRef.current;
     if (selId && !visibleIds.has(selId)) closeDrawer();
   }, [visibleIds, closeDrawer]);

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -258,8 +258,14 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       el.className = "hq-marker";
       el.dataset.state = h.state;
       el.tabIndex = 0;
-      el.role = "button";
-      el.ariaLabel = `Open details for ${h.title} in ${h.location}`;
+      // setAttribute, not the el.role / el.ariaLabel IDL props: those only map to
+      // the underlying attributes on browsers with ARIA reflection (roughly
+      // 2023+), so older engines would announce each pin as an unlabeled generic.
+      el.setAttribute("role", "button");
+      el.setAttribute(
+        "aria-label",
+        `Open details for ${h.title} in ${h.location}`,
+      );
       markerMap.set(h.id, el);
 
       el.addEventListener("mouseenter", () => showPopup(h));

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import mapboxgl from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import type { Hackathon } from "@/lib/types-hq";
-import { STATE_META, countdown } from "@/lib/types-hq";
+import { STATE_META, countdown, type Hackathon } from "@/lib/types-hq";
+import { GlobeDetailDrawer } from "./globe-detail-drawer";
 
 mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? "";
 
@@ -20,7 +20,15 @@ const SECONDS_PER_REVOLUTION = 110;
 export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map | null>(null);
+  const markerRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const selectedMarkerIdRef = useRef<string | null>(null);
+  // Latest close handler, so the map-created "click" listener (bound once in
+  // the effect) always calls the current one instead of a stale closure.
+  const closeDrawerRef = useRef<() => void>(() => {});
   const [zoomedIn, setZoomedIn] = useState(false);
+  const [selectedHackathon, setSelectedHackathon] = useState<Hackathon | null>(
+    null,
+  );
   const hasToken = Boolean(mapboxgl.accessToken);
 
   const located = hackathons.filter((h) => h.lat !== null && h.lng !== null);
@@ -101,60 +109,95 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       className: "hq-popup",
       maxWidth: "280px",
     });
+    const markerMap = markerRefs.current;
+
+    function showPopup(h: Hackathon) {
+      const meta = STATE_META[h.state];
+      const cd = countdown(h);
+
+      const root = document.createElement("div");
+
+      const statusRow = document.createElement("div");
+      statusRow.style.fontFamily = "var(--font-mono)";
+      statusRow.style.fontSize = "10px";
+      statusRow.style.letterSpacing = "0.22em";
+      statusRow.style.color = meta.color;
+      statusRow.style.marginBottom = "4px";
+      statusRow.textContent = `● ${meta.label}${cd ? ` · ${cd.toUpperCase()}` : ""}`;
+
+      const titleRow = document.createElement("div");
+      titleRow.style.fontWeight = "600";
+      titleRow.style.fontSize = "14px";
+      titleRow.style.lineHeight = "1.25";
+      titleRow.textContent = h.title;
+
+      const metaRow = document.createElement("div");
+      metaRow.style.fontSize = "12px";
+      metaRow.style.color = "#9ba1a5";
+      metaRow.style.marginTop = "3px";
+      metaRow.textContent = h.location;
+
+      root.append(statusRow, titleRow, metaRow);
+
+      popup
+        .setLngLat([h.lng!, h.lat!])
+        .setDOMContent(root)
+        .addTo(map);
+    }
+
+    function openHackathon(h: Hackathon) {
+      selectedMarkerIdRef.current = h.id;
+      setSelectedHackathon(h);
+      spinEnabled = false;
+      popup.remove();
+      // On small screens the detail card is a bottom sheet, so reserve the
+      // lower ~55% of the map with camera padding. flyTo then centers the pin
+      // in the remaining upper band, keeping it clear of the card. (offset is
+      // unreliable here with the globe projection + large zoom change.)
+      const smallScreen = window.matchMedia("(max-width: 767px)").matches;
+      map.flyTo({
+        center: [h.lng!, h.lat!],
+        zoom: 9.5,
+        // Respect prefers-reduced-motion: jump instead of a 2.6s fly. (The
+        // auto-spin is already disabled for these users; essential:true would
+        // otherwise force this animation to play regardless.)
+        duration: reducedMotion ? 0 : 2600,
+        essential: true,
+        padding: smallScreen
+          ? {
+              top: 0,
+              right: 0,
+              bottom: Math.round(map.getContainer().clientHeight * 0.55),
+              left: 0,
+            }
+          : { top: 0, right: 0, bottom: 0, left: 0 },
+      });
+    }
+
+    map.on("click", () => closeDrawerRef.current());
 
     const markers = located.map((h) => {
       const el = document.createElement("div");
       el.className = "hq-marker";
       el.dataset.state = h.state;
+      el.tabIndex = 0;
+      el.role = "button";
+      el.ariaLabel = `Open details for ${h.title} in ${h.location}`;
+      markerMap.set(h.id, el);
 
-      el.addEventListener("mouseenter", () => {
-        const meta = STATE_META[h.state];
-        const cd = countdown(h);
-
-        const root = document.createElement("div");
-
-        const statusRow = document.createElement("div");
-        statusRow.style.fontFamily = "var(--font-mono)";
-        statusRow.style.fontSize = "10px";
-        statusRow.style.letterSpacing = "0.22em";
-        statusRow.style.color = meta.color;
-        statusRow.style.marginBottom = "4px";
-        statusRow.textContent = `● ${meta.label}${cd ? ` · ${cd.toUpperCase()}` : ""}`;
-
-        const titleRow = document.createElement("div");
-        titleRow.style.fontWeight = "600";
-        titleRow.style.fontSize = "14px";
-        titleRow.style.lineHeight = "1.25";
-        titleRow.textContent = h.title;
-
-        const metaRow = document.createElement("div");
-        metaRow.style.fontSize = "12px";
-        metaRow.style.color = "#9ba1a5";
-        metaRow.style.marginTop = "3px";
-        metaRow.textContent = `${h.host} · ${h.location}`;
-
-        root.append(statusRow, titleRow, metaRow);
-
-        popup
-          .setLngLat([h.lng!, h.lat!])
-          .setDOMContent(root)
-          .addTo(map);
-      });
+      el.addEventListener("mouseenter", () => showPopup(h));
       el.addEventListener("mouseleave", () => popup.remove());
+      el.addEventListener("focus", () => showPopup(h));
+      el.addEventListener("blur", () => popup.remove());
       el.addEventListener("click", (e) => {
         e.stopPropagation();
-        spinEnabled = false;
-        popup.remove();
-        // Clicking a marker only flies the camera in — it deliberately does NOT
-        // open the detail card, which would cover the very map you just zoomed
-        // into. The hover popup carries the quick facts; full details live in
-        // the Deck / hackathons list.
-        map.flyTo({
-          center: [h.lng!, h.lat!],
-          zoom: 9.5,
-          duration: 2600,
-          essential: true,
-        });
+        openHackathon(h);
+      });
+      el.addEventListener("keydown", (e) => {
+        if (e.key !== "Enter" && e.key !== " ") return;
+        e.preventDefault();
+        e.stopPropagation();
+        openHackathon(h);
       });
 
       return new mapboxgl.Marker({ element: el })
@@ -178,6 +221,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       ro.disconnect();
       globeEl.removeEventListener("hq:backToGlobe", restoreSpin);
       markers.forEach((m) => m.remove());
+      markerMap.clear();
       popup.remove();
       map.remove();
       mapRef.current = null;
@@ -186,10 +230,37 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   }, [hasToken]);
 
   const backToGlobe = () => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     setZoomedIn(false);
-    mapRef.current?.flyTo({ ...GLOBE_VIEW, duration: 2400, essential: true });
+    setSelectedHackathon(null);
+    selectedMarkerIdRef.current = null;
+    mapRef.current?.flyTo({
+      ...GLOBE_VIEW,
+      duration: reduced ? 0 : 2400,
+      essential: true,
+      padding: { top: 0, right: 0, bottom: 0, left: 0 },
+    });
     containerRef.current?.dispatchEvent(new Event("hq:backToGlobe"));
   };
+
+  // Every dismiss path (Escape, close button, background click) routes here so
+  // focus always returns to the marker that opened the drawer (WCAG 2.4.3). If
+  // nothing is open the markerId is null and this is a no-op.
+  const closeDrawer = useCallback(() => {
+    const markerId = selectedMarkerIdRef.current;
+    selectedMarkerIdRef.current = null;
+    setSelectedHackathon(null);
+    if (!markerId) return;
+    window.requestAnimationFrame(() => {
+      markerRefs.current.get(markerId)?.focus({ preventScroll: true });
+    });
+  }, []);
+
+  // The map's "click" listener is bound once in the effect; keep the ref it
+  // calls pointed at the latest handler.
+  useEffect(() => {
+    closeDrawerRef.current = closeDrawer;
+  }, [closeDrawer]);
 
   return (
     <section id="globe" className="p-2 pt-0">
@@ -211,11 +282,16 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
         {zoomedIn && (
           <button
             onClick={backToGlobe}
-            className="glass-dark absolute right-6 top-6 z-10 rounded-full px-5 py-2.5 font-mono text-[11px] tracking-[0.2em] text-paper transition hover:bg-ink/80 sm:right-10 sm:top-9"
+            className="glass-dark absolute right-6 top-6 z-20 rounded-full px-5 py-2.5 font-mono text-[11px] tracking-[0.2em] text-paper transition hover:bg-ink/80 sm:right-10 sm:top-9"
           >
             ← BACK TO GLOBE
           </button>
         )}
+
+        <GlobeDetailDrawer
+          hackathon={selectedHackathon}
+          onClose={closeDrawer}
+        />
 
         {/* Page title overlay - bottom-left */}
         <div className="pointer-events-none absolute inset-x-0 bottom-0 p-6 sm:p-10">

--- a/web/components/hq/globe-virtual-drawer.tsx
+++ b/web/components/hq/globe-virtual-drawer.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { STATE_META, countdown, type Hackathon } from "@/lib/types-hq";
+
+type GlobeVirtualDrawerProps = {
+  open: boolean;
+  hackathons: Hackathon[];
+  onClose: () => void;
+  onSelect: (h: Hackathon) => void;
+};
+
+export function GlobeVirtualDrawer({
+  open,
+  hackathons,
+  onClose,
+  onSelect,
+}: GlobeVirtualDrawerProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    window.requestAnimationFrame(() => {
+      closeButtonRef.current?.focus();
+    });
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      // Return focus to the trigger (the Virtual button) on close (WCAG 2.4.3).
+      const prev = previousFocusRef.current;
+      if (prev && document.contains(prev)) prev.focus({ preventScroll: true });
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <aside
+      role="dialog"
+      aria-modal="false"
+      aria-label="Online events"
+      className="absolute inset-x-2 bottom-36 top-[20%] z-10 flex flex-col overflow-hidden rounded-3xl border border-white/15 bg-[rgba(23,19,15,0.92)] text-paper shadow-[0_20px_70px_rgba(0,0,0,0.55)] backdrop-blur-xl md:inset-x-auto md:right-6 md:bottom-auto md:top-24 md:max-h-[calc(100%-7.5rem)] md:w-[min(26rem,calc(100%-2rem))] md:rounded-[1.75rem]"
+    >
+      <div className="flex shrink-0 justify-center pt-2.5 md:hidden">
+        <span className="h-1.5 w-10 rounded-full bg-white/25" />
+      </div>
+
+      <div className="flex items-start justify-between gap-4 px-4 py-3 md:border-b md:border-white/10 md:px-5 md:py-4">
+        <div>
+          <div className="font-mono text-[10px] tracking-[0.22em] text-coral">
+            🌐 ONLINE EVENTS
+          </div>
+          <div className="mt-2 font-mono text-[10px] tracking-[0.2em] text-paper/45">
+            {hackathons.length} {hackathons.length === 1 ? "EVENT" : "EVENTS"} · NO
+            MAP PIN
+          </div>
+        </div>
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close online events"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-white/15 text-paper/70 transition hover:bg-white/10 hover:text-paper focus:outline-none focus:ring-2 focus:ring-coral md:h-9 md:w-9"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="rail-scroll flex-1 overflow-y-auto px-3 py-3 md:px-4 md:py-4">
+        {hackathons.length === 0 ? (
+          <p className="px-2 py-8 text-center text-sm text-paper/50">
+            No online events match your filters.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {hackathons.map((h) => {
+              const meta = STATE_META[h.state];
+              const cd = countdown(h);
+              return (
+                <li key={h.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(h)}
+                    className="flex w-full items-start gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-left transition hover:border-white/20 hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-coral"
+                  >
+                    <span
+                      className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                      style={{ background: meta.color }}
+                      aria-hidden
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm font-medium text-paper">
+                        {h.title}
+                      </span>
+                      <span className="mt-0.5 block truncate font-mono text-[10px] tracking-[0.14em] text-paper/50">
+                        {h.host}
+                        {cd ? ` · ${cd.toUpperCase()}` : ""}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/web/components/hq/globe-virtual-drawer.tsx
+++ b/web/components/hq/globe-virtual-drawer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { STATE_META, countdown, type Hackathon } from "@/lib/types-hq";
+import { useDialogDismiss } from "./use-dialog-dismiss";
 
 type GlobeVirtualDrawerProps = {
   open: boolean;
@@ -17,28 +18,13 @@ export function GlobeVirtualDrawer({
   onSelect,
 }: GlobeVirtualDrawerProps) {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    previousFocusRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    window.requestAnimationFrame(() => {
-      closeButtonRef.current?.focus();
-    });
-    return () => {
-      window.removeEventListener("keydown", onKey);
-      // Return focus to the trigger (the Virtual button) on close (WCAG 2.4.3).
-      const prev = previousFocusRef.current;
-      if (prev && document.contains(prev)) prev.focus({ preventScroll: true });
-    };
-  }, [open, onClose]);
+  // Escape closes, focus lands on the close button, and on close it returns to
+  // the trigger (the 🌐 VIRTUAL button) that opened the drawer (WCAG 2.4.3).
+  useDialogDismiss(open, onClose, {
+    initialFocusRef: closeButtonRef,
+    restoreFocus: true,
+  });
 
   if (!open) return null;
 

--- a/web/components/hq/use-dialog-dismiss.ts
+++ b/web/components/hq/use-dialog-dismiss.ts
@@ -1,0 +1,49 @@
+import { useEffect, type RefObject } from "react";
+
+type UseDialogDismissOptions<T extends HTMLElement> = {
+  /** Focused when the dialog opens — usually the close button. */
+  initialFocusRef: RefObject<T | null>;
+  /**
+   * Restore focus to whatever held it before opening, on close. Leave off when
+   * an outer owner returns focus itself (e.g. the globe detail drawer, whose
+   * opener in globe-map points focus back at the map pin / VIRTUAL trigger).
+   */
+  restoreFocus?: boolean;
+};
+
+/**
+ * The shared "non-modal dismiss" behaviour for the globe drawers: while open,
+ * Escape closes and focus moves to `initialFocusRef`; on close, focus optionally
+ * returns to the opener (WCAG 2.4.3). Deliberately minimal — no focus trap and
+ * no scroll lock, because these drawers leave the map interactive behind them.
+ *
+ * `onClose` must be stable (useCallback) — an unstable identity re-runs this
+ * effect on every parent render, and the restore-focus cleanup would then yank
+ * focus out of whatever the user is doing (e.g. typing in the filter search).
+ */
+export function useDialogDismiss<T extends HTMLElement>(
+  open: boolean,
+  onClose: () => void,
+  { initialFocusRef, restoreFocus = false }: UseDialogDismissOptions<T>,
+) {
+  useEffect(() => {
+    if (!open) return;
+    const previouslyFocused =
+      restoreFocus && document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    window.requestAnimationFrame(() => {
+      initialFocusRef.current?.focus();
+    });
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+    };
+  }, [open, onClose, initialFocusRef, restoreFocus]);
+}


### PR DESCRIPTION
Closes #17
Closes #18 

### Summary
- Add an interactive `GlobeDetailDrawer` with keyboard accessibility, focus restore, and consistent styling for hackathon details.
- Add a globe filter bar (search + status/format pills) that updates map pins live, plus an online-only drawer for virtual events.
- Improve mobile UX: two-row filter layout, hide filters when zoomed in or details open, correct counts based on mapped events, and reset camera padding on close.


### Test Plan
- Manual: /globe on mobile width (~375px)
- Filters render as two rows, no clipping
- Filter bar hides when a pin/detail is open or zoomed in
- CLOSING SOON (0) matches pins, virtual drawer shows online events
- Closing detail restores centered zoom/pan