### PR TITLE
feat: gallery submission

### DIFF
--- a/.github/scripts/gallery_approved.py
+++ b/.github/scripts/gallery_approved.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Process an approved "Share a Hackathon Photo" issue (#221).
+Process an approved "Share a Hackathon Photo" issue.
 
 On `approved` + `gallery` labels:
   1. Parse the issue form fields (hackathon, caption, credit, …).

--- a/.github/scripts/gallery_approved.py
+++ b/.github/scripts/gallery_approved.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Process an approved "Share a Hackathon Photo" issue (#221).
+
+On `approved` + `gallery` labels:
+  1. Parse the issue form fields (hackathon, caption, credit, …).
+  2. Find the first attached image URL in the photo field (or whole body).
+  3. Download it via auto_extract.safe_get (SSRF-guarded), validate type/size.
+  4. Write assets/gallery/<slug>.jpg|.png and append .github/scripts/gallery.json.
+
+The README collage is rebuilt by the caller (generate_gallery.py) in the same
+job — a GITHUB_TOKEN push would not trigger gallery.yml.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import util
+from auto_extract import safe_get
+
+# Cap matches the website CTA copy. GitHub itself allows larger attachments;
+# we refuse anything over this before it lands in the repo.
+MAX_BYTES = 5 * 1024 * 1024
+
+# Hosts GitHub uses for issue image attachments / their CDN redirects.
+ALLOWED_IMAGE_HOST_SUFFIXES = (
+    "github.com",
+    "githubusercontent.com",
+)
+
+IMAGE_URL_RE = re.compile(
+    r"https://(?:github\.com/user-attachments/assets/[A-Za-z0-9\-]+"
+    r"|user-images\.githubusercontent\.com/[^\s\)\"'<>]+"
+    r"|private-user-images\.githubusercontent\.com/[^\s\)\"'<>]+)",
+    re.IGNORECASE,
+)
+
+JPEG_MAGIC = b"\xff\xd8\xff"
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+GALLERY_JSON = Path(".github/scripts/gallery.json")
+GALLERY_DIR = Path("assets/gallery")
+
+
+def get_first(data, *keys):
+    for key in keys:
+        value = data.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def slugify(text: str, max_len: int = 48) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return (slug or "photo")[:max_len].strip("-") or "photo"
+
+
+def extract_image_url(text: str) -> str:
+    """Return the first GitHub attachment / user-image URL in text."""
+    if not text:
+        return ""
+    match = IMAGE_URL_RE.search(text)
+    return match.group(0) if match else ""
+
+
+def host_allowed(url: str) -> bool:
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return False
+    return any(host == suffix or host.endswith("." + suffix) for suffix in ALLOWED_IMAGE_HOST_SUFFIXES)
+
+
+def detect_image_type(data: bytes) -> str:
+    if data.startswith(JPEG_MAGIC):
+        return "jpg"
+    if data.startswith(PNG_MAGIC):
+        return "png"
+    return ""
+
+
+def load_gallery() -> list:
+    if not GALLERY_JSON.exists():
+        return []
+    raw = json.loads(GALLERY_JSON.read_text(encoding="utf-8"))
+    if not isinstance(raw, list):
+        util.fail("gallery.json is not a JSON array")
+    return raw
+
+
+def save_gallery(entries: list) -> None:
+    GALLERY_JSON.write_text(
+        json.dumps(entries, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def unique_filename(base: str, ext: str) -> str:
+    candidate = f"{base}.{ext}"
+    if not (GALLERY_DIR / candidate).exists():
+        return candidate
+    for i in range(2, 50):
+        candidate = f"{base}-{i}.{ext}"
+        if not (GALLERY_DIR / candidate).exists():
+            return candidate
+    util.fail(f"Could not find a free filename for {base}.{ext}")
+
+
+def download_image(url: str) -> tuple[bytes, str]:
+    if not host_allowed(url):
+        util.fail(f"Image host not allowed: {urlparse(url).hostname}")
+
+    headers = {
+        "User-Agent": "HackHQ-gallery-bot/1.0",
+        "Accept": "image/jpeg,image/png,image/*;q=0.8,*/*;q=0.5",
+    }
+    # Private user-attachment redirects often need the Actions token.
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = safe_get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 — surface any fetch failure to the issue
+        util.fail(f"Could not download the attached image: {exc}")
+
+    data = response.content or b""
+    if len(data) == 0:
+        util.fail("Downloaded image was empty")
+    if len(data) > MAX_BYTES:
+        util.fail(f"Image exceeds {MAX_BYTES // (1024 * 1024)} MB limit")
+
+    ext = detect_image_type(data)
+    if not ext:
+        util.fail("Only JPG and PNG images are accepted")
+    return data, ext
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        util.fail("Missing event data file path")
+
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        event = json.load(f)
+
+    issue = event.get("issue", {})
+    body = issue.get("body") or ""
+    labels = [l.get("name", "") for l in issue.get("labels", [])]
+    username = issue.get("user", {}).get("login", "unknown")
+
+    if "gallery" not in labels:
+        util.fail(f"Not a gallery issue. Labels: {labels}")
+
+    data = util.parse_issue_body(body)
+    hackathon = util.sanitize_field(
+        get_first(data, "which_hackathon?", "which_hackathon", "hackathon")
+    )
+    if not hackathon:
+        util.fail("Missing required field: Which hackathon?")
+
+    caption = util.sanitize_field(get_first(data, "caption_(optional)", "caption"))
+    credit = util.sanitize_field(
+        get_first(data, "credit_name_(optional)", "credit_name", "credit")
+    ) or username
+    credit_url_raw = get_first(
+        data, "link_to_credit_(optional)", "link_to_credit", "credit_url"
+    )
+    credit_url = util.clean_url(credit_url_raw) if credit_url_raw else ""
+
+    # Prefer the dedicated photo field; fall back to scanning the whole body
+    # (GitHub sometimes places the attachment outside the form section).
+    photo_field = get_first(data, "your_photo", "photo")
+    image_url = extract_image_url(photo_field) or extract_image_url(body)
+    if not image_url:
+        util.fail(
+            "No image attachment found. Drag a JPG or PNG into the "
+            '"Your photo" field and re-approve.'
+        )
+
+    image_bytes, ext = download_image(image_url)
+
+    GALLERY_DIR.mkdir(parents=True, exist_ok=True)
+    base = f"{slugify(hackathon)}-{slugify(credit, 24)}"
+    filename = unique_filename(base, ext)
+    rel_path = f"assets/gallery/{filename}"
+    (GALLERY_DIR / filename).write_bytes(image_bytes)
+
+    entries = load_gallery()
+    for entry in entries:
+        if entry.get("image") == rel_path:
+            util.fail(f"Gallery already has {rel_path}")
+
+    new_entry = {
+        "image": rel_path,
+        "hackathon": hackathon,
+    }
+    if caption:
+        new_entry["caption"] = caption
+    if credit:
+        new_entry["credit"] = credit
+    if credit_url:
+        new_entry["credit_url"] = credit_url
+
+    entries.append(new_entry)
+    save_gallery(entries)
+
+    util.set_output("commit_message", f"Add gallery photo: {hackathon}")
+    util.set_output("contributor_name", username)
+    util.set_output("contributor_email", "actions@github.com")
+    util.set_output("image_path", rel_path)
+
+    print(f"Successfully added gallery photo: {rel_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_scripts.py
+++ b/.github/scripts/test_scripts.py
@@ -1011,5 +1011,41 @@ class BuildRowOrigin(unittest.TestCase):
         self.assertEqual(seed.build_row(self.LISTING)["host"], "Major League Hacking")
 
 
+class GalleryApprovedHelpers(unittest.TestCase):
+    """Pure helpers from gallery_approved.py (#221) — no network."""
+
+    @classmethod
+    def setUpClass(cls):
+        import gallery_approved as ga
+        cls.ga = ga
+
+    def test_extracts_user_attachments_url(self):
+        text = "See ![p](https://github.com/user-attachments/assets/abc-123-def)"
+        self.assertEqual(
+            self.ga.extract_image_url(text),
+            "https://github.com/user-attachments/assets/abc-123-def",
+        )
+
+    def test_extract_returns_empty_when_missing(self):
+        self.assertEqual(self.ga.extract_image_url("no image here"), "")
+
+    def test_slugify_collapses_punctuation(self):
+        self.assertEqual(self.ga.slugify("HackMIT 2026!!!"), "hackmit-2026")
+
+    def test_detects_jpeg_and_png_magic(self):
+        self.assertEqual(self.ga.detect_image_type(b"\xff\xd8\xff\xe0rest"), "jpg")
+        self.assertEqual(self.ga.detect_image_type(b"\x89PNG\r\n\x1a\nrest"), "png")
+        self.assertEqual(self.ga.detect_image_type(b"GIF89a"), "")
+
+    def test_host_allowlist(self):
+        self.assertTrue(
+            self.ga.host_allowed("https://github.com/user-attachments/assets/x")
+        )
+        self.assertTrue(
+            self.ga.host_allowed("https://user-images.githubusercontent.com/1/x.png")
+        )
+        self.assertFalse(self.ga.host_allowed("https://evil.example/x.jpg"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/test_workflows.py
+++ b/.github/scripts/test_workflows.py
@@ -165,7 +165,12 @@ class SupabaseSyncTriggers(unittest.TestCase):
     def test_bot_pushes_cannot_trigger_a_run(self):
         # The premise of the above: no workflow checks out with a PAT, so every
         # push these workflows make carries the default token.
-        for name in ("auto_extract.yml", "contribution_approved.yml"):
+        for name in (
+            "auto_extract.yml",
+            "contribution_approved.yml",
+            "gallery_approved.yml",
+            "gallery.yml",
+        ):
             with self.subTest(workflow=name):
                 text = read(name)
                 self.assertIn("git push origin main", text)

--- a/.github/workflows/gallery_approved.yml
+++ b/.github/workflows/gallery_approved.yml
@@ -1,4 +1,10 @@
-name: Contribution Approved
+# Approve a "Share a Hackathon Photo" issue → commit image + gallery.json (#221).
+#
+# Mirrors contribution_approved.yml: maintainer applies the `approved` label,
+# the bot downloads the attached JPG/PNG (SSRF-guarded), appends gallery.json,
+# rebuilds the README collage, and closes the issue. A GITHUB_TOKEN push does
+# not start gallery.yml, so generate_gallery.py runs in this job instead.
+name: Gallery Photo Approved
 
 on:
   issues:
@@ -13,14 +19,10 @@ permissions:
   issues: write
 
 jobs:
-  process-contribution:
-    # Manual listing submissions only. Gallery photos have their own workflow
-    # (gallery_approved.yml); auto_extract issues go through auto_extract.yml.
+  process-gallery-photo:
     if: >
       github.event.label.name == 'approved' &&
-      contains(github.event.issue.labels.*.name, 'approved') &&
-      !contains(github.event.issue.labels.*.name, 'auto_extract') &&
-      !contains(github.event.issue.labels.*.name, 'gallery')
+      contains(github.event.issue.labels.*.name, 'gallery')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -35,22 +37,18 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Process contribution
+      - name: Install dependencies
+        run: pip install -r .github/scripts/requirements.txt
+
+      - name: Process gallery photo
         id: process
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python .github/scripts/contribution_approved.py "${{ github.event_path }}"
+          python .github/scripts/gallery_approved.py "${{ github.event_path }}"
 
-      - name: Update READMEs
-        id: update_readme
-        run: |
-          python .github/scripts/update_readmes.py
-
-      # Same reason as auto_extract: this job pushes to main with the default
-      # GITHUB_TOKEN, so no workflow run is created and Web CI's coverage test
-      # never sees the new listing. Ask here instead. Never blocks the add (#111).
-      - name: Check globe coverage
-        id: geo
-        run: python .github/scripts/check_geo_coverage.py
+      - name: Rebuild README gallery
+        run: python .github/scripts/generate_gallery.py
 
       - name: Configure Git
         env:
@@ -64,13 +62,12 @@ jobs:
         env:
           COMMIT_MSG: ${{ steps.process.outputs.commit_message }}
         run: |
-          git add .github/scripts/listings.json README.md assets/hackathons-banner.svg
+          git add .github/scripts/gallery.json assets/gallery README.md
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
             git commit -m "$COMMIT_MSG"
           fi
-          # Rebase and retry push up to 3 times
           ok=false
           for i in 1 2 3; do
             git fetch origin main || { sleep 2; continue; }
@@ -83,37 +80,34 @@ jobs:
       - name: Close issue with success message
         if: success()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          IMAGE_PATH: ${{ steps.process.outputs.image_path }}
         with:
           script: |
-            let body = '✅ Your contribution has been added to the repository! Thank you for contributing!\n\nYour changes should now be visible in the README.';
-
-            // Named, not silent: live everywhere except the globe until someone
-            // adds the city (#111).
-            const missingGeo = (process.env.MISSING_GEO || '').trim();
-            if (missingGeo) {
-              body += `\n\n> **Not on the globe yet.**\n`;
-              body += `> \`\`\`\n${missingGeo.split('\n').map(l => `> ${l}`).join('\n')}\n> \`\`\`\n`;
-              body += `> A maintainer can put it on the map by adding the location to \`.github/scripts/geocodes.json\`.`;
-            }
-
+            const imagePath = process.env.IMAGE_PATH || 'assets/gallery/';
+            const body = [
+              '✅ Your photo has been added to the community gallery. Thank you!',
+              '',
+              `Saved as \`${imagePath}\`. It will show on the site after the next deploy/rebuild, and in the README gallery now.`,
+            ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: body
+              body,
             });
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              state: 'closed'
+              state: 'closed',
             });
 
       - name: Comment on failure
         if: failure()
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
-          ERROR_MSG: ${{ steps.process.outputs.error_message || steps.update_readme.outputs.error_message }}
+          ERROR_MSG: ${{ steps.process.outputs.error_message }}
         with:
           script: |
             const errorMsg = process.env.ERROR_MSG || 'Unknown error';
@@ -121,5 +115,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: '❌ There was an error processing your contribution. A maintainer will review this issue.\n\nError details: ' + errorMsg
+              body: '❌ Could not add this photo. A maintainer will take a look.\n\nError details: ' + errorMsg,
             });

--- a/assets/gallery/README.md
+++ b/assets/gallery/README.md
@@ -4,14 +4,22 @@ Community photos from hackathons people found through this list.
 
 ## How a photo gets here
 
-1. Someone opens a **Share a Hackathon Photo** issue and attaches their picture.
-2. A maintainer saves the image into this folder and adds an entry to
-   [`.github/scripts/gallery.json`](../../.github/scripts/gallery.json).
-3. `generate_gallery.py` rebuilds the gallery grid in the root `README.md`.
+1. Someone opens a **Share a Hackathon Photo** issue (from the website gallery
+   CTA or [the issue form](../../.github/ISSUE_TEMPLATE/gallery_photo.yaml))
+   and attaches a JPG or PNG (max 5 MB).
+2. A maintainer adds the `approved` label.
+3. [`gallery_approved.yml`](../../.github/workflows/gallery_approved.yml) downloads
+   the attachment, saves it here, appends
+   [`.github/scripts/gallery.json`](../../.github/scripts/gallery.json), and
+   rebuilds the README collage via `generate_gallery.py`.
+4. The website infinite canvas reads `gallery.json` at build time
+   (`web/scripts/prepare-repo-data.mjs`), so the new photo appears on the next
+   deploy — no code change required.
 
 ## Filename convention
 
-`hackathon-year-name.jpg` — for example `hackmit-2026-jose.jpg`.
+`hackathon-credit.jpg` (or `.png`) — for example `hackmit-2026-jose.jpg`.
+The approval bot slugifies the hackathon + credit fields automatically.
 
 ## gallery.json entry
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { loadGalleryPhotos } from "@/lib/gallery";
 import { loadHackathons, siteStats } from "@/lib/listings";
 import { HomeClient } from "@/components/hq/home-client";
 
@@ -8,6 +9,13 @@ export const revalidate = 3600;
 export default function Home() {
   const hackathons = loadHackathons();
   const stats = siteStats(hackathons);
+  const galleryPhotos = loadGalleryPhotos();
 
-  return <HomeClient hackathons={hackathons} stats={stats} />;
+  return (
+    <HomeClient
+      hackathons={hackathons}
+      stats={stats}
+      galleryPhotos={galleryPhotos}
+    />
+  );
 }

--- a/web/components/hq/gallery-canvas.tsx
+++ b/web/components/hq/gallery-canvas.tsx
@@ -1,62 +1,51 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  packGalleryTiles,
+  type GalleryPhoto,
+  type GalleryTileItem,
+} from "@/lib/gallery";
+import { submitGalleryPhotoUrl } from "@/lib/types-hq";
 
 /* Infinite draggable canvas of the community's hackathon photos.
 
-   The photos pack into one seamless 6×6 tile (cells matched to each image's
-   orientation — portraits in tall cells, landscapes in wide ones). That tile is
-   repeated across a grid large enough to cover the viewport plus a margin, and
-   the whole world is panned by dragging. The pan offset is wrapped modulo the
-   tile period, so the pattern repeats forever in every direction. */
-
-const BASE = "/repo-assets/gallery/";
-
-type Item = {
-  src: string;
-  col: number;
-  colSpan: number;
-  row: number;
-  rowSpan: number;
-};
-
-// Every cell of the 6×6 grid is filled exactly once, so the tile is a perfect
-// rectangle and butts seamlessly against its own copies.
-const TILE_ITEMS: Item[] = [
-  { src: "lahacks-ucla", col: 1, colSpan: 2, row: 1, rowSpan: 3 }, // portrait
-  { src: "code-and-tell", col: 3, colSpan: 2, row: 1, rowSpan: 2 }, // landscape
-  { src: "library-coding", col: 5, colSpan: 1, row: 1, rowSpan: 2 }, // tall
-  { src: "bostonhacks", col: 6, colSpan: 1, row: 1, rowSpan: 3 }, // tall
-  { src: "hackpsu", col: 3, colSpan: 3, row: 3, rowSpan: 2 }, // landscape
-  { src: "gtm-hackathon", col: 1, colSpan: 2, row: 4, rowSpan: 3 }, // portrait
-  { src: "gtm-welcome", col: 6, colSpan: 1, row: 4, rowSpan: 3 }, // tall
-  { src: "yhack", col: 3, colSpan: 3, row: 5, rowSpan: 2 }, // landscape
-];
+   Photos come from gallery.json (via loadGalleryPhotos on the server). They
+   pack into one seamless tile — the hand-tuned 6×6 slot template, stacked
+   vertically when there are more than eight photos — which is repeated across
+   a grid large enough to cover the viewport plus a margin. The pan offset is
+   wrapped modulo the tile period, so the pattern repeats forever. */
 
 const CW = 138; // base cell size (px)
 const G = 8; // gap between cells / tiles
-const COLS = 6;
-const ROWS = 6;
-const TILE_W = COLS * CW + (COLS - 1) * G;
-const TILE_H = ROWS * CW + (ROWS - 1) * G;
-const PERIOD_X = TILE_W + G;
-const PERIOD_Y = TILE_H + G;
 
-function Tile() {
+function Tile({
+  items,
+  cols,
+  rows,
+  tileW,
+  tileH,
+}: {
+  items: GalleryTileItem[];
+  cols: number;
+  rows: number;
+  tileW: number;
+  tileH: number;
+}) {
   return (
     <div
       className="grid shrink-0"
       style={{
-        gridTemplateColumns: `repeat(${COLS}, ${CW}px)`,
-        gridTemplateRows: `repeat(${ROWS}, ${CW}px)`,
+        gridTemplateColumns: `repeat(${cols}, ${CW}px)`,
+        gridTemplateRows: `repeat(${rows}, ${CW}px)`,
         gap: `${G}px`,
-        width: TILE_W,
-        height: TILE_H,
+        width: tileW,
+        height: tileH,
       }}
     >
-      {TILE_ITEMS.map((it) => (
+      {items.map((it) => (
         <div
-          key={it.src}
+          key={it.key}
           className="overflow-hidden rounded-lg bg-ink-soft"
           style={{
             gridColumn: `${it.col} / span ${it.colSpan}`,
@@ -65,8 +54,8 @@ function Tile() {
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={`${BASE}${it.src}.jpg`}
-            alt=""
+            src={it.src}
+            alt={it.alt}
             draggable={false}
             className="pointer-events-none h-full w-full select-none object-cover"
           />
@@ -76,7 +65,72 @@ function Tile() {
   );
 }
 
-export function GalleryCanvas() {
+type ShareState = "idle" | "ready" | "opened" | "blocked";
+
+function SharePhotoCta() {
+  const [hackathon, setHackathon] = useState("");
+  const [state, setState] = useState<ShareState>("idle");
+
+  const trimmed = hackathon.trim();
+  const canSubmit = trimmed.length > 0;
+
+  return (
+    <div className="mt-4 flex flex-col gap-3 sm:mt-0 sm:max-w-sm sm:items-end">
+      <form
+        className="flex w-full flex-col gap-2 sm:flex-row sm:items-end"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!canSubmit) {
+            setState("idle");
+            return;
+          }
+          const url = submitGalleryPhotoUrl({ hackathon: trimmed });
+          const win = window.open(url, "_blank", "noopener,noreferrer");
+          setState(win ? "opened" : "blocked");
+        }}
+      >
+        <label className="min-w-0 flex-1">
+          <span className="kicker mb-1.5 block text-[9px] text-paper/45">
+            Share a photo
+          </span>
+          <input
+            value={hackathon}
+            onChange={(e) => {
+              setHackathon(e.target.value);
+              setState(e.target.value.trim() ? "ready" : "idle");
+            }}
+            placeholder="Which hackathon?"
+            maxLength={80}
+            className="w-full rounded-xl border border-white/15 bg-ink-deep/40 px-3 py-2.5 text-sm text-paper outline-none backdrop-blur transition placeholder:text-paper/30 focus:border-coral"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="shrink-0 rounded-full bg-coral px-5 py-2.5 font-mono text-[10px] font-bold tracking-[0.16em] text-paper transition hover:bg-coral-bright disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          OPEN GITHUB ↗
+        </button>
+      </form>
+      <p className="text-right font-mono text-[10px] tracking-wide text-paper/35">
+        {state === "opened" &&
+          "Issue opened — attach a JPG or PNG (max 5 MB) there."}
+        {state === "blocked" &&
+          "Popup blocked. Allow popups for this site, then try again."}
+        {state === "ready" && "Opens a prefilled photo issue. JPG or PNG, ≤5 MB."}
+        {state === "idle" && "JPG or PNG, ≤5 MB. A maintainer approves before it lands."}
+      </p>
+    </div>
+  );
+}
+
+export function GalleryCanvas({ photos }: { photos: GalleryPhoto[] }) {
+  const packed = useMemo(() => packGalleryTiles(photos), [photos]);
+  const tileW = packed.cols * CW + (packed.cols - 1) * G;
+  const tileH = packed.rows * CW + (packed.rows - 1) * G;
+  const periodX = tileW + G;
+  const periodY = tileH + G;
+
   const canvasRef = useRef<HTMLDivElement>(null);
   const worldRef = useRef<HTMLDivElement>(null);
   const st = useRef({
@@ -97,9 +151,9 @@ export function GalleryCanvas() {
     const el = worldRef.current;
     if (!el) return;
     const wrap = (v: number, p: number) => (((v % p) + p) % p) - p;
-    el.style.transform = `translate3d(${wrap(st.current.ox, PERIOD_X)}px, ${wrap(
+    el.style.transform = `translate3d(${wrap(st.current.ox, periodX)}px, ${wrap(
       st.current.oy,
-      PERIOD_Y,
+      periodY,
     )}px, 0)`;
   };
 
@@ -109,8 +163,8 @@ export function GalleryCanvas() {
       const el = canvasRef.current;
       if (!el) return;
       setGrid({
-        cols: Math.ceil(el.clientWidth / TILE_W) + 2,
-        rows: Math.ceil(el.clientHeight / TILE_H) + 2,
+        cols: Math.ceil(el.clientWidth / tileW) + 2,
+        rows: Math.ceil(el.clientHeight / tileH) + 2,
       });
     };
     measure();
@@ -120,7 +174,9 @@ export function GalleryCanvas() {
       window.removeEventListener("resize", measure);
       cancelAnimationFrame(s.raf);
     };
-  }, []);
+    // Re-measure when the packed tile size changes (more photos → taller tile).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- apply closes over periodX/Y
+  }, [tileW, tileH, periodX, periodY]);
 
   const onDown = (e: React.PointerEvent) => {
     cancelAnimationFrame(st.current.raf);
@@ -168,42 +224,64 @@ export function GalleryCanvas() {
   };
 
   const tiles = Array.from({ length: grid.cols * grid.rows });
+  const empty = packed.items.length === 0;
 
   return (
     <section className="p-2 pt-20">
-      <div className="mb-3 flex items-end justify-between px-2">
+      <div className="mb-3 flex flex-col gap-4 px-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="kicker text-coral">The community · In the wild</div>
           <h2 className="display mt-3 text-[clamp(2rem,5vw,3.4rem)] text-paper">
             The gallery
           </h2>
+          <p className="mt-2 hidden max-w-md text-sm text-paper/50 sm:block">
+            Drag to explore. Photos land here after a maintainer approves a
+            Share a Hackathon Photo issue.
+          </p>
         </div>
-        <span className="kicker hidden text-paper/35 sm:block">
-          Drag to explore ↔
-        </span>
+        <SharePhotoCta />
       </div>
 
       <div
         ref={canvasRef}
         aria-label="Photo wall from community hackathons — drag to explore"
         className="shell relative h-[clamp(440px,76vh,820px)] cursor-grab touch-none select-none bg-ink-deep active:cursor-grabbing"
-        onPointerDown={onDown}
-        onPointerMove={onMove}
-        onPointerUp={onUp}
-        onPointerCancel={onUp}
+        onPointerDown={empty ? undefined : onDown}
+        onPointerMove={empty ? undefined : onMove}
+        onPointerUp={empty ? undefined : onUp}
+        onPointerCancel={empty ? undefined : onUp}
       >
-        <div
-          ref={worldRef}
-          className="absolute left-0 top-0 grid will-change-transform"
-          style={{
-            gridTemplateColumns: `repeat(${grid.cols}, ${TILE_W}px)`,
-            gap: `${G}px`,
-          }}
-        >
-          {tiles.map((_, i) => (
-            <Tile key={i} />
-          ))}
-        </div>
+        {empty ? (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+            <p className="font-display text-lg text-paper/70">
+              No photos yet — be the first.
+            </p>
+            <p className="max-w-sm text-sm text-paper/40">
+              Use Share a photo above to open a GitHub issue and attach a JPG or
+              PNG from a hackathon you found here.
+            </p>
+          </div>
+        ) : (
+          <div
+            ref={worldRef}
+            className="absolute left-0 top-0 grid will-change-transform"
+            style={{
+              gridTemplateColumns: `repeat(${grid.cols}, ${tileW}px)`,
+              gap: `${G}px`,
+            }}
+          >
+            {tiles.map((_, i) => (
+              <Tile
+                key={i}
+                items={packed.items}
+                cols={packed.cols}
+                rows={packed.rows}
+                tileW={tileW}
+                tileH={tileH}
+              />
+            ))}
+          </div>
+        )}
 
         {/* edge vignette so the wall fades into the shell */}
         <div

--- a/web/components/hq/gallery-canvas.tsx
+++ b/web/components/hq/gallery-canvas.tsx
@@ -6,7 +6,6 @@ import {
   type GalleryPhoto,
   type GalleryTileItem,
 } from "@/lib/gallery";
-import { submitGalleryPhotoUrl } from "@/lib/types-hq";
 
 /* Infinite draggable canvas of the community's hackathon photos.
 
@@ -14,7 +13,10 @@ import { submitGalleryPhotoUrl } from "@/lib/types-hq";
    pack into one seamless tile — the hand-tuned 6×6 slot template, stacked
    vertically when there are more than eight photos — which is repeated across
    a grid large enough to cover the viewport plus a margin. The pan offset is
-   wrapped modulo the tile period, so the pattern repeats forever. */
+   wrapped modulo the tile period, so the pattern repeats forever.
+
+   Photo submission lives in GallerySubmitSection (sections.tsx), immediately
+   below this canvas — same glass-card pattern as the hackathon SubmitSection. */
 
 const CW = 138; // base cell size (px)
 const G = 8; // gap between cells / tiles
@@ -61,65 +63,6 @@ function Tile({
           />
         </div>
       ))}
-    </div>
-  );
-}
-
-type ShareState = "idle" | "ready" | "opened" | "blocked";
-
-function SharePhotoCta() {
-  const [hackathon, setHackathon] = useState("");
-  const [state, setState] = useState<ShareState>("idle");
-
-  const trimmed = hackathon.trim();
-  const canSubmit = trimmed.length > 0;
-
-  return (
-    <div className="mt-4 flex flex-col gap-3 sm:mt-0 sm:max-w-sm sm:items-end">
-      <form
-        className="flex w-full flex-col gap-2 sm:flex-row sm:items-end"
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (!canSubmit) {
-            setState("idle");
-            return;
-          }
-          const url = submitGalleryPhotoUrl({ hackathon: trimmed });
-          const win = window.open(url, "_blank", "noopener,noreferrer");
-          setState(win ? "opened" : "blocked");
-        }}
-      >
-        <label className="min-w-0 flex-1">
-          <span className="kicker mb-1.5 block text-[9px] text-paper/45">
-            Share a photo
-          </span>
-          <input
-            value={hackathon}
-            onChange={(e) => {
-              setHackathon(e.target.value);
-              setState(e.target.value.trim() ? "ready" : "idle");
-            }}
-            placeholder="Which hackathon?"
-            maxLength={80}
-            className="w-full rounded-xl border border-white/15 bg-ink-deep/40 px-3 py-2.5 text-sm text-paper outline-none backdrop-blur transition placeholder:text-paper/30 focus:border-coral"
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={!canSubmit}
-          className="shrink-0 rounded-full bg-coral px-5 py-2.5 font-mono text-[10px] font-bold tracking-[0.16em] text-paper transition hover:bg-coral-bright disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          OPEN GITHUB ↗
-        </button>
-      </form>
-      <p className="text-right font-mono text-[10px] tracking-wide text-paper/35">
-        {state === "opened" &&
-          "Issue opened — attach a JPG or PNG (max 5 MB) there."}
-        {state === "blocked" &&
-          "Popup blocked. Allow popups for this site, then try again."}
-        {state === "ready" && "Opens a prefilled photo issue. JPG or PNG, ≤5 MB."}
-        {state === "idle" && "JPG or PNG, ≤5 MB. A maintainer approves before it lands."}
-      </p>
     </div>
   );
 }
@@ -228,18 +171,16 @@ export function GalleryCanvas({ photos }: { photos: GalleryPhoto[] }) {
 
   return (
     <section className="p-2 pt-20">
-      <div className="mb-3 flex flex-col gap-4 px-2 sm:flex-row sm:items-end sm:justify-between">
+      <div className="mb-3 flex items-end justify-between px-2">
         <div>
           <div className="kicker text-coral">The community · In the wild</div>
           <h2 className="display mt-3 text-[clamp(2rem,5vw,3.4rem)] text-paper">
             The gallery
           </h2>
-          <p className="mt-2 hidden max-w-md text-sm text-paper/50 sm:block">
-            Drag to explore. Photos land here after a maintainer approves a
-            Share a Hackathon Photo issue.
-          </p>
         </div>
-        <SharePhotoCta />
+        <span className="kicker hidden text-paper/35 sm:block">
+          Drag to explore ↔
+        </span>
       </div>
 
       <div
@@ -257,8 +198,11 @@ export function GalleryCanvas({ photos }: { photos: GalleryPhoto[] }) {
               No photos yet — be the first.
             </p>
             <p className="max-w-sm text-sm text-paper/40">
-              Use Share a photo above to open a GitHub issue and attach a JPG or
-              PNG from a hackathon you found here.
+              Use{" "}
+              <a href="#share-photo" className="text-coral underline-offset-4 hover:underline">
+                Share a photo
+              </a>{" "}
+              below to open a GitHub issue and attach a JPG or PNG.
             </p>
           </div>
         ) : (

--- a/web/components/hq/home-client.tsx
+++ b/web/components/hq/home-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { GalleryPhoto } from "@/lib/gallery";
 import type { Hackathon, SiteStats } from "@/lib/types-hq";
 import { HQProvider } from "./store";
 import { NavPill } from "./nav";
@@ -20,9 +21,11 @@ import { GalleryCanvas } from "./gallery-canvas";
 export function HomeClient({
   hackathons,
   stats,
+  galleryPhotos,
 }: {
   hackathons: Hackathon[];
   stats: SiteStats;
+  galleryPhotos: GalleryPhoto[];
 }) {
   return (
     <HQProvider>
@@ -33,7 +36,7 @@ export function HomeClient({
         <StatsStrip stats={stats} />
         <ThemeMarquee hackathons={hackathons} />
         <ResourcesShowcase />
-        <GalleryCanvas />
+        <GalleryCanvas photos={galleryPhotos} />
         <Developers />
         <SubmitSection />
       </main>

--- a/web/components/hq/home-client.tsx
+++ b/web/components/hq/home-client.tsx
@@ -12,6 +12,7 @@ import {
   StatsStrip,
   ThemeMarquee,
   Developers,
+  GallerySubmitSection,
   SubmitSection,
   Footer,
 } from "./sections";
@@ -37,6 +38,7 @@ export function HomeClient({
         <ThemeMarquee hackathons={hackathons} />
         <ResourcesShowcase />
         <GalleryCanvas photos={galleryPhotos} />
+        <GallerySubmitSection />
         <Developers />
         <SubmitSection />
       </main>

--- a/web/components/hq/sections.tsx
+++ b/web/components/hq/sections.tsx
@@ -419,7 +419,11 @@ export function GallerySubmitSection() {
                 hackathon: trimmed,
                 credit: credit.trim() || undefined,
               });
-              const win = window.open(url, "_blank", "noopener,noreferrer");
+              // Same as SubmitSection: open in a new tab from a user gesture.
+              // Do NOT pass "noopener" as a window feature — browsers then return
+              // null even when the tab opened, which falsely looked like a block.
+              const win = window.open(url, "_blank");
+              if (win) win.opener = null;
               setState(win ? "opened" : "blocked");
             }}
           >

--- a/web/components/hq/sections.tsx
+++ b/web/components/hq/sections.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { buildContactMailto } from "@/lib/contact-email";
 import type { Hackathon, SiteStats } from "@/lib/types-hq";
-import { REPO_URL, submitIssueUrl } from "@/lib/types-hq";
+import { REPO_URL, submitGalleryPhotoUrl, submitIssueUrl } from "@/lib/types-hq";
 
 /* ----- Stats strip (Magnetto metrics style) ----- */
 
@@ -362,6 +362,116 @@ export function Developers() {
               </button>
             ),
           )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ----- Share a gallery photo (#221) -----
+   Same glass-card pattern as SubmitSection, parked between the infinite
+   canvas and the crew so a visitor who just dragged the wall can contribute
+   without scrolling to the hackathon form further down. Opens gallery_photo.yaml;
+   the image itself has to be attached on GitHub (query params can't carry files). */
+
+type GalleryShareState = "idle" | "ready" | "opened" | "blocked";
+
+export function GallerySubmitSection() {
+  const [hackathon, setHackathon] = useState("");
+  const [credit, setCredit] = useState("");
+  const [state, setState] = useState<GalleryShareState>("idle");
+
+  const trimmed = hackathon.trim();
+  const canSubmit = trimmed.length > 0;
+
+  return (
+    <section
+      id="share-photo"
+      tabIndex={-1}
+      style={{ scrollMarginTop: "var(--nav-pill-bottom, 4.875rem)" }}
+      className="mt-10 p-2 focus:outline-none"
+    >
+      <div className="shell flex min-h-[60vh] items-center justify-center bg-ink px-5 py-14 sm:px-10">
+        <div className="glass w-full max-w-2xl rounded-[2.5rem] p-8 sm:p-12">
+          <div className="kicker text-center text-coral">
+            The community · Share a moment
+          </div>
+          <h2 className="display mt-3 text-center text-[clamp(1.5rem,3.4vw,2.6rem)] text-paper">
+            Add your photo
+            <br />
+            to the wall
+          </h2>
+          <p className="mx-auto mt-4 max-w-md text-center text-sm leading-relaxed text-paper/60">
+            Went to a hackathon you found here? Drop the name, open the issue,
+            and attach a JPG or PNG (max 5 MB). A maintainer approves it before
+            it lands on the canvas.
+          </p>
+
+          <form
+            className="mt-8 flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!canSubmit) {
+                setState("idle");
+                return;
+              }
+              const url = submitGalleryPhotoUrl({
+                hackathon: trimmed,
+                credit: credit.trim() || undefined,
+              });
+              const win = window.open(url, "_blank", "noopener,noreferrer");
+              setState(win ? "opened" : "blocked");
+            }}
+          >
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <label className="flex-1">
+                <span className="kicker mb-2 block text-[9px] text-paper/50">
+                  Hackathon name
+                </span>
+                <input
+                  value={hackathon}
+                  onChange={(e) => {
+                    setHackathon(e.target.value);
+                    setState(e.target.value.trim() ? "ready" : "idle");
+                  }}
+                  placeholder="HackMIT 2027"
+                  maxLength={80}
+                  required
+                  className="w-full rounded-xl border border-white/15 bg-ink-deep/40 px-4 py-3.5 text-sm text-paper outline-none backdrop-blur transition placeholder:text-paper/30 focus:border-coral"
+                />
+              </label>
+              <label className="flex-1">
+                <span className="kicker mb-2 block text-[9px] text-paper/50">
+                  Your name (optional)
+                </span>
+                <input
+                  value={credit}
+                  onChange={(e) => setCredit(e.target.value)}
+                  placeholder="How should we credit you?"
+                  maxLength={80}
+                  className="w-full rounded-xl border border-white/15 bg-ink-deep/40 px-4 py-3.5 text-sm text-paper outline-none backdrop-blur transition placeholder:text-paper/30 focus:border-coral"
+                />
+              </label>
+            </div>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="mt-2 rounded-full bg-paper py-4 font-mono text-[12px] font-bold tracking-[0.2em] text-ink transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              SHARE VIA GITHUB ↗
+            </button>
+          </form>
+
+          <div className="kicker mt-6 text-center text-[9px] text-paper/35">
+            {state === "opened" &&
+              "Issue opened — attach your JPG or PNG there (max 5 MB)."}
+            {state === "blocked" &&
+              "Popup blocked. Allow popups for this site, then try again."}
+            {state === "ready" &&
+              "Opens a prefilled photo issue — attach the image on GitHub."}
+            {state === "idle" &&
+              "Same engine as hackathon submit — opens a prefilled GitHub issue"}
+          </div>
         </div>
       </div>
     </section>

--- a/web/lib/gallery.test.ts
+++ b/web/lib/gallery.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  GALLERY_COLS,
+  GALLERY_ROWS,
+  SLOT_TEMPLATE,
+  galleryPublicSrc,
+  packGalleryTiles,
+  parseGalleryPhotos,
+  type GalleryPhoto,
+} from "./gallery";
+
+function photo(n: number): GalleryPhoto {
+  return {
+    image: `assets/gallery/photo-${n}.jpg`,
+    hackathon: `Hack ${n}`,
+  };
+}
+
+/** Every cell of a cols×rows grid is covered exactly once. */
+function coversExactly(items: ReturnType<typeof packGalleryTiles>["items"], cols: number, rows: number) {
+  const cells = new Set<string>();
+  for (const it of items) {
+    for (let r = it.row; r < it.row + it.rowSpan; r++) {
+      for (let c = it.col; c < it.col + it.colSpan; c++) {
+        const key = `${c},${r}`;
+        expect(cells.has(key), `overlap at ${key}`).toBe(false);
+        cells.add(key);
+        expect(c).toBeGreaterThanOrEqual(1);
+        expect(c).toBeLessThanOrEqual(cols);
+        expect(r).toBeGreaterThanOrEqual(1);
+        expect(r).toBeLessThanOrEqual(rows);
+      }
+    }
+  }
+  expect(cells.size).toBe(cols * rows);
+}
+
+describe("galleryPublicSrc", () => {
+  it("maps assets/ paths into the public repo-assets URL", () => {
+    expect(galleryPublicSrc("assets/gallery/lahacks-ucla.jpg")).toBe(
+      "/repo-assets/gallery/lahacks-ucla.jpg",
+    );
+  });
+});
+
+describe("parseGalleryPhotos", () => {
+  it("keeps only rows with an assets/gallery image and a hackathon name", () => {
+    const photos = parseGalleryPhotos([
+      {
+        image: "assets/gallery/a.jpg",
+        hackathon: "A",
+        credit: "X",
+        credit_url: "https://example.com",
+      },
+      { image: "assets/other/b.jpg", hackathon: "B" },
+      { image: "assets/gallery/c.jpg", hackathon: "" },
+      { image: "assets/gallery/a.jpg", hackathon: "Dup" },
+      null,
+      "nope",
+    ]);
+    expect(photos).toEqual([
+      {
+        image: "assets/gallery/a.jpg",
+        hackathon: "A",
+        credit: "X",
+        creditUrl: "https://example.com",
+      },
+    ]);
+  });
+
+  it("returns empty for a non-array", () => {
+    expect(parseGalleryPhotos(null)).toEqual([]);
+  });
+});
+
+describe("packGalleryTiles", () => {
+  it("uses one 6×6 stack for up to eight photos and covers every cell", () => {
+    const packed = packGalleryTiles(Array.from({ length: 8 }, (_, i) => photo(i)));
+    expect(packed.cols).toBe(GALLERY_COLS);
+    expect(packed.rows).toBe(GALLERY_ROWS);
+    expect(packed.items).toHaveLength(SLOT_TEMPLATE.length);
+    coversExactly(packed.items, packed.cols, packed.rows);
+  });
+
+  it("stacks the template when there are more than eight photos", () => {
+    const packed = packGalleryTiles(Array.from({ length: 9 }, (_, i) => photo(i)));
+    expect(packed.rows).toBe(GALLERY_ROWS * 2);
+    expect(packed.items).toHaveLength(SLOT_TEMPLATE.length * 2);
+    coversExactly(packed.items, packed.cols, packed.rows);
+  });
+
+  it("cycles photos to fill a stack when N is not a multiple of eight", () => {
+    const packed = packGalleryTiles([photo(0), photo(1), photo(2)]);
+    expect(packed.items).toHaveLength(SLOT_TEMPLATE.length);
+    const keys = new Set(packed.items.map((it) => it.src));
+    expect(keys.size).toBe(3);
+    coversExactly(packed.items, packed.cols, packed.rows);
+  });
+
+  it("returns an empty pack for no photos", () => {
+    expect(packGalleryTiles([])).toEqual({
+      items: [],
+      cols: GALLERY_COLS,
+      rows: GALLERY_ROWS,
+    });
+  });
+
+  it("preserves the original slot geometry for the first stack", () => {
+    const packed = packGalleryTiles(Array.from({ length: 8 }, (_, i) => photo(i)));
+    for (let i = 0; i < SLOT_TEMPLATE.length; i++) {
+      const slot = SLOT_TEMPLATE[i]!;
+      const item = packed.items[i]!;
+      expect(item.col).toBe(slot.col);
+      expect(item.colSpan).toBe(slot.colSpan);
+      expect(item.row).toBe(slot.row);
+      expect(item.rowSpan).toBe(slot.rowSpan);
+    }
+  });
+});

--- a/web/lib/gallery.ts
+++ b/web/lib/gallery.ts
@@ -1,0 +1,164 @@
+/* ---------------------------------------------------------------------------
+   Community gallery photos (#221).
+
+   Source of truth is .github/scripts/gallery.json (same file the README collage
+   is built from). prepare-repo-data.mjs snapshots it into lib/generated/ so the
+   infinite canvas can import it on Workers with no request-time filesystem.
+
+   The canvas needs a perfect rectangular tile with no holes — otherwise the
+   modulo wrap exposes empty cells. SLOT_TEMPLATE is the hand-packed 6×6 layout
+   the gallery shipped with; packGalleryTiles stacks that template vertically
+   enough times to hold every photo, cycling when a stack isn't full so the
+   rectangle stays complete.
+--------------------------------------------------------------------------- */
+
+import galleryData from "./generated/gallery.json";
+
+export type GalleryPhoto = {
+  /** Repo-relative path, e.g. assets/gallery/lahacks-ucla.jpg */
+  image: string;
+  hackathon: string;
+  caption?: string;
+  credit?: string;
+  creditUrl?: string;
+};
+
+export type GalleryTileItem = {
+  /** Public URL under /repo-assets/… */
+  src: string;
+  /** Stable key for React lists (the repo-relative image path). */
+  key: string;
+  alt: string;
+  col: number;
+  colSpan: number;
+  row: number;
+  rowSpan: number;
+};
+
+export type PackedGallery = {
+  items: GalleryTileItem[];
+  cols: number;
+  rows: number;
+};
+
+/** One seamless 6×6 pack — every cell covered exactly once. */
+export const GALLERY_COLS = 6;
+export const GALLERY_ROWS = 6;
+
+/**
+ * Relative slot geometry for one 6×6 tile. Order matches the original
+ * TILE_ITEMS layout in gallery-canvas.tsx so N=8 keeps the same masonry rhythm
+ * (only which photo sits in which slot follows gallery.json order).
+ */
+export const SLOT_TEMPLATE: ReadonlyArray<{
+  col: number;
+  colSpan: number;
+  row: number;
+  rowSpan: number;
+}> = [
+  { col: 1, colSpan: 2, row: 1, rowSpan: 3 },
+  { col: 3, colSpan: 2, row: 1, rowSpan: 2 },
+  { col: 5, colSpan: 1, row: 1, rowSpan: 2 },
+  { col: 6, colSpan: 1, row: 1, rowSpan: 3 },
+  { col: 3, colSpan: 3, row: 3, rowSpan: 2 },
+  { col: 1, colSpan: 2, row: 4, rowSpan: 3 },
+  { col: 6, colSpan: 1, row: 4, rowSpan: 3 },
+  { col: 3, colSpan: 3, row: 5, rowSpan: 2 },
+];
+
+type RawGalleryEntry = {
+  image?: unknown;
+  hackathon?: unknown;
+  caption?: unknown;
+  credit?: unknown;
+  credit_url?: unknown;
+};
+
+/** assets/gallery/foo.jpg → /repo-assets/gallery/foo.jpg */
+export function galleryPublicSrc(imagePath: string): string {
+  const relative = imagePath.replace(/^\/+/, "");
+  if (relative.startsWith("assets/")) {
+    return `/repo-assets/${relative.slice("assets/".length)}`;
+  }
+  return `/${relative}`;
+}
+
+function asOptionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Coerce untrusted gallery.json into clean photos. Drop rows without a usable
+ * image path + hackathon name so a bad entry can't blank the whole canvas.
+ */
+export function parseGalleryPhotos(value: unknown): GalleryPhoto[] {
+  if (!Array.isArray(value)) return [];
+  const out: GalleryPhoto[] = [];
+  const seen = new Set<string>();
+  for (const row of value) {
+    if (!row || typeof row !== "object") continue;
+    const raw = row as RawGalleryEntry;
+    const image = asOptionalString(raw.image);
+    const hackathon = asOptionalString(raw.hackathon);
+    if (!image || !hackathon) continue;
+    if (!image.startsWith("assets/gallery/")) continue;
+    if (seen.has(image)) continue;
+    seen.add(image);
+    out.push({
+      image,
+      hackathon,
+      caption: asOptionalString(raw.caption),
+      credit: asOptionalString(raw.credit),
+      creditUrl: asOptionalString(raw.credit_url),
+    });
+  }
+  return out;
+}
+
+export function loadGalleryPhotos(): GalleryPhoto[] {
+  return parseGalleryPhotos(galleryData);
+}
+
+/**
+ * Map photos onto stacked copies of SLOT_TEMPLATE. One stack when there are at
+ * most 8 photos; ceil(N/8) stacks otherwise. Empty input yields an empty pack
+ * (the canvas shows a CTA-only empty state).
+ */
+export function packGalleryTiles(photos: GalleryPhoto[]): PackedGallery {
+  if (photos.length === 0) {
+    return { items: [], cols: GALLERY_COLS, rows: GALLERY_ROWS };
+  }
+
+  const slotsPerStack = SLOT_TEMPLATE.length;
+  const stacks = Math.max(1, Math.ceil(photos.length / slotsPerStack));
+  const items: GalleryTileItem[] = [];
+
+  for (let s = 0; s < stacks; s++) {
+    for (let i = 0; i < slotsPerStack; i++) {
+      const photo = photos[(s * slotsPerStack + i) % photos.length]!;
+      const slot = SLOT_TEMPLATE[i]!;
+      const alt = photo.caption
+        ? `${photo.hackathon} — ${photo.caption}`
+        : photo.hackathon;
+      items.push({
+        src: galleryPublicSrc(photo.image),
+        // Stack index keeps keys unique when a photo is cycled into a later
+        // stack to fill the rectangle.
+        key: `${photo.image}#${s}-${i}`,
+        alt,
+        col: slot.col,
+        colSpan: slot.colSpan,
+        row: slot.row + s * GALLERY_ROWS,
+        rowSpan: slot.rowSpan,
+      });
+    }
+  }
+
+  return {
+    items,
+    cols: GALLERY_COLS,
+    rows: GALLERY_ROWS * stacks,
+  };
+}

--- a/web/lib/gallery.ts
+++ b/web/lib/gallery.ts
@@ -1,5 +1,5 @@
 /* ---------------------------------------------------------------------------
-   Community gallery photos (#221).
+   Community gallery photos.
 
    Source of truth is .github/scripts/gallery.json (same file the README collage
    is built from). prepare-repo-data.mjs snapshots it into lib/generated/ so the

--- a/web/lib/types-hq.test.ts
+++ b/web/lib/types-hq.test.ts
@@ -5,6 +5,7 @@ import {
   deadlineDisplay,
   eventDateDisplay,
   isActiveHackathon,
+  submitGalleryPhotoUrl,
   submitIssueUrl,
   type Hackathon,
 } from "./types-hq";
@@ -15,6 +16,14 @@ const TEMPLATE_PATH = path.join(
   ".github",
   "ISSUE_TEMPLATE",
   "link_only.yaml",
+);
+
+const GALLERY_TEMPLATE_PATH = path.join(
+  process.cwd(),
+  "..",
+  ".github",
+  "ISSUE_TEMPLATE",
+  "gallery_photo.yaml",
 );
 
 describe("submitIssueUrl", () => {
@@ -57,6 +66,51 @@ describe("submitIssueUrl", () => {
     for (const key of params.keys()) {
       if (key === "template" || key === "title") continue;
       expect(ids, `link_only.yaml has no field id "${key}"`).toContain(key);
+    }
+  });
+});
+
+describe("submitGalleryPhotoUrl", () => {
+  it("targets the gallery_photo issue form", () => {
+    const u = new URL(submitGalleryPhotoUrl({ hackathon: "HackMIT 2026" }));
+    expect(u.pathname).toMatch(/\/issues\/new$/);
+    expect(u.searchParams.get("template")).toBe("gallery_photo.yaml");
+  });
+
+  it("prefills title and hackathon to match the template prefix", () => {
+    const u = new URL(submitGalleryPhotoUrl({ hackathon: "HackMIT 2026" }));
+    expect(u.searchParams.get("title")).toBe("Photo: HackMIT 2026");
+    expect(u.searchParams.get("hackathon")).toBe("HackMIT 2026");
+  });
+
+  it("prefills optional credit fields when provided", () => {
+    const u = new URL(
+      submitGalleryPhotoUrl({
+        hackathon: "YHack",
+        caption: "Demo night",
+        credit: "Ada",
+        creditUrl: "https://example.com/ada",
+      }),
+    );
+    expect(u.searchParams.get("caption")).toBe("Demo night");
+    expect(u.searchParams.get("credit")).toBe("Ada");
+    expect(u.searchParams.get("credit_url")).toBe("https://example.com/ada");
+  });
+
+  it("uses field ids the gallery_photo template declares", () => {
+    const template = fs.readFileSync(GALLERY_TEMPLATE_PATH, "utf8");
+    const ids = [...template.matchAll(/^\s*id:\s*(\S+)/gm)].map((m) => m[1]);
+    const params = new URL(
+      submitGalleryPhotoUrl({
+        hackathon: "X",
+        caption: "c",
+        credit: "n",
+        creditUrl: "https://x.dev",
+      }),
+    ).searchParams;
+    for (const key of params.keys()) {
+      if (key === "template" || key === "title") continue;
+      expect(ids, `gallery_photo.yaml has no field id "${key}"`).toContain(key);
     }
   });
 });

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -104,4 +104,33 @@ export function submitIssueUrl(name = "", url = ""): string {
   return `${REPO_URL}/issues/new?${params.toString()}`;
 }
 
+/**
+ * Prefilled GitHub issue for sharing a gallery photo (#221).
+ *
+ * Targets gallery_photo.yaml. The image itself cannot be attached via query
+ * params — GitHub only prefills text fields — so the form opens with the
+ * hackathon (and optional credit fields) filled and the submitter drops the
+ * JPG/PNG onto the issue. Field ids must match the template; the test pins them.
+ */
+export function submitGalleryPhotoUrl(fields: {
+  hackathon?: string;
+  caption?: string;
+  credit?: string;
+  creditUrl?: string;
+} = {}): string {
+  const params = new URLSearchParams({ template: "gallery_photo.yaml" });
+  const hackathon = fields.hackathon?.trim() ?? "";
+  if (hackathon) {
+    params.set("title", `Photo: ${hackathon}`);
+    params.set("hackathon", hackathon);
+  }
+  const caption = fields.caption?.trim() ?? "";
+  if (caption) params.set("caption", caption);
+  const credit = fields.credit?.trim() ?? "";
+  if (credit) params.set("credit", credit);
+  const creditUrl = fields.creditUrl?.trim() ?? "";
+  if (creditUrl) params.set("credit_url", creditUrl);
+  return `${REPO_URL}/issues/new?${params.toString()}`;
+}
+
 export { REPO_URL };

--- a/web/scripts/prepare-repo-data.mjs
+++ b/web/scripts/prepare-repo-data.mjs
@@ -68,8 +68,8 @@ writeFileSync(path.join(outDir, "listings.json"), JSON.stringify(listings));
 const geocodes = JSON.parse(readFileSync(GEOCODES_PATH, "utf8"));
 writeFileSync(path.join(outDir, "geocodes.json"), JSON.stringify(geocodes));
 
-// --- gallery.json: community photos for the infinite canvas (#221). Same
-// build-time snapshot pattern as listings — no request-time fs on Workers.
+// --- gallery.json: community photos for the infinite canvas. Same
+// build-time snapshot pattern as listings, no request-time fs on Workers.
 const gallery = JSON.parse(readFileSync(GALLERY_PATH, "utf8"));
 if (!Array.isArray(gallery)) {
   throw new Error("gallery.json did not parse to an array");

--- a/web/scripts/prepare-repo-data.mjs
+++ b/web/scripts/prepare-repo-data.mjs
@@ -45,6 +45,7 @@ const outDir = path.join(webRoot, "lib", "generated");
 const README_PATH = path.join(repoRoot, "README.md");
 const LISTINGS_PATH = path.join(repoRoot, ".github", "scripts", "listings.json");
 const GEOCODES_PATH = path.join(repoRoot, ".github", "scripts", "geocodes.json");
+const GALLERY_PATH = path.join(repoRoot, ".github", "scripts", "gallery.json");
 const ASSETS_DIR = path.join(repoRoot, "assets");
 
 mkdirSync(outDir, { recursive: true });
@@ -66,6 +67,14 @@ writeFileSync(path.join(outDir, "listings.json"), JSON.stringify(listings));
 
 const geocodes = JSON.parse(readFileSync(GEOCODES_PATH, "utf8"));
 writeFileSync(path.join(outDir, "geocodes.json"), JSON.stringify(geocodes));
+
+// --- gallery.json: community photos for the infinite canvas (#221). Same
+// build-time snapshot pattern as listings — no request-time fs on Workers.
+const gallery = JSON.parse(readFileSync(GALLERY_PATH, "utf8"));
+if (!Array.isArray(gallery)) {
+  throw new Error("gallery.json did not parse to an array");
+}
+writeFileSync(path.join(outDir, "gallery.json"), JSON.stringify(gallery));
 
 // --- Asset manifest: the "assets/<path>" list resolveAssetSrc() uses to decide
 // local-vs-remote without an fs.existsSync at request time. Mirrors what
@@ -92,5 +101,6 @@ writeFileSync(
 
 console.log(
   `[prepare-repo-data] wrote lib/generated/ ` +
-    `(${listings.length} listings, ${assetManifest.length} assets)`,
+    `(${listings.length} listings, ${gallery.length} gallery photos, ` +
+    `${assetManifest.length} assets)`,
 );


### PR DESCRIPTION
#### Summary
- Drive the infinite canvas from .github/scripts/gallery.json (build-time snapshot via prepare-repo-data.mjs) so approved photos appear on the site without a code change
- Add a Share a photo glass card (same pattern as hackathon submit) between the gallery and contributors; opens the prefilled gallery_photo.yaml issue
- On approved + gallery, download the attached JPG/PNG (≤5 MB, SSRF-guarded), commit it under assets/gallery/, append gallery.json, and rebuild the README collage

Closes #221.

#### How it works
- Visitor fills hackathon name (+ optional credit) → opens a prefilled photo issue
- They attach a JPG or PNG on GitHub
- Maintainer adds the approved label
- gallery_approved.yml commits the image + JSON + README
- Next site rebuild picks it up from gallery.json — canvas and README stay in sync
- Listing approvals (contribution_approved.yml) skip gallery-labeled issues so the two pipelines don’t collide.

#### Test plan

- [x] npm test (gallery pack + submit URL helpers)
- [x] Python unit tests for gallery helpers + workflow coverage list
- [x] Local smoke: image → gallery.json → README collage → site snapshot (9 photos)
- [x] Homepage: gallery still pans; Share a photo card sits under the canvas and opens the issue form with fields prefilled
- [x] Open a real gallery issue with an attached image, add approved, confirm image + gallery.json + README update and issue closes
- [x] Confirm a listing approved issue still goes through contribution_approved.yml (not the gallery workflow)