### PR TITLE
docs: point MLH links at the evergreen canonical URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Hackathons are the fastest way to build something real, meet your future team, a
 
 ## Resources
 
-- [MLH Official Event Calendar](https://mlh.io/seasons/2027/events) — Major League Hacking's full season schedule
+- [MLH Official Event Calendar](https://www.mlh.com/events) — Major League Hacking's full season schedule
 - [Devpost Hackathons](https://devpost.com/hackathons) — online & in-person hackathons with submissions
 - [hackathon.com](https://www.hackathon.com/) — global hackathon directory
 - [Hackathon Survival Guide](https://github.com/Devang-25/Hackathon-Survival-Guide) — tips for first-timers

--- a/web/lib/resources.ts
+++ b/web/lib/resources.ts
@@ -36,7 +36,7 @@ export const RESOURCE_STAGES: ResourceStage[] = [
     links: [
       {
         title: "Major League Hacking",
-        href: "https://mlh.io/",
+        href: "https://www.mlh.com/",
         blurb: "The student hackathon circuit—events, community, and how seasons work.",
       },
       {
@@ -126,7 +126,7 @@ export const RESOURCE_STAGES: ResourceStage[] = [
     links: [
       {
         title: "MLH Event Calendar",
-        href: "https://mlh.io/events",
+        href: "https://www.mlh.com/events",
         blurb: "Plan a season instead of scrambling week to week.",
       },
       {
@@ -156,7 +156,7 @@ export const RESOURCE_STAGES: ResourceStage[] = [
     links: [
       {
         title: "MLH Coach & Mentor",
-        href: "https://mlh.io/coaches",
+        href: "https://www.mlh.com/coaches",
         blurb: "Paths into mentoring and coaching once you have a few weekends behind you.",
       },
       {


### PR DESCRIPTION
Closes #155

### Summary

@srirae reported the README's MLH calendar link as pointing at the 2026 season. Two corrections to that report, both verified:

- **The year was already fixed.** Line 143 already read `2027` — someone had bumped it before this issue was triaged.
- **`mlh.io` is not broken**, it 301s to `www.mlh.com`. So the link worked; it just took a redirect hop to a non-canonical host.

What was still worth fixing is the part that caused the report in the first place: **the season is pinned in the path**, so the link goes stale every rollover.

`https://www.mlh.com/events` redirects to the current season, so it survives the rollover on its own. Verified — it resolves 200 to `/seasons/2027/events` today.

### Changes

1. README's MLH Official Event Calendar → `www.mlh.com/events`
2. The three remaining `mlh.io` links in `web/lib/resources.ts` → their `mlh.com` targets. The `guide.mlh.io` links in that file were already normalised when the resources page landed; these were missed. Verified all three resolve 200.

### Deliberately not changed

`listings.json` has one entry still pointing at `mlh.io/seasons/2026/events` — the *Midnight Virtual Hackathon, Jul 17–19 2026*, which is `state: closed, active: false`. A 2026 event pointing at the 2026 season page is historically correct, so I left the archived record alone.

`ghw.mlh.io` links in the generated table are listing data and out of scope here.

### Test plan

- [ ] README Resources → MLH Official Event Calendar opens the current MLH season
- [ ] /resources → the three MLH links under stages 01, 04 and 05 all open

`tsc` and `vitest` (94/94) pass; the README section edited is outside the `HACKATHONS_TABLE` generated block, so automation won't overwrite it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)