### PR TITLE
fix(hackathons): hide closed events and surface event dates

### DIFF
--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -2,7 +2,13 @@
 
 import { useMemo, useState } from "react";
 import type { Hackathon, HackState } from "@/lib/types-hq";
-import { STATE_META, countdown } from "@/lib/types-hq";
+import {
+  STATE_META,
+  countdown,
+  deadlineDisplay,
+  eventDateDisplay,
+  isActiveHackathon,
+} from "@/lib/types-hq";
 import { safeHttpUrl } from "@/lib/url";
 import { useSelection, useTracker } from "./store";
 
@@ -16,7 +22,7 @@ export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
 
   const filtered = useMemo(() => {
     const needle = q.trim().toLowerCase();
-    return hackathons.filter((h) => {
+    return hackathons.filter(isActiveHackathon).filter((h) => {
       if (status !== "all" && h.state !== status) return false;
       if (format !== "all" && h.format !== format) return false;
       if (!needle) return true;
@@ -172,6 +178,8 @@ function HackRow({ h }: { h: Hackathon }) {
   const { setSelected } = useSelection();
   const meta = STATE_META[h.state];
   const cd = countdown(h);
+  const deadline = deadlineDisplay(h);
+  const eventDates = eventDateDisplay(h);
   const openDetails = () => setSelected(h);
   const onOpenKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.target !== e.currentTarget) return;
@@ -188,7 +196,7 @@ function HackRow({ h }: { h: Hackathon }) {
       role="button"
       tabIndex={0}
       aria-label={`View details for ${h.title}`}
-      className={`flex cursor-pointer items-center gap-4 px-5 py-4 transition hover:bg-ink/4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset sm:px-7 ${h.state === "closed" ? "opacity-50" : ""}`}
+      className="flex cursor-pointer items-center gap-4 px-5 py-4 transition hover:bg-ink/4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-inset sm:px-7"
     >
       <span
         className="h-2.5 w-2.5 shrink-0 rounded-full"
@@ -209,9 +217,17 @@ function HackRow({ h }: { h: Hackathon }) {
       <div className="hidden w-32 text-right font-display text-sm font-semibold text-ink sm:block">
         {h.prize ?? "-"}
       </div>
-      <div className="hidden w-28 text-right font-mono text-[10px] tracking-wider text-coral lg:block">
-        {cd?.toUpperCase() ?? ""}
-      </div>
+      {eventDates && (
+        <DateColumn className="hidden w-44 lg:block" label="Event dates" value={eventDates} />
+      )}
+      {deadline && (
+        <DateColumn
+          className="hidden w-36 text-coral lg:block"
+          label="Deadline"
+          value={deadline}
+          detail={cd?.toUpperCase()}
+        />
+      )}
       <SaveHeart h={h} />
       <a
         href={safeHttpUrl(h.url)}
@@ -222,6 +238,26 @@ function HackRow({ h }: { h: Hackathon }) {
       >
         {h.state === "opens_soon" ? "SITE" : "GO"}
       </a>
+    </div>
+  );
+}
+
+function DateColumn({
+  className,
+  label,
+  value,
+  detail,
+}: {
+  className: string;
+  label: string;
+  value: string;
+  detail?: string;
+}) {
+  return (
+    <div className={`text-right font-mono text-[10px] tracking-wider ${className}`}>
+      <div className="text-[9px] text-ink/40">{label.toUpperCase()}</div>
+      <div className="mt-1 leading-tight text-ink/70">{value}</div>
+      {detail && <div className="mt-1 text-[9px]">{detail}</div>}
     </div>
   );
 }

--- a/web/components/hq/detail-modal.tsx
+++ b/web/components/hq/detail-modal.tsx
@@ -128,7 +128,7 @@ export function DetailModal() {
 
           <div className="mt-5 flex flex-wrap gap-2">
             <InfoChip>{h.location}</InfoChip>
-            {eventDates && <InfoChip>{eventDates}</InfoChip>}
+            {eventDates && <InfoChip>Event dates · {eventDates}</InfoChip>}
             {h.deadline && (
               <InfoChip>
                 Deadline {deadlineDisplay(h)}

--- a/web/components/hq/globe-detail-drawer.tsx
+++ b/web/components/hq/globe-detail-drawer.tsx
@@ -95,7 +95,7 @@ export function GlobeDetailDrawer({
           <DetailRow label="City" value={h.location} />
           <DetailRow label="Format" value={h.format} />
           <DetailRow label="Prize" value={h.prize ?? "See website"} />
-          {eventDates && <DetailRow label="Dates" value={eventDates} />}
+          {eventDates && <DetailRow label="Event dates" value={eventDates} />}
           {deadline && <DetailRow label="Deadline" value={deadline} />}
         </div>
 

--- a/web/components/hq/globe-map.tsx
+++ b/web/components/hq/globe-map.tsx
@@ -6,6 +6,8 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import {
   STATE_META,
   countdown,
+  eventDateDisplay,
+  isActiveHackathon,
   type HackState,
   type Hackathon,
 } from "@/lib/types-hq";
@@ -57,14 +59,20 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   const hasToken = Boolean(mapboxgl.accessToken);
 
   const located = useMemo(
-    () => hackathons.filter((h) => h.lat !== null && h.lng !== null),
+    () =>
+      hackathons
+        .filter(isActiveHackathon)
+        .filter((h) => h.lat !== null && h.lng !== null),
     [hackathons],
   );
 
   // Non-virtual listings we could not place. A virtual hackathon isn't missing
   // from the map — it has nowhere to be — so it doesn't count here.
   const unmapped = hackathons.filter(
-    (h) => h.format !== "Virtual" && (h.lat === null || h.lng === null),
+    (h) =>
+      isActiveHackathon(h) &&
+      h.format !== "Virtual" &&
+      (h.lat === null || h.lng === null),
   ).length;
 
   // Search + status apply everywhere (map pins and the virtual list). The
@@ -101,7 +109,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
   // dedicated drawer instead — this is how online-only events stay
   // discoverable. They ignore the pin-only format filters.
   const virtualList = useMemo(
-    () => hackathons.filter((h) => h.format === "Virtual" && h.state !== "closed"),
+    () => hackathons.filter(isActiveHackathon).filter((h) => h.format === "Virtual"),
     [hackathons],
   );
   const visibleVirtual = useMemo(
@@ -186,6 +194,7 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
     function showPopup(h: Hackathon) {
       const meta = STATE_META[h.state];
       const cd = countdown(h);
+      const eventDates = eventDateDisplay(h);
 
       const root = document.createElement("div");
 
@@ -210,6 +219,17 @@ export function GlobeMap({ hackathons }: { hackathons: Hackathon[] }) {
       metaRow.textContent = `${h.host} · ${h.location}`;
 
       root.append(statusRow, titleRow, metaRow);
+
+      if (eventDates) {
+        const datesRow = document.createElement("div");
+        datesRow.style.fontFamily = "var(--font-mono)";
+        datesRow.style.fontSize = "10px";
+        datesRow.style.letterSpacing = "0.1em";
+        datesRow.style.color = "#9ba1a5";
+        datesRow.style.marginTop = "7px";
+        datesRow.textContent = `EVENT DATES · ${eventDates.toUpperCase()}`;
+        root.append(datesRow);
+      }
 
       popup
         .setLngLat([h.lng!, h.lat!])

--- a/web/lib/types-hq.test.ts
+++ b/web/lib/types-hq.test.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { eventDateDisplay, submitIssueUrl, type Hackathon } from "./types-hq";
+import {
+  deadlineDisplay,
+  eventDateDisplay,
+  isActiveHackathon,
+  submitIssueUrl,
+  type Hackathon,
+} from "./types-hq";
 
 const TEMPLATE_PATH = path.join(
   process.cwd(),
@@ -98,5 +104,21 @@ describe("eventDateDisplay", () => {
 
   it("returns null when event dates are absent", () => {
     expect(eventDateDisplay(hackStub({}))).toBeNull();
+  });
+});
+
+describe("isActiveHackathon", () => {
+  it("excludes only closed listings from discovery surfaces", () => {
+    expect(isActiveHackathon(hackStub({ state: "open" }))).toBe(true);
+    expect(isActiveHackathon(hackStub({ state: "opens_soon" }))).toBe(true);
+    expect(isActiveHackathon(hackStub({ state: "closing_soon" }))).toBe(true);
+    expect(isActiveHackathon(hackStub({ state: "closed" }))).toBe(false);
+  });
+});
+
+describe("deadlineDisplay", () => {
+  it("formats a deadline and omits a missing value", () => {
+    expect(deadlineDisplay(hackStub({ deadline: "2026-09-10" }))).toBe("Sep 10, 2026");
+    expect(deadlineDisplay(hackStub({}))).toBeNull();
   });
 });

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -33,6 +33,11 @@ export type SiteStats = {
   cities: number;
 };
 
+/** Whether a listing belongs in active discovery surfaces such as the deck and globe. */
+export function isActiveHackathon(hackathon: Pick<Hackathon, "state">): boolean {
+  return hackathon.state !== "closed";
+}
+
 export const STATE_META: Record<
   HackState,
   { label: string; color: string; dim?: boolean }


### PR DESCRIPTION
closes #225 

Use a single active-listing rule for the deck and globe, while showing the actual deadline and event-date range where people browse event details.