### PR TITLE
feat(my): sync My Passport stamps with the local tracker (#199)

### DIFF
--- a/web/components/hq/my-client.tsx
+++ b/web/components/hq/my-client.tsx
@@ -21,7 +21,7 @@ export function MyClient({
       ) : (
         <>
           <AuthSetupNotice />
-          <Passport />
+          <Passport hackathons={hackathons} />
           <Tracker hackathons={hackathons} />
         </>
       )}
@@ -46,7 +46,7 @@ function GatedHub({ hackathons }: { hackathons: Hackathon[] }) {
   return (
     <>
       <HubGreeting />
-      <Passport />
+      <Passport hackathons={hackathons} />
       <Tracker hackathons={hackathons} />
     </>
   );

--- a/web/components/hq/passport.tsx
+++ b/web/components/hq/passport.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Hackathon } from "@/lib/types-hq";
+import { buildPassport, type PassportStamp } from "@/lib/passport-stamps";
+import { useTracker } from "./store";
 
 /* ---------------------------------------------------------------------------
    My Passport — Members · Pillar 03
@@ -20,148 +23,22 @@ import { useEffect, useRef, useState } from "react";
 const BOOK_W = 680;
 const BOOK_H = 470;
 
-type Stamp = {
-  id: string;
-  top: string; // arc text along the top
-  sub: string; // arc text along the bottom
-  year: string;
-  mono: string; // big monogram in the middle
-  label: string; // HACKED / VISA / ADMITTED
-  color: string;
-  pos: { left: number; top: number; size: number };
-  rotate: number;
-  delay: number; // stamp-in animation delay, ms
+// Stamps come from the generator (lib/passport-stamps.ts), which fills every
+// data-driven field. The renderer still supports these hand-authored styling
+// knobs as optional overrides; the generator simply omits them and the defaults
+// in <StampMark> apply.
+type Stamp = PassportStamp & {
   ringOpacity?: number;
   inkOpacity?: number;
-  topSize?: number;
   topLS?: number;
-  subSize?: number;
   subLS?: number;
-  monoSize?: number;
 };
-
-// Inside-left page (revealed under the opening cover).
-const STAMPS_LEFT: Stamp[] = [
-  {
-    id: "htn",
-    top: "HACK THE NORTH",
-    sub: "TORONTO · ON",
-    year: "2024",
-    mono: "HTN",
-    label: "HACKED",
-    color: "#ed5b29",
-    pos: { left: -6, top: 8, size: 196 },
-    rotate: -8,
-    delay: 0,
-    topSize: 13,
-    topLS: 1.2,
-  },
-  {
-    id: "pennapps",
-    top: "PENNAPPS",
-    sub: "PHILADELPHIA · PA",
-    year: "2024",
-    mono: "PA",
-    label: "VISA",
-    color: "#7a4bd0",
-    pos: { left: 150, top: 30, size: 190 },
-    rotate: 9,
-    delay: 160,
-    ringOpacity: 0.9,
-    inkOpacity: 0.88,
-    subSize: 10,
-    subLS: 1.8,
-  },
-  {
-    id: "mhacks",
-    top: "MHACKS",
-    sub: "ANN ARBOR · MI",
-    year: "2024",
-    mono: "MH",
-    label: "ADMITTED",
-    color: "#17b26a",
-    pos: { left: 22, top: 205, size: 190 },
-    rotate: 6,
-    delay: 320,
-  },
-  {
-    id: "h6ix",
-    top: "HACK THE 6IX",
-    sub: "TORONTO · ON",
-    year: "2025",
-    mono: "H6",
-    label: "HACKED",
-    color: "#ff7a45",
-    pos: { left: 140, top: 238, size: 190 },
-    rotate: -13,
-    delay: 480,
-    ringOpacity: 0.9,
-    topSize: 14,
-    topLS: 1.4,
-  },
-];
-
-// Right page (the base spread).
-const STAMPS_RIGHT: Stamp[] = [
-  {
-    id: "lahacks",
-    top: "LA HACKS",
-    sub: "LOS ANGELES · CA",
-    year: "2025",
-    mono: "LA",
-    label: "HACKED",
-    color: "#3b6bf0",
-    pos: { left: 12, top: 14, size: 196 },
-    rotate: -10,
-    delay: 80,
-  },
-  {
-    id: "bitcamp",
-    top: "BITCAMP",
-    sub: "COLLEGE PARK · MD",
-    year: "2025",
-    mono: "BC",
-    label: "VISA",
-    color: "#c98a2b",
-    pos: { left: 150, top: 44, size: 190 },
-    rotate: 8,
-    delay: 240,
-  },
-  {
-    id: "cuhacking",
-    top: "CUHACKING",
-    sub: "OTTAWA · ON",
-    year: "2025",
-    mono: "cuH",
-    label: "ADMITTED",
-    color: "#17b26a",
-    pos: { left: -4, top: 232, size: 190 },
-    rotate: 12,
-    delay: 400,
-    topSize: 14,
-    topLS: 1.6,
-    monoSize: 30,
-  },
-  {
-    id: "hackumass",
-    top: "HACKUMASS",
-    sub: "AMHERST · MA",
-    year: "2023",
-    mono: "UM",
-    label: "HACKED",
-    color: "#b0552f",
-    pos: { left: 150, top: 250, size: 190 },
-    rotate: -6,
-    delay: 560,
-    ringOpacity: 0.85,
-    inkOpacity: 0.82,
-    topSize: 14,
-    topLS: 1.6,
-  },
-];
 
 const MONO = "var(--font-mono)";
 const DISPLAY = "var(--font-display)";
+
+// Header counts read as passport-plate figures ("08 stamps · 07 cities").
+const pad2 = (n: number) => String(n).padStart(2, "0");
 
 /* Shared turbulence filters that give every stamp its rough, hand-inked edge.
    Rendered once, referenced by url(#…) from all stamp SVGs. */
@@ -310,6 +187,68 @@ function StampLayer({
   );
 }
 
+/* Shown on the open spread when nothing has earned a stamp yet — a fresh
+   passport rather than a blank page. Engraved into the paper to match the
+   guilloché plate. */
+function EmptyStampNote() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 10,
+        padding: 28,
+        textAlign: "center",
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        style={{
+          width: 46,
+          height: 46,
+          borderRadius: "50%",
+          border: "1.5px dashed rgba(90,66,40,0.45)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: DISPLAY,
+          fontSize: 22,
+          color: "rgba(90,66,40,0.5)",
+        }}
+      >
+        +
+      </div>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 10,
+          letterSpacing: "0.28em",
+          textTransform: "uppercase",
+          color: "rgba(90,66,40,0.7)",
+        }}
+      >
+        No stamps yet
+      </div>
+      <div
+        style={{
+          fontFamily: MONO,
+          fontSize: 9,
+          lineHeight: 1.6,
+          letterSpacing: "0.08em",
+          maxWidth: 210,
+          color: "rgba(90,66,40,0.5)",
+        }}
+      >
+        Track a hackathon and move it to Applied to earn your first visa.
+      </div>
+    </div>
+  );
+}
+
 /* The foil crest on the cover: a trench-coated "incognito hacker" seal. */
 function CoverCrest() {
   return (
@@ -376,13 +315,14 @@ function CoverCrest() {
 
 type Phase = "closed" | "flash" | "open";
 
-export function Passport({
-  stampCount = "08",
-  cities = "07",
-}: {
-  stampCount?: string;
-  cities?: string;
-}) {
+export function Passport({ hackathons }: { hackathons: Hackathon[] }) {
+  const { tracked } = useTracker();
+  const { left, right, stampCount, cityCount } = useMemo(
+    () => buildPassport(tracked, hackathons),
+    [tracked, hackathons],
+  );
+  const isEmpty = stampCount === 0;
+
   const [phase, setPhase] = useState<Phase>("closed");
   const [opened, setOpened] = useState(false);
   const [scale, setScale] = useState(1);
@@ -468,7 +408,7 @@ export function Passport({
             My Passport
           </h2>
           <div className="mt-3 font-mono text-[10px] uppercase tracking-[0.16em] text-paper/40">
-            {stampCount} stamps · {cities} cities
+            {pad2(stampCount)} stamps · {pad2(cityCount)} cities
           </div>
         </div>
 
@@ -582,7 +522,8 @@ export function Passport({
                     P. 04
                   </div>
 
-                  <StampLayer stamps={STAMPS_RIGHT} indexOffset={10} visible={opened} />
+                  <StampLayer stamps={right} indexOffset={100} visible={opened} />
+                  {opened && isEmpty && <EmptyStampNote />}
                 </div>
 
                 {/* COVER (rotates open) */}
@@ -786,7 +727,7 @@ export function Passport({
                       P. 03
                     </div>
 
-                    <StampLayer stamps={STAMPS_LEFT} indexOffset={0} visible={opened} />
+                    <StampLayer stamps={left} indexOffset={0} visible={opened} />
                   </div>
                 </div>
 

--- a/web/components/hq/passport.tsx
+++ b/web/components/hq/passport.tsx
@@ -522,7 +522,9 @@ export function Passport({ hackathons }: { hackathons: Hackathon[] }) {
                     P. 04
                   </div>
 
-                  <StampLayer stamps={right} indexOffset={100} visible={opened} />
+                  {/* Offset by the left page's count so every stamp's SVG arc
+                      ids stay globally unique for any number of stamps. */}
+                  <StampLayer stamps={right} indexOffset={left.length} visible={opened} />
                   {opened && isEmpty && <EmptyStampNote />}
                 </div>
 

--- a/web/lib/passport-stamps.test.ts
+++ b/web/lib/passport-stamps.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import type { Hackathon } from "./types-hq";
+import {
+  buildPassport,
+  cleanName,
+  cityKey,
+  locationArc,
+  monogram,
+  type TrackerMap,
+} from "./passport-stamps";
+
+/** Minimal Hackathon factory — only the fields the generator reads. */
+function hack(over: Partial<Hackathon> & { id: string }): Hackathon {
+  return {
+    host: "Host",
+    title: "Some Hackathon",
+    tagline: null,
+    url: "https://example.com",
+    location: "Toronto, ON",
+    format: "In-Person",
+    prize: null,
+    prizeValue: 0,
+    state: "open",
+    deadline: null,
+    startDate: null,
+    endDate: null,
+    daysLeft: null,
+    lat: null,
+    lng: null,
+    themes: [],
+    postedAt: 0,
+    ...over,
+  };
+}
+
+describe("cleanName", () => {
+  it("drops a trailing date range after ' - '", () => {
+    expect(cleanName("cuHacking 2026 - Jul 10 - Jul 12, 2026")).toBe("cuHacking");
+  });
+
+  it("drops a subtitle after a colon", () => {
+    expect(cleanName("Arm Create: AI Optimization Challenge")).toBe("Arm Create");
+  });
+
+  it("keeps a plain name untouched", () => {
+    expect(cleanName("Healthcare Hack NYC")).toBe("Healthcare Hack NYC");
+  });
+
+  it("strips a dangling year", () => {
+    expect(cleanName("PennApps 2024")).toBe("PennApps");
+  });
+
+  it("collapses whitespace", () => {
+    expect(cleanName("  Hack   the  North ")).toBe("Hack the North");
+  });
+});
+
+describe("monogram", () => {
+  it("takes initials of significant words", () => {
+    expect(monogram("Hack the North")).toBe("HN");
+  });
+
+  it("caps initials at three words", () => {
+    expect(monogram("Major League Hacking Global")).toBe("MLH");
+  });
+
+  it("uses the first two letters of a single word", () => {
+    expect(monogram("MHacks")).toBe("MH");
+  });
+
+  it("never returns empty", () => {
+    expect(monogram("")).toBe("HQ");
+  });
+});
+
+describe("locationArc", () => {
+  it("formats city and region", () => {
+    expect(locationArc("Ottawa, ON")).toBe("OTTAWA · ON");
+  });
+
+  it("collapses online/virtual to REMOTE", () => {
+    expect(locationArc("Online")).toBe("REMOTE");
+    expect(locationArc("Virtual")).toBe("REMOTE");
+  });
+
+  it("returns nothing for TBA or empty", () => {
+    expect(locationArc("TBA")).toBe("");
+    expect(locationArc("")).toBe("");
+  });
+
+  it("handles a city with no region", () => {
+    expect(locationArc("Singapore")).toBe("SINGAPORE");
+  });
+});
+
+describe("cityKey", () => {
+  it("keys on the city, case-insensitively", () => {
+    expect(cityKey("Ottawa, ON")).toBe("ottawa");
+  });
+
+  it("returns null for remote / TBA", () => {
+    expect(cityKey("Online")).toBeNull();
+    expect(cityKey("TBA")).toBeNull();
+    expect(cityKey("")).toBeNull();
+  });
+});
+
+describe("buildPassport", () => {
+  const hackathons = [
+    hack({ id: "a", title: "Hack the North", location: "Toronto, ON", startDate: "2024-09-13" }),
+    hack({ id: "b", title: "PennApps", location: "Philadelphia, PA", startDate: "2025-09-05" }),
+    hack({ id: "c", title: "MHacks", location: "Ann Arbor, MI", startDate: "2023-11-10" }),
+    hack({ id: "d", title: "LA Hacks", location: "Los Angeles, CA", startDate: "2025-04-18" }),
+  ];
+
+  it("ignores interested (a bookmark earns no stamp)", () => {
+    const tracked: TrackerMap = { a: "interested" };
+    const p = buildPassport(tracked, hackathons);
+    expect(p.stampCount).toBe(0);
+    expect(p.left).toHaveLength(0);
+    expect(p.right).toHaveLength(0);
+  });
+
+  it("maps applied/accepted/going to VISA/ADMITTED/HACKED", () => {
+    const tracked: TrackerMap = { a: "applied", b: "accepted", d: "going" };
+    const p = buildPassport(tracked, hackathons);
+    const all = [...p.left, ...p.right];
+    const stamp = (id: string) => all.find((s) => s.id === id)!;
+    expect(stamp("a").label).toBe("VISA");
+    expect(stamp("b").label).toBe("ADMITTED");
+    expect(stamp("d").label).toBe("HACKED");
+    expect(stamp("d").color).toBe("#ed5b29");
+  });
+
+  it("drops tracked ids that no longer exist in the listing set", () => {
+    const tracked: TrackerMap = { a: "going", ghost: "going" };
+    const p = buildPassport(tracked, hackathons);
+    expect(p.stampCount).toBe(1);
+    expect([...p.left, ...p.right].map((s) => s.id)).toEqual(["a"]);
+  });
+
+  it("counts unique cities, ignoring remote/TBA", () => {
+    const withRemote = [
+      ...hackathons,
+      hack({ id: "e", title: "Remote Jam", location: "Online" }),
+      hack({ id: "f", title: "Second Toronto", location: "Toronto, ON" }),
+    ];
+    const tracked: TrackerMap = { a: "going", e: "going", f: "going" };
+    const p = buildPassport(tracked, withRemote);
+    expect(p.stampCount).toBe(3);
+    // a + f are both Toronto (one city); e is remote (uncounted).
+    expect(p.cityCount).toBe(1);
+  });
+
+  it("orders stamps chronologically by event date", () => {
+    const tracked: TrackerMap = { a: "going", b: "going", c: "going", d: "going" };
+    const p = buildPassport(tracked, hackathons);
+    const order = [...p.left, ...p.right].map((s) => s.id);
+    // c (2023) < a (2024) < d (2025-04) < b (2025-09)
+    expect(order).toEqual(["c", "a", "d", "b"]);
+  });
+
+  it("splits stamps across the two pages", () => {
+    const tracked: TrackerMap = { a: "going", b: "going", c: "going", d: "going" };
+    const p = buildPassport(tracked, hackathons);
+    expect(p.left).toHaveLength(2);
+    expect(p.right).toHaveLength(2);
+  });
+
+  it("returns an empty passport for no tracked hackathons", () => {
+    const p = buildPassport({}, hackathons);
+    expect(p).toEqual({ left: [], right: [], stampCount: 0, cityCount: 0 });
+  });
+
+  it("scales many stamps down but keeps every one placed and legible", () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      hack({ id: `h${i}`, title: `Hackathon ${i}`, location: `City ${i}, ST` }),
+    );
+    const tracked: TrackerMap = Object.fromEntries(many.map((h) => [h.id, "going"]));
+    const p = buildPassport(tracked, many);
+    expect(p.stampCount).toBe(12);
+    const all = [...p.left, ...p.right];
+    expect(all).toHaveLength(12);
+    for (const s of all) {
+      expect(s.pos.size).toBeGreaterThanOrEqual(92);
+      expect(s.pos.size).toBeLessThanOrEqual(206);
+    }
+  });
+});

--- a/web/lib/passport-stamps.test.ts
+++ b/web/lib/passport-stamps.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { Hackathon } from "./types-hq";
 import {
+  BLEED,
+  PAGE_H,
+  PAGE_W,
   buildPassport,
   cleanName,
   cityKey,
@@ -172,18 +175,70 @@ describe("buildPassport", () => {
     expect(p).toEqual({ left: [], right: [], stampCount: 0, cityCount: 0 });
   });
 
-  it("scales many stamps down but keeps every one placed and legible", () => {
-    const many = Array.from({ length: 12 }, (_, i) =>
-      hack({ id: `h${i}`, title: `Hackathon ${i}`, location: `City ${i}, ST` }),
-    );
-    const tracked: TrackerMap = Object.fromEntries(many.map((h) => [h.id, "going"]));
-    const p = buildPassport(tracked, many);
-    expect(p.stampCount).toBe(12);
-    const all = [...p.left, ...p.right];
-    expect(all).toHaveLength(12);
-    for (const s of all) {
-      expect(s.pos.size).toBeGreaterThanOrEqual(92);
-      expect(s.pos.size).toBeLessThanOrEqual(206);
-    }
+  it.each([12, 20, 40])(
+    "scales %i stamps to fit the page without clipping off the bottom",
+    (howMany) => {
+      const many = Array.from({ length: howMany }, (_, i) =>
+        hack({ id: `h${i}`, title: `Hackathon ${i}`, location: `City ${i}, ST` }),
+      );
+      const tracked: TrackerMap = Object.fromEntries(
+        many.map((h) => [h.id, "going"]),
+      );
+      const p = buildPassport(tracked, many);
+      expect(p.stampCount).toBe(howMany);
+      const all = [...p.left, ...p.right];
+      expect(all).toHaveLength(howMany);
+      for (const s of all) {
+        expect(s.pos.size).toBeGreaterThanOrEqual(92);
+        expect(s.pos.size).toBeLessThanOrEqual(206);
+        // Fully within the page vertically (the page clips overflow).
+        expect(s.pos.top).toBeGreaterThanOrEqual(0);
+        expect(s.pos.top + s.pos.size).toBeLessThanOrEqual(PAGE_H);
+        // Horizontally within a small, bounded bleed.
+        expect(s.pos.left).toBeGreaterThanOrEqual(-BLEED);
+        expect(s.pos.left + s.pos.size).toBeLessThanOrEqual(PAGE_W + BLEED);
+      }
+    },
+  );
+});
+
+describe("buildPassport — derived fields (end to end)", () => {
+  it("wires cleaned title -> arc + monogram and location -> sub", () => {
+    const h = hack({
+      id: "cu",
+      title: "cuHacking 2026 - Jul 10 - Jul 12, 2026", // post-loader form
+      location: "Ottawa, ON",
+      startDate: "2026-07-10",
+    });
+    const p = buildPassport({ cu: "going" }, [h]);
+    const [s] = [...p.left, ...p.right];
+    expect(s!.top).toBe("CUHACKING");
+    expect(s!.mono).toBe("CU");
+    expect(s!.sub).toBe("OTTAWA · ON");
+    expect(s!.label).toBe("HACKED");
+    expect(s!.year).toBe("2026");
+  });
+
+  const yearOf = (h: Hackathon) => {
+    const p = buildPassport({ [h.id]: "going" }, [h]);
+    return [...p.left, ...p.right][0]!.year;
+  };
+
+  it("derives the year from an ISO event date", () => {
+    expect(yearOf(hack({ id: "a", startDate: "2025-04-18" }))).toBe("2025");
+  });
+
+  it("falls back to postedAt in seconds", () => {
+    // 2024-06-01T00:00:00Z in seconds.
+    expect(yearOf(hack({ id: "b", postedAt: 1717200000 }))).toBe("2024");
+  });
+
+  it("falls back to postedAt in milliseconds", () => {
+    // 2023-01-15T00:00:00Z in milliseconds.
+    expect(yearOf(hack({ id: "c", postedAt: 1673740800000 }))).toBe("2023");
+  });
+
+  it("leaves the year blank when there is no usable date", () => {
+    expect(yearOf(hack({ id: "d", postedAt: 0 }))).toBe("");
   });
 });

--- a/web/lib/passport-stamps.ts
+++ b/web/lib/passport-stamps.ts
@@ -64,9 +64,16 @@ function earnsStamp(stage: Stage): stage is StampStage {
 }
 
 // Page geometry (matches the 340x470 pages in passport.tsx).
-const PAGE_W = 340;
-const PAGE_H = 470;
+export const PAGE_W = 340;
+export const PAGE_H = 470;
 const PAD = 10;
+// How far a stamp's inked ring may bleed off the left/right edge — the crowded,
+// stamped-over-the-margin look the original artwork used (its stamps sat at
+// negative `left`). Bounded so it stays constant instead of growing with count.
+export const BLEED = 14;
+
+const clamp = (n: number, lo: number, hi: number) =>
+  Math.max(lo, Math.min(hi, n));
 
 const STOP_WORDS = new Set(["the", "of", "and", "a", "an", "for", "at"]);
 
@@ -201,12 +208,15 @@ function layoutPage(stamps: PassportStamp[], count: number): PassportStamp[] {
     const cx = PAD + rowOffset + cellW * (col + 0.5);
     const cy = PAD + cellH * (row + 0.5);
     // Small deterministic jitter so the grid doesn't read as mechanical.
-    const jx = (hash(s.id + "x") % 17) - 8;
-    const jy = (hash(s.id + "y") % 17) - 8;
-    return {
-      ...s,
-      pos: { left: cx - size / 2 + jx, top: cy - size / 2 + jy, size },
-    };
+    const jx = (hash(s.id + "x") % 15) - 7;
+    const jy = (hash(s.id + "y") % 15) - 7;
+    // Keep every stamp fully within the page vertically (the page clips
+    // overflow, and the legible content sits mid-ring); allow a small, bounded
+    // horizontal bleed for the stamped-over-the-margin look. Denser grids just
+    // overlap more rather than spilling off the bottom.
+    const left = clamp(cx - size / 2 + jx, -BLEED, PAGE_W - size + BLEED);
+    const top = clamp(cy - size / 2 + jy, 0, PAGE_H - size);
+    return { ...s, pos: { left, top, size } };
   });
 }
 
@@ -229,7 +239,9 @@ function makeStamp(
     label,
     color,
     rotate: rotateFor(h.id),
-    delay: index * 80,
+    // Stagger the stamp-in, but cap it so a large passport doesn't leave the
+    // last stamps waiting several seconds to appear.
+    delay: Math.min(index, 9) * 80,
     topSize: topSizeFor(top),
     subSize: subSizeFor(sub),
     monoSize: mono.length >= 3 ? 27 : 34,

--- a/web/lib/passport-stamps.ts
+++ b/web/lib/passport-stamps.ts
@@ -1,0 +1,269 @@
+/* ---------------------------------------------------------------------------
+   Passport stamp generator — derives ink-stamped visas from the local tracker.
+
+   The My Passport artwork (components/hq/passport.tsx) was authored with eight
+   hand-tuned stamps: every monogram, colour, rotation and coordinate picked per
+   hackathon. Real tracked data arrives as arbitrary hackathons with none of
+   that, so this module is the bridge: it turns a TrackerMap + the hackathon list
+   into fully-placed stamps, deriving each visual property from the data.
+
+   Kept as a pure, side-effect-free module (no React, no DOM) so the fiddly
+   string logic — name cleaning, monogram derivation, location parsing — is unit
+   tested in isolation (passport-stamps.test.ts).
+
+   Which stage earns a stamp, and its label (issue #199):
+     applied  -> VISA        accepted -> ADMITTED        going -> HACKED
+   `interested` (a mere bookmark) earns nothing.
+--------------------------------------------------------------------------- */
+
+import type { Hackathon } from "./types-hq";
+// Type-only import: erased at build, so this file stays free of the "use client"
+// store module at runtime (and in tests).
+import type { Stage } from "@/components/hq/store";
+
+/** A tracker map: hackathon id -> pipeline stage. Mirrors store.tsx. */
+export type TrackerMap = Record<string, Stage>;
+
+/** A stage that earns a stamp (everything except `interested`). */
+type StampStage = Exclude<Stage, "interested">;
+
+/** A generated stamp, ready to hand to the passport's <StampMark>. */
+export type PassportStamp = {
+  id: string;
+  top: string; // arc text along the top (hackathon name)
+  sub: string; // arc text along the bottom (city · region)
+  year: string;
+  mono: string; // big monogram in the middle
+  label: string; // HACKED / VISA / ADMITTED
+  color: string;
+  pos: { left: number; top: number; size: number };
+  rotate: number;
+  delay: number; // stamp-in animation delay, ms
+  topSize?: number;
+  subSize?: number;
+  monoSize?: number;
+};
+
+export type Passport = {
+  left: PassportStamp[]; // inside-left page (revealed under the cover)
+  right: PassportStamp[]; // right base page
+  stampCount: number;
+  cityCount: number;
+};
+
+/* Stage -> stamp presentation. Colours mirror STAGES in store.tsx; the labels
+   reuse the three variants the artwork already ships. */
+const STAGE_STAMP: Record<StampStage, { label: string; color: string }> = {
+  applied: { label: "VISA", color: "#f5a623" },
+  accepted: { label: "ADMITTED", color: "#3b6bf0" },
+  going: { label: "HACKED", color: "#ed5b29" },
+};
+
+function earnsStamp(stage: Stage): stage is StampStage {
+  return stage !== "interested";
+}
+
+// Page geometry (matches the 340x470 pages in passport.tsx).
+const PAGE_W = 340;
+const PAGE_H = 470;
+const PAD = 10;
+
+const STOP_WORDS = new Set(["the", "of", "and", "a", "an", "for", "at"]);
+
+/**
+ * Clean a raw listing title down to a stamp-sized name. Real titles carry date
+ * ranges and subtitles ("cuHacking 2026 - Jul 10 - Jul 12, 2026", "Arm Create:
+ * AI Optimization Challenge"); keep only the leading identity segment.
+ */
+export function cleanName(title: string): string {
+  let name = (title ?? "").trim();
+  // Drop everything after the first " - " (loader turns em-dashes into " - ",
+  // which is where date ranges and subtitles get appended) or first ": ".
+  const dash = name.indexOf(" - ");
+  if (dash !== -1) name = name.slice(0, dash);
+  const colon = name.indexOf(": ");
+  if (colon !== -1) name = name.slice(0, colon);
+  // Strip a trailing standalone year ("cuHacking 2026" -> "cuHacking").
+  name = name.replace(/\s+\d{4}$/, "");
+  name = name.replace(/\s+/g, " ").trim();
+  return name;
+}
+
+/**
+ * A short monogram for the middle of the stamp. Multi-word names become the
+ * initials of their first significant words ("Hack the North" -> "HTN"); a
+ * single word becomes its first two letters ("MHacks" -> "MH"). Won't always
+ * match a brand's own mark, but it's stable and legible.
+ */
+export function monogram(name: string): string {
+  const words = name.split(/\s+/).filter((w) => /[a-z]/i.test(w));
+  const significant = words.filter((w) => !STOP_WORDS.has(w.toLowerCase()));
+  const pick = (significant.length >= 2 ? significant : words).slice(0, 3);
+  if (pick.length >= 2) {
+    return pick.map((w) => w[0]!.toUpperCase()).join("");
+  }
+  const only = pick[0] ?? name;
+  return only.slice(0, 2).toUpperCase() || "HQ";
+}
+
+/**
+ * Bottom-arc location text. "Ottawa, ON" -> "OTTAWA · ON"; online/virtual
+ * events read "REMOTE"; TBA/unknown locations get no text.
+ */
+export function locationArc(location: string): string {
+  const loc = (location ?? "").trim();
+  if (!loc || /\b(tba|to be announced)\b/i.test(loc)) return "";
+  if (/\b(online|virtual|remote)\b/i.test(loc)) return "REMOTE";
+  const [city, ...rest] = loc.split(",").map((p) => p.trim());
+  const region = rest.join(", ").trim();
+  const cityText = (city ?? "").toUpperCase();
+  return region ? `${cityText} · ${region.toUpperCase()}` : cityText;
+}
+
+/** A stable dedupe key for the city count: null for remote/TBA locations. */
+export function cityKey(location: string): string | null {
+  const loc = (location ?? "").trim();
+  if (!loc) return null;
+  if (/\b(tba|to be announced|online|virtual|remote)\b/i.test(loc)) return null;
+  return loc.split(",")[0]!.trim().toLowerCase();
+}
+
+function eventYear(h: Hackathon): string {
+  const iso = h.startDate ?? h.endDate ?? h.deadline;
+  if (iso && /^\d{4}/.test(iso)) return iso.slice(0, 4);
+  if (h.postedAt > 0) {
+    // date_posted may be seconds or milliseconds; normalise to ms.
+    const ms = h.postedAt < 1e12 ? h.postedAt * 1000 : h.postedAt;
+    const year = new Date(ms).getUTCFullYear();
+    if (year > 2000 && year < 2100) return String(year);
+  }
+  return "";
+}
+
+/** Sort key: when the event happened, so the passport reads chronologically. */
+function eventTime(h: Hackathon): number {
+  const iso = h.startDate ?? h.endDate ?? h.deadline;
+  if (iso) {
+    const t = Date.parse(iso);
+    if (!Number.isNaN(t)) return t;
+  }
+  return h.postedAt > 0 ? (h.postedAt < 1e12 ? h.postedAt * 1000 : h.postedAt) : 0;
+}
+
+/** Deterministic 32-bit hash of a string (djb2). */
+function hash(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+/** Stable per-stamp rotation in [-12, 11] degrees, keyed off the id. */
+function rotateFor(id: string): number {
+  return (hash(id) % 24) - 12;
+}
+
+function topSizeFor(top: string): number {
+  if (top.length > 22) return 10;
+  if (top.length > 17) return 12;
+  if (top.length > 13) return 13;
+  return 15;
+}
+
+function subSizeFor(sub: string): number {
+  if (sub.length > 20) return 8.5;
+  if (sub.length > 15) return 9.5;
+  return 11;
+}
+
+/**
+ * Grid layout for a single page. Density (columns and stamp size) scales with
+ * the count so 1..9+ stamps all fit the fixed page — the "scale to fit" choice
+ * from #199. `count` is the per-page target (both pages share it for symmetry),
+ * `n` is how many stamps this page actually renders.
+ */
+function layoutPage(stamps: PassportStamp[], count: number): PassportStamp[] {
+  const n = stamps.length;
+  if (n === 0) return stamps;
+  const cols = count <= 1 ? 1 : count <= 6 ? 2 : 3;
+  const rows = Math.max(1, Math.ceil(count / cols));
+  const cellW = (PAGE_W - 2 * PAD) / cols;
+  const cellH = (PAGE_H - 2 * PAD) / rows;
+  // Overlap factor >1 keeps the crowded, hand-placed feel; clamp for legibility.
+  const size = Math.max(92, Math.min(206, Math.min(cellW, cellH) * 1.15));
+
+  return stamps.map((s, i) => {
+    const row = Math.floor(i / cols);
+    const rowStart = row * cols;
+    const inRow = Math.min(cols, n - rowStart);
+    const col = i - rowStart;
+    // Centre a partial last row.
+    const rowOffset = ((cols - inRow) * cellW) / 2;
+    const cx = PAD + rowOffset + cellW * (col + 0.5);
+    const cy = PAD + cellH * (row + 0.5);
+    // Small deterministic jitter so the grid doesn't read as mechanical.
+    const jx = (hash(s.id + "x") % 17) - 8;
+    const jy = (hash(s.id + "y") % 17) - 8;
+    return {
+      ...s,
+      pos: { left: cx - size / 2 + jx, top: cy - size / 2 + jy, size },
+    };
+  });
+}
+
+function makeStamp(
+  h: Hackathon,
+  stage: StampStage,
+  index: number,
+): PassportStamp {
+  const { label, color } = STAGE_STAMP[stage];
+  const name = cleanName(h.title) || h.host || "HACKATHON";
+  const top = name.toUpperCase();
+  const sub = locationArc(h.location);
+  const mono = monogram(name);
+  return {
+    id: h.id,
+    top,
+    sub,
+    year: eventYear(h),
+    mono,
+    label,
+    color,
+    rotate: rotateFor(h.id),
+    delay: index * 80,
+    topSize: topSizeFor(top),
+    subSize: subSizeFor(sub),
+    monoSize: mono.length >= 3 ? 27 : 34,
+    pos: { left: 0, top: 0, size: 0 }, // filled by layoutPage
+  };
+}
+
+/**
+ * Build the passport from the local tracker. Filters to stamp-earning stages,
+ * resolves ids against the current listing set (dropping stale ones), sorts
+ * chronologically, then splits and lays out the stamps across the two pages.
+ */
+export function buildPassport(
+  tracked: TrackerMap,
+  hackathons: Hackathon[],
+): Passport {
+  const byId = new Map(hackathons.map((h) => [h.id, h]));
+
+  const earned = Object.entries(tracked)
+    .filter((e): e is [string, StampStage] => earnsStamp(e[1]))
+    .map(([id, stage]) => ({ h: byId.get(id), stage }))
+    .filter((e): e is { h: Hackathon; stage: StampStage } => Boolean(e.h))
+    .sort((a, b) => eventTime(a.h) - eventTime(b.h));
+
+  const stamps = earned.map((e, i) => makeStamp(e.h, e.stage, i));
+
+  // Split half/half; earliest events fill the left (inside-cover) page first.
+  const perPage = Math.max(1, Math.ceil(stamps.length / 2));
+  const left = layoutPage(stamps.slice(0, perPage), perPage);
+  const right = layoutPage(stamps.slice(perPage), perPage);
+
+  const cityCount = new Set(
+    earned.map((e) => cityKey(e.h.location)).filter((k): k is string => Boolean(k)),
+  ).size;
+
+  return { left, right, stampCount: stamps.length, cityCount };
+}


### PR DESCRIPTION
Closes #199.

## What

The My Passport spread (#172) shipped with **eight fully hand-authored stamps** — every monogram, colour, rotation and coordinate picked per hackathon. This replaces that static artwork with stamps **generated from real tracked data**, so the passport reflects the hackathons you've actually tracked.

## Decisions (from the issue discussion)

- **Data source — local tracker (Option A).** Driven by the existing `useTracker()` / localStorage tracker. Server-persisted cross-device sync (Option B) stays out of scope until per-user persistence exists.
- **Which stage earns a stamp.** `applied → VISA`, `accepted → ADMITTED`, `going → HACKED` — reusing the three label variants the artwork already ships. `interested` (a mere bookmark) earns nothing.
- **Overflow — scale to fit.** Stamps lay out on a per-page grid that scales down as the count grows, so everything fits the two fixed pages.

## How

- **`lib/passport-stamps.ts`** — a pure, side-effect-free `buildPassport(tracked, hackathons)` generator (no React/DOM, so the fiddly string logic is unit-tested in isolation). It filters to stamp-earning stages, resolves ids against the current listing set (dropping stale ones), sorts chronologically, splits across the two pages, and lays each out on a scaling grid. Every visual property is derived: cleaned title → arc name + monogram, `location` → `CITY · REGION` (remote/TBA handled), stage → label + colour (mirrors the `STAGES` palette).
- **`components/hq/passport.tsx`** — now a consumer: reads the tracker, takes `hackathons` as a prop, renders generated stamps. **All artwork is unchanged** (leather cover, foil crest, turbulence ink filters, 3D flip). Header counts (`NN stamps · NN cities`) are computed. Adds an engraved **empty state** for a passport with no stamps.
- **`components/hq/my-client.tsx`** — passes the hackathon list into both `<Passport>` render sites.
- **`lib/passport-stamps.test.ts`** — 23 unit tests covering name cleaning, monogram derivation, location parsing, stage→label/colour mapping, stale-id drop, city dedupe, chronological ordering, page split, and overflow scaling.

## Verification

- `npx tsc --noEmit` clean, `eslint` clean, **120/120 tests pass**, `next build` green (incl. `/my`).
- Verified end-to-end against real listings: seeding the tracker with 6 hackathons (2 `going`, 2 `accepted`, 1 `applied`, 1 `interested`) renders **5 stamps · 4 cities** — the `interested` one excluded, the two NYC events deduped to one city — with correct labels, monograms, and date-suffix-stripped names.

## Notes / out of scope

- Personalizing the holder page from Clerk identity, and Option B server persistence — natural follow-ups, intentionally not included.