### PR TITLE
Polish navigation and player readability

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -68,6 +68,47 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
+/* A darker, more dimensional lens for floating navigation. The translucent
+   layers preserve the page behind it while the bright upper rim gives the
+   pane a curved-glass edge instead of reading as a flat frosted surface. */
+.glass-lens {
+  background:
+    radial-gradient(120% 110% at 15% -35%, rgba(255, 255, 255, 0.13), transparent 48%),
+    radial-gradient(80% 120% at 100% 130%, rgba(237, 91, 41, 0.08), transparent 58%),
+    linear-gradient(135deg, rgba(31, 26, 23, 0.92), rgba(13, 11, 9, 0.86));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.2),
+    0 16px 48px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(28px) saturate(155%);
+  -webkit-backdrop-filter: blur(28px) saturate(155%);
+}
+
+/* Mobile menus cover busy page content, so trade some translucency for legible
+   navigation labels while retaining the same lens edge and depth. */
+.mobile-nav-lens {
+  background:
+    radial-gradient(110% 100% at 10% -25%, rgba(255, 255, 255, 0.12), transparent 48%),
+    linear-gradient(135deg, rgba(31, 26, 23, 0.94), rgba(13, 11, 9, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.14),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.28),
+    0 16px 48px rgba(0, 0, 0, 0.52);
+  backdrop-filter: blur(28px) saturate(140%);
+  -webkit-backdrop-filter: blur(28px) saturate(140%);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .glass-lens,
+  .mobile-nav-lens {
+    background: rgb(27, 23, 20);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 /* Mono kicker - the "built by devs" label */
 .kicker {
   font-family: var(--font-mono);

--- a/web/components/hq/disc-player.tsx
+++ b/web/components/hq/disc-player.tsx
@@ -199,12 +199,12 @@ export function DiscPlayer() {
   return (
     <div
       ref={rootRef}
-      className="fixed right-2 top-2 z-[80] hidden flex-col items-end gap-1 sm:flex"
+      className="fixed right-2 top-2 z-[80] hidden flex-col items-end gap-1 lg:flex"
     >
       {/* The exact Framer DiscPlayer - naked disc, no card. Plays only the
           music the user loads. Negative margins offset the component's
           internal 24px padding so the record sits snug in the corner. */}
-      <div ref={discWrapRef} onClickCapture={onDiscClickCapture} className="-mr-4 -mt-4">
+      <div ref={discWrapRef} onClickCapture={onDiscClickCapture} className="-mr-4 mt-10">
         <FramerDiscPlayer
           style={{ width: 190, height: 190 }}
           backgroundColor="rgba(0, 0, 0, 0)"
@@ -216,7 +216,7 @@ export function DiscPlayer() {
       {/* Music panel toggle */}
       <button
         onClick={() => setPanelOpen((v) => !v)}
-        className="glass-dark flex items-center gap-2 rounded-full px-4 py-2 font-mono text-[9px] font-bold tracking-[0.18em] text-paper transition hover:bg-white/10"
+        className="mobile-nav-lens flex items-center gap-2 rounded-full px-4 py-2 font-mono text-[11px] font-bold tracking-[0.18em] text-paper transition hover:bg-white/10"
       >
         <span
           className={`h-1.5 w-1.5 rounded-full bg-coral ${playing ? "" : "opacity-60"}`}
@@ -229,12 +229,12 @@ export function DiscPlayer() {
       <div
         className={
           panelOpen
-            ? "glass-dark w-[19rem] rounded-3xl p-4 shadow-[0_24px_64px_rgba(0,0,0,0.55)]"
+            ? "mobile-nav-lens w-[24rem] rounded-3xl p-4"
             : "pointer-events-none invisible h-0 w-[19rem] overflow-hidden opacity-0"
         }
       >
         {!hasMusic && !connecting && (
-          <div className="mb-3 font-mono text-[10px] leading-relaxed tracking-[0.12em] text-paper/60">
+          <div className="mb-2 font-mono text-[12px] leading-relaxed tracking-[0.12em] text-paper-dim">
             PASTE A SPOTIFY LINK. THE DISC PLAYS YOUR MUSIC - NOTHING ELSE.
           </div>
         )}
@@ -242,7 +242,7 @@ export function DiscPlayer() {
           <div data-spotify-mount />
         </div>
         {connecting && (
-          <div className="mt-2 text-center font-mono text-[9px] tracking-[0.2em] text-paper/40">
+          <div className="mt-2 text-center font-mono text-[11px] tracking-[0.2em] text-paper-dim">
             LOADING YOUR MUSIC…
           </div>
         )}
@@ -254,18 +254,18 @@ export function DiscPlayer() {
               setLinkError(false);
             }}
             placeholder="Paste your Spotify link…"
-            className={`min-w-0 flex-1 rounded-lg border bg-ink-deep/50 px-3 py-2 font-mono text-[10px] text-paper outline-none transition placeholder:text-paper/30 ${
+            className={`min-w-0 flex-1 rounded-lg border bg-ink-deep/70 px-3 py-2 font-mono text-[12px] text-paper outline-none transition placeholder:text-paper/50 ${
               linkError ? "border-coral" : "border-white/15 focus:border-coral"
             }`}
           />
           <button
             type="submit"
-            className="rounded-lg bg-paper px-3 py-2 font-mono text-[9px] font-bold tracking-[0.12em] text-ink transition hover:bg-white"
+            className="rounded-lg bg-paper px-3 py-2 font-mono text-[11px] font-bold tracking-[0.12em] text-ink transition hover:bg-white"
           >
             LOAD
           </button>
         </form>
-        <div className="kicker mt-2 text-[8px] text-paper/30">
+        <div className="kicker mt-5 text-[10px] text-paper-dim">
           Then tap the record to play. Signed into Spotify? Full tracks.
         </div>
       </div>

--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -108,7 +108,7 @@ export function MobileMenu() {
           // it — for exactly the users who set larger text. `top-full` tracks
           // the real height instead. inset-x-3 matches the nav's px-3 gutter,
           // which keeps the panel on screen at 375px.
-          className="glass-dark absolute inset-x-3 top-full mt-3 flex flex-col gap-1 rounded-3xl p-2 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
+          className="mobile-nav-lens absolute inset-x-3 top-full mt-3 flex flex-col gap-1 rounded-3xl p-2"
         >
           {NAV_LINKS.map(([label, href]) => {
             const active = isActiveRoute(pathname, href);
@@ -123,8 +123,8 @@ export function MobileMenu() {
                 // tap on the section you are already in.
                 onClick={() => setOpen(false)}
                 aria-current={active ? "page" : undefined}
-                className={`rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset ${
-                  active ? "bg-white/10 text-paper" : "text-paper/80"
+                className={`rounded-2xl px-4 py-3 font-mono text-[15px] tracking-[0.18em] transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset ${
+                  active ? "bg-white/10 text-paper" : "text-paper-dim"
                 }`}
               >
                 {label}
@@ -137,7 +137,7 @@ export function MobileMenu() {
             target="_blank"
             rel="noreferrer"
             onClick={() => setOpen(false)}
-            className="rounded-2xl px-4 py-3 font-mono text-[11px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset"
+            className="rounded-2xl px-4 py-3 font-mono text-[13px] tracking-[0.18em] text-paper/50 transition hover:bg-white/10 hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset"
           >
             ★ GITHUB
           </a>
@@ -150,16 +150,16 @@ export function MobileMenu() {
 /** Hamburger that becomes a close glyph while the panel is open. */
 function MenuIcon({ open }: { open: boolean }) {
   return (
-    <span aria-hidden="true" className="flex h-4 w-4 flex-col justify-center gap-[3px]">
+    <span aria-hidden="true" className="flex h-5 w-5 flex-col justify-center gap-[5px]">
       <span
         className={`h-[1.5px] w-full bg-current transition ${
-          open ? "translate-y-[4.5px] rotate-45" : ""
+          open ? "translate-y-[6.5px] rotate-45" : ""
         }`}
       />
       <span className={`h-[1.5px] w-full bg-current transition ${open ? "opacity-0" : ""}`} />
       <span
         className={`h-[1.5px] w-full bg-current transition ${
-          open ? "-translate-y-[4.5px] -rotate-45" : ""
+          open ? "-translate-y-[6.5px] -rotate-45" : ""
         }`}
       />
     </span>

--- a/web/components/hq/nav.tsx
+++ b/web/components/hq/nav.tsx
@@ -44,7 +44,7 @@ export function NavPill() {
     <nav className="fixed inset-x-0 top-4 z-50 flex justify-center px-3">
       <div
         ref={pillRef}
-        className="glass-dark flex items-center gap-1 rounded-3xl p-2 pl-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
+        className="glass-lens flex items-center gap-5 rounded-3xl p-2 pl-2.5 shadow-[0_16px_48px_rgba(0,0,0,0.45)]"
       >
         {/* Logo chip - HQ monogram */}
         <Link
@@ -126,7 +126,7 @@ export function NavPill() {
               window.history.pushState(null, "", "#submit");
             }
           }}
-          className="ml-1 flex items-center gap-2 rounded-2xl bg-paper px-5 py-3 font-mono text-[11px] font-bold tracking-[0.18em] text-ink transition hover:bg-white"
+          className="ml-1 flex items-center gap-2 rounded-2xl bg-paper px-5 py-3 font-mono text-[12px] font-bold tracking-[0.18em] text-ink transition hover:bg-white md:text-[12px]"
         >
           + SUBMIT
         </Link>


### PR DESCRIPTION
#### Summary
Improves navigation and music-player readability with a darker glass treatment and larger, higher-contrast UI text.

- Added reusable dark glass lens styles with reduced-transparency support.
- Updated the nav pill and mobile dropdown to use the new lens styling.
- Increased mobile menu label sizes, contrast, and close-icon sizing.
- Restyled the Disc Player controls/panel with the darker lens, larger text, and more legible form elements.
- Hidden the Disc Player below the lg breakpoint.

<img width="1202" height="360" alt="Screenshot 2026-07-23 at 8 35 05 AM" src="https://github.com/user-attachments/assets/a38fa37e-b750-44f7-b679-9d5e85e26e04" />
<img width="444" height="577" alt="Screenshot 2026-07-23 at 8 35 20 AM" src="https://github.com/user-attachments/assets/1068079b-8458-473f-aa41-9b9af4de1820" />
<img width="437" height="601" alt="Screenshot 2026-07-23 at 8 36 05 AM" src="https://github.com/user-attachments/assets/fcf72a99-ff31-4e1a-b6a2-a025648afea8" />


#### Testing
npm run lint