### PR TITLE
security: code-level hardening batch (#205–#211)

### DIFF
--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -29,6 +29,10 @@ except ImportError:
 
 
 MAX_REDIRECTS = 5
+# Hard ceiling on a fetched page body. A submitted URL is attacker-influenced,
+# so cap how much we download to stop a multi-GB body or a compression bomb from
+# OOM-ing the runner (this path also runs unattended via deadline_watcher.py).
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
 def _resolve_and_validate(host):
@@ -181,14 +185,58 @@ def _build_pinned_session(host, pinned_ip):
     return session
 
 
+def _read_capped(response, max_bytes=MAX_RESPONSE_BYTES):
+    """Read a streamed response body into memory, bounded by ``max_bytes``.
+
+    ``requests`` decompresses gzip/deflate/br while iterating, so the cap applies
+    to the *decompressed* size — this defeats a small compression bomb as well as
+    a plain multi-GB body. Populates ``response._content`` so downstream
+    ``response.text`` / ``.content`` keep working. Fails closed past the cap.
+    """
+    declared = response.headers.get("Content-Length")
+    if declared is not None:
+        try:
+            declared_int = int(declared)
+        except (TypeError, ValueError):
+            declared_int = None
+        if declared_int is not None and declared_int > max_bytes:
+            response.close()
+            raise ValueError(
+                f"Response Content-Length {declared} exceeds {max_bytes}-byte cap; refusing to fetch"
+            )
+    total = 0
+    chunks = []
+    for chunk in response.iter_content(chunk_size=65536):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_bytes:
+            response.close()
+            raise ValueError(
+                f"Response body exceeds {max_bytes}-byte cap; refusing to fetch"
+            )
+        chunks.append(chunk)
+    # Inject the fully-read body so response.text/.content work without a second
+    # (already-consumed) network read.
+    response._content = b"".join(chunks)
+    response._content_consumed = True
+    return response
+
+
 def _get_with_retries(session, url, headers, timeout, retries=2, backoff=1.5):
-    """GET a single URL, retrying only transient network errors with backoff."""
+    """GET a single URL, retrying only transient network errors with backoff.
+
+    Streams the body and reads it under a size cap (:func:`_read_capped`) so an
+    oversized or compression-bomb response is rejected instead of buffered whole.
+    """
     last_exc = None
     for attempt in range(retries + 1):
         try:
-            return session.get(
-                url, headers=headers, timeout=timeout, allow_redirects=False
+            response = session.get(
+                url, headers=headers, timeout=timeout, allow_redirects=False,
+                stream=True,
             )
+            return _read_capped(response)
         except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
             last_exc = e
             if attempt < retries:

--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -538,10 +538,11 @@ def main():
     if fmt not in util.VALID_FORMATS:
         fmt = "In-Person"
 
-    # Sanitize locations — remove any that look like URLs or HTML
+    # Sanitize locations — strip control chars / collapse whitespace / truncate
+    # (sanitize_field), then drop any that look like URLs or HTML.
     clean_locations = []
     for loc in locations:
-        loc = loc.strip()
+        loc = util.sanitize_field(loc)
         if loc and not loc.startswith("http") and "<" not in loc:
             clean_locations.append(loc)
     if not clean_locations:
@@ -582,7 +583,7 @@ def main():
         "url": url,
         "locations": locations,
         "format": fmt,
-        "prize": extracted.get("prize", "—") or "—",
+        "prize": util.sanitize_field(extracted.get("prize")) or "—",
         "state": state,
         "active": state != "closed",
         "is_visible": True,

--- a/.github/scripts/auto_extract.py
+++ b/.github/scripts/auto_extract.py
@@ -50,9 +50,15 @@ def _resolve_and_validate(host):
             ip = ipaddress.ip_address(ip_str)
         except ValueError:
             return False, f"Unresolvable address for host: {host}", frozenset(), None
-        if (ip.is_private or ip.is_loopback or ip.is_link_local
-                or ip.is_reserved or ip.is_multicast or ip.is_unspecified):
-            return False, f"Refusing to fetch internal address {ip} (host {host})", frozenset(), None
+        # Allowlist: only fetch globally-routable public addresses. `is_global`
+        # is False for the private/loopback/link-local/reserved/multicast ranges
+        # AND for CGNAT (100.64.0.0/10) and benchmark (198.18.0.0/15) space that
+        # a bare denylist misses. The explicit predicates are kept as belt-and-
+        # suspenders defense in case of a future is_global edge case.
+        if (not ip.is_global or ip.is_private or ip.is_loopback
+                or ip.is_link_local or ip.is_reserved or ip.is_multicast
+                or ip.is_unspecified):
+            return False, f"Refusing to fetch non-global address {ip} (host {host})", frozenset(), None
         ips.append(ip_str)
     if not ips:
         return False, f"Could not resolve host: {host}", frozenset(), None

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -298,6 +298,44 @@ class SsrfGuard(unittest.TestCase):
         self.assertFalse(ok)
 
 
+class ResponseSizeCap(unittest.TestCase):
+    """Fetch caps the body to defeat multi-GB responses / compression bombs."""
+
+    class _FakeResp:
+        def __init__(self, chunks, headers=None):
+            self._chunks = chunks
+            self.headers = headers or {}
+            self.closed = False
+            self._content = None
+            self._content_consumed = False
+
+        def iter_content(self, chunk_size=65536):
+            yield from self._chunks
+
+        def close(self):
+            self.closed = True
+
+    def test_reads_body_under_cap(self):
+        resp = self._FakeResp([b"a" * 100, b"b" * 100])
+        out = ax._read_capped(resp, max_bytes=1000)
+        self.assertEqual(out._content, b"a" * 100 + b"b" * 100)
+        self.assertTrue(out._content_consumed)
+
+    def test_rejects_body_over_cap(self):
+        # Simulates a decompression bomb: chunks (already decompressed by
+        # requests) accumulate past the cap.
+        resp = self._FakeResp([b"x" * 600, b"x" * 600])
+        with self.assertRaises(ValueError):
+            ax._read_capped(resp, max_bytes=1000)
+        self.assertTrue(resp.closed)
+
+    def test_rejects_declared_content_length_over_cap(self):
+        resp = self._FakeResp([b"x"], headers={"Content-Length": str(10_000)})
+        with self.assertRaises(ValueError):
+            ax._read_capped(resp, max_bytes=1000)
+        self.assertTrue(resp.closed)
+
+
 class SsrfDnsRebinding(unittest.TestCase):
     """Regression tests for the check-then-connect (TOCTOU) SSRF gap, issue #74."""
 

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -286,6 +286,13 @@ class SsrfGuard(unittest.TestCase):
             ok, _ = ax._resolved_ips_are_public(host)
             self.assertFalse(ok, f"{host} should be blocked")
 
+    def test_blocks_cgnat_and_benchmark_ranges(self):
+        # A bare private/loopback/... denylist misses CGNAT (100.64.0.0/10) and
+        # benchmark (198.18.0.0/15); the is_global allowlist catches them.
+        for host in ("100.64.0.1", "198.18.0.5"):
+            ok, _ = ax._resolved_ips_are_public(host)
+            self.assertFalse(ok, f"{host} should be blocked")
+
     def test_rejects_non_http_scheme(self):
         ok, _ = ax._validate_fetch_url("file:///etc/passwd")
         self.assertFalse(ok)

--- a/.github/workflows/auto_extract.yml
+++ b/.github/workflows/auto_extract.yml
@@ -121,14 +121,25 @@ jobs:
 
             const warning = process.env.WARNING_MSG || '';
 
+            // Escape model-derived values before dropping them into the markdown
+            // table: strip newlines and escape pipes so an attacker-influenced
+            // extracted field can't break the table or inject markdown (#211).
+            const cell = (v) => {
+              const s = String(v ?? '').replace(/\r?\n/g, ' ').replace(/\|/g, '\\|').trim();
+              return s || 'Unknown';
+            };
+            const locations = Array.isArray(extractedData.locations)
+              ? extractedData.locations
+              : ['Unknown'];
+
             let body = `## Opportunity Added Successfully!\n\n`;
             body += `| Field | Value |\n`;
             body += `|-------|-------|\n`;
-            body += `| **Company** | ${extractedData.company_name || 'Unknown'} |\n`;
-            body += `| **Role** | ${extractedData.title || 'Unknown'} |\n`;
-            body += `| **Category** | ${extractedData.category || 'Unknown'} |\n`;
-            body += `| **Location** | ${(extractedData.locations || ['Unknown']).join(', ')} |\n`;
-            body += `| **Season** | ${extractedData.season || 'Unknown'} |\n\n`;
+            body += `| **Company** | ${cell(extractedData.company_name)} |\n`;
+            body += `| **Role** | ${cell(extractedData.title)} |\n`;
+            body += `| **Category** | ${cell(extractedData.category)} |\n`;
+            body += `| **Location** | ${cell(locations.join(', '))} |\n`;
+            body += `| **Season** | ${cell(extractedData.season)} |\n\n`;
 
             if (warning) {
               body += `> Note: ${warning}\n\n`;

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Syncopate, Inter, Space_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
-import { validateEnv } from "@/lib/env";
+import { isClerkConfigured, validateEnv } from "@/lib/env";
 import "./globals.css";
 
 // Validate/log environment configuration once when the server boots.
@@ -52,9 +52,13 @@ export default function RootLayout({
     </html>
   );
 
-  // ClerkProvider requires a publishable key; without one (pre-setup) the
-  // site must still run, so only wrap once the key exists.
-  return process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ? (
+  // Mount <ClerkProvider> only when Clerk is FULLY configured (both keys),
+  // matching isClerkConfigured() used by proxy.ts and the /my + /auth gates.
+  // A partial config (one key) previously mounted the provider here while the
+  // proxy and pages treated auth as off — an inconsistent, fail-open state.
+  // Now all surfaces agree: a half-configured deploy runs consistently in open
+  // mode (and /auth redirects to /my rather than rendering a dead form).
+  return isClerkConfigured() ? (
     <ClerkProvider>{page}</ClerkProvider>
   ) : (
     page

--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -332,7 +332,7 @@ function HackCard({ h }: { h: Hackathon }) {
             <div className="flex shrink-0 items-center gap-2">
               <SaveHeart h={h} dark />
               <a
-                href={safeHttpUrl(h.url)}
+                href={h.url}
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}

--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import type { Hackathon, HackState } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
+import { safeHttpUrl } from "@/lib/url";
 import { useSelection, useTracker } from "./store";
 
 type StatusFilter = "all" | HackState;
@@ -331,7 +332,7 @@ function HackCard({ h }: { h: Hackathon }) {
             <div className="flex shrink-0 items-center gap-2">
               <SaveHeart h={h} dark />
               <a
-                href={h.url}
+                href={safeHttpUrl(h.url)}
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
@@ -397,7 +398,7 @@ function HackRow({ h }: { h: Hackathon }) {
       </div>
       <SaveHeart h={h} />
       <a
-        href={h.url}
+        href={safeHttpUrl(h.url)}
         target="_blank"
         rel="noreferrer"
         onClick={(e) => e.stopPropagation()}

--- a/web/components/hq/detail-modal.tsx
+++ b/web/components/hq/detail-modal.tsx
@@ -8,6 +8,7 @@ import {
   eventDateDisplay,
 } from "@/lib/types-hq";
 import { lockScroll } from "@/lib/scroll-lock";
+import { safeHttpUrl } from "@/lib/url";
 import { useSelection, useTracker } from "./store";
 
 export function DetailModal() {
@@ -163,7 +164,7 @@ export function DetailModal() {
           {/* Actions */}
           <div className="mt-6 flex flex-wrap gap-3">
             <a
-              href={h.url}
+              href={safeHttpUrl(h.url)}
               target="_blank"
               rel="noreferrer"
               className="flex-1 rounded-full bg-coral px-7 py-4 text-center font-mono text-[12px] font-bold tracking-[0.18em] text-paper transition hover:bg-coral-bright"

--- a/web/components/hq/globe-detail-drawer.tsx
+++ b/web/components/hq/globe-detail-drawer.tsx
@@ -8,6 +8,7 @@ import {
   eventDateDisplay,
   type Hackathon,
 } from "@/lib/types-hq";
+import { safeHttpUrl } from "@/lib/url";
 import { useDialogDismiss } from "./use-dialog-dismiss";
 import { useTracker } from "./store";
 
@@ -137,7 +138,7 @@ function ActionButton({ hackathon }: { hackathon: Hackathon }) {
 
   return (
     <a
-      href={hackathon.url}
+      href={safeHttpUrl(hackathon.url)}
       target="_blank"
       rel="noreferrer"
       className={`block flex-1 rounded-full px-6 py-4 text-center font-mono text-[12px] font-bold tracking-[0.18em] transition focus:outline-none focus:ring-2 ${

--- a/web/components/hq/tracker.tsx
+++ b/web/components/hq/tracker.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import type { Hackathon } from "@/lib/types-hq";
 import { STATE_META, countdown } from "@/lib/types-hq";
 import { countKnownTracked } from "@/lib/tracker-utils";
+import { safeHttpUrl } from "@/lib/url";
 import { STAGES, useSelection, useTracker, type Stage } from "./store";
 
 export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
@@ -145,7 +146,7 @@ export function Tracker({ hackathons }: { hackathons: Hackathon[] }) {
           </div>
           {urgent && (
             <a
-              href={urgent.url}
+              href={safeHttpUrl(urgent.url)}
               target="_blank"
               rel="noreferrer"
               className="shrink-0 rounded-full bg-coral px-6 py-3 text-center font-mono text-[11px] font-bold tracking-[0.15em] text-paper transition hover:bg-coral-bright"

--- a/web/components/legacy/event-cards.tsx
+++ b/web/components/legacy/event-cards.tsx
@@ -1,4 +1,5 @@
 import type { Opportunity } from "@/lib/types";
+import { safeHttpUrl } from "@/lib/url";
 
 // Three distinct cinematic moods, one per card (ember / emerald / gold),
 // mirroring the template's restaurant / cocktail / car project scenes.
@@ -47,7 +48,7 @@ export function EventCards({ events }: { events: Opportunity[] }) {
               </h2>
 
               <a
-                href={opp.url}
+                href={safeHttpUrl(opp.url)}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 rounded-full bg-black/25 px-7 py-3.5 text-sm text-white backdrop-blur-md transition-colors hover:bg-black/40"

--- a/web/components/legacy/journal-card.tsx
+++ b/web/components/legacy/journal-card.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { GalleryPhoto, Opportunity } from "@/lib/types";
 import { STATUS_LABELS } from "@/lib/types";
+import { safeHttpUrl } from "@/lib/url";
 import { Reveal } from "./reveal";
 
 // Fallback scenes when there aren't enough gallery photos.
@@ -46,7 +47,7 @@ export function JournalCard({
             return (
               <Reveal key={opp.id}>
                 <a
-                  href={opp.url}
+                  href={safeHttpUrl(opp.url)}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="group block"

--- a/web/components/legacy/opportunity-card.tsx
+++ b/web/components/legacy/opportunity-card.tsx
@@ -1,4 +1,5 @@
 import { Opportunity } from "@/lib/types";
+import { safeHttpUrl } from "@/lib/url";
 
 const STATUS_STYLES: Record<Opportunity["status"], string> = {
   CLOSING_SOON:
@@ -30,7 +31,7 @@ export function OpportunityCard({ opp }: { opp: Opportunity }) {
 
   return (
     <a
-      href={opp.url || "#"}
+      href={safeHttpUrl(opp.url) ?? "#"}
       target="_blank"
       rel="noopener noreferrer"
       className={`group flex flex-col gap-3 rounded-xl border bg-white p-4 transition-all hover:-translate-y-0.5 hover:shadow-md dark:bg-zinc-950 ${

--- a/web/lib/url.test.ts
+++ b/web/lib/url.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { safeHttpUrl } from "./url";
+
+describe("safeHttpUrl", () => {
+  it("allows https and http URLs", () => {
+    expect(safeHttpUrl("https://example.com/x")).toBe("https://example.com/x");
+    expect(safeHttpUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("is case-insensitive on the scheme and trims whitespace", () => {
+    expect(safeHttpUrl("HTTPS://Example.com")).toBe("HTTPS://Example.com");
+    expect(safeHttpUrl("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  it("rejects javascript: and data: URLs", () => {
+    expect(safeHttpUrl("javascript:alert(1)")).toBeUndefined();
+    expect(safeHttpUrl("JavaScript:alert(1)")).toBeUndefined();
+    expect(safeHttpUrl("data:text/html,<script>alert(1)</script>")).toBeUndefined();
+    expect(safeHttpUrl("vbscript:msgbox(1)")).toBeUndefined();
+  });
+
+  it("rejects relative, protocol-relative, and empty values", () => {
+    expect(safeHttpUrl("/relative")).toBeUndefined();
+    expect(safeHttpUrl("//evil.com")).toBeUndefined();
+    expect(safeHttpUrl("")).toBeUndefined();
+    expect(safeHttpUrl(null)).toBeUndefined();
+    expect(safeHttpUrl(undefined)).toBeUndefined();
+  });
+
+  it("passes the ingestion-neutralized form (https://javascript:...) through as safe", () => {
+    // util.clean_url turns `javascript:alert(1)` into `https://javascript:alert(1)`
+    // — no longer an executable scheme, so it's correctly allowed.
+    expect(safeHttpUrl("https://javascript:alert(1)")).toBe(
+      "https://javascript:alert(1)",
+    );
+  });
+});

--- a/web/lib/url.ts
+++ b/web/lib/url.ts
@@ -1,0 +1,17 @@
+/**
+ * Return `url` only if it is a plain http(s) link, otherwise `undefined`.
+ *
+ * Listing URLs are community-submitted. Ingestion already neutralizes bad
+ * schemes (`util.clean_url` force-prepends `https://`), but the frontend should
+ * not blindly trust that: if `listings.json` is ever populated by a path that
+ * skips `clean_url` (a new script, a manual edit, a compromised CI step), a
+ * `javascript:` / `data:` value rendered into an anchor's `href` becomes
+ * click-to-XSS — React does not sanitize hrefs. Passing every listing `url`
+ * through this guard means an unsafe value yields no `href` (a dead, harmless
+ * anchor) instead of an executable one.
+ */
+export function safeHttpUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+  const trimmed = url.trim();
+  return /^https?:\/\//i.test(trimmed) ? trimmed : undefined;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -46,15 +46,46 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // Baseline security headers for every response. Deliberately scoped to
+        // safe, high-value headers: framing/clickjacking defense, referrer
+        // trimming, MIME sniffing, HSTS, and a locked-down Permissions-Policy.
+        // A full resource CSP (default-src/script-src/…) is intentionally NOT
+        // set here — it needs per-integration allowances (Clerk, Mapbox,
+        // next/image) and careful testing, so it's tracked as a follow-up. The
+        // `frame-ancestors` directive below is safe on its own (it restricts
+        // only who may embed us, not what we may load).
+        source: "/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "SAMEORIGIN" },
+          {
+            key: "Content-Security-Policy",
+            value: "frame-ancestors 'self'",
+          },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
+          },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+      {
         // Repo assets are copied into public/repo-assets at build time
         // (scripts/copy-repo-assets.mjs). Their PATHS are stable but their
         // CONTENT is not — the stats banner and gallery photos are regenerated
         // and committed by CI at the same filename. A long/immutable cache would
         // freeze the live banner for returning visitors (and next/image), so use
         // a short CDN cache that revalidates and serves stale while doing so.
+        // (X-Content-Type-Options is already set globally above.)
         source: "/repo-assets/:path*",
         headers: [
-          { key: "X-Content-Type-Options", value: "nosniff" },
           {
             key: "Cache-Control",
             value: "public, max-age=0, s-maxage=300, stale-while-revalidate=86400",


### PR DESCRIPTION
Implements the **code-level** security hardening from the security review as granular, independently-reviewable commits. Dependency upgrades (`next ≥16.2.11` #203, `sharp ≥0.35.0` #204) are intentionally **left as separate follow-ups** — they change `package-lock.json` and are best verified on their own.

Closes #205. Closes #206. Closes #207. Closes #208. Closes #209. Closes #210. Closes #211.

## Commits (one per finding)

| Commit | Issue | Change |
|---|---|---|
| `security(web): add baseline security headers + frame-ancestors CSP` | #205 | Global `headers()` rule: `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'`, `Referrer-Policy`, site-wide `nosniff`, HSTS, `Permissions-Policy`. (Full resource CSP deferred — needs Clerk/Mapbox allowances.) |
| `security(web): mount ClerkProvider only when fully configured` | #207 | `layout.tsx` now uses `isClerkConfigured()` (both keys), matching the proxy + `/my`/`/auth` gates, so a partial config no longer fails open. |
| `security(web): guard listing URLs with an http(s) scheme check` | #210 | New tested `lib/url.ts` `safeHttpUrl()`; applied at every listing-URL anchor (defense-in-depth vs `javascript:`/`data:` hrefs). |
| `security(pipeline): block CGNAT/benchmark IPs in SSRF guard via is_global` | #208 | Adds a `not ip.is_global` allowlist check (+ regression test) so CGNAT `100.64/10` and benchmark `198.18/15` are blocked; explicit predicates kept as defense. |
| `security(pipeline): sanitize LLM-extracted prize and locations` | #209 | Routes `prize` + each location through `util.sanitize_field`, matching host/title. |
| `security(pipeline): cap fetched response size` | #206 | Streams the body under a 5 MB cap (applies to decompressed bytes) + early `Content-Length` reject → stops gzip-bomb / multi-GB OOM (also protects the unattended `deadline_watcher` path). Adds tests. |
| `security(ci): escape model-derived values in bot success comment` | #211 | Escapes `\|`/newlines in the success-comment markdown table; guards non-array locations. |

## Verification

- **web**: `tsc` clean, `eslint` clean, **132 tests pass** (incl. new `url.test.ts`), `next build` green (`/my` builds).
- **pipeline**: `py_compile` clean, **102 tests + 20 subtests pass** (incl. new SSRF CGNAT and response-size-cap tests), `auto_extract.yml` valid YAML + workflow tests pass.

## Not in this PR (follow-ups)
- #203 `next ≥16.2.11` (auth-bypass advisory) + the in-page `auth()` defense-in-depth
- #204 `sharp ≥0.35.0` / `npm audit fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)