### PR TITLE
Fix: resources coming soon deck featured

### DIFF
--- a/.github/workflows/gallery_approved.yml
+++ b/.github/workflows/gallery_approved.yml
@@ -1,4 +1,4 @@
-# Approve a "Share a Hackathon Photo" issue → commit image + gallery.json (#221).
+# Approve a "Share a Hackathon Photo" issue → commit image + gallery.json.
 #
 # Mirrors contribution_approved.yml: maintainer applies the `approved` label,
 # the bot downloads the attached JPG/PNG (SSRF-guarded), appends gallery.json,

--- a/assets/gallery/README.md
+++ b/assets/gallery/README.md
@@ -18,7 +18,7 @@ Community photos from hackathons people found through this list.
 
 ## Filename convention
 
-`hackathon-credit.jpg` (or `.png`) — for example `hackmit-2026-jose.jpg`.
+`hackathon-year-name.jpg` (or `.png`) — for example `hackmit-2026-jose.jpg`.
 The approval bot slugifies the hackathon + credit fields automatically.
 
 ## gallery.json entry

--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -7,31 +7,24 @@ import {
   countdown,
   deadlineDisplay,
   eventDateDisplay,
-  isActiveHackathon,
 } from "@/lib/types-hq";
+import {
+  filterDeckHackathons,
+  type DeckFormatFilter,
+  type DeckStatusFilter,
+} from "@/lib/deck-order";
 import { safeHttpUrl } from "@/lib/url";
 import { useSelection, useTracker } from "./store";
 
-type StatusFilter = "all" | HackState;
-type FormatFilter = "all" | "In-Person" | "Virtual";
-
 export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
   const [q, setQ] = useState("");
-  const [status, setStatus] = useState<StatusFilter>("all");
-  const [format, setFormat] = useState<FormatFilter>("all");
+  const [status, setStatus] = useState<DeckStatusFilter>("all");
+  const [format, setFormat] = useState<DeckFormatFilter>("all");
 
-  const filtered = useMemo(() => {
-    const needle = q.trim().toLowerCase();
-    return hackathons.filter(isActiveHackathon).filter((h) => {
-      if (status !== "all" && h.state !== status) return false;
-      if (format !== "all" && h.format !== format) return false;
-      if (!needle) return true;
-      return [h.title, h.host, h.location, ...h.themes]
-        .join(" ")
-        .toLowerCase()
-        .includes(needle);
-    });
-  }, [hackathons, q, status, format]);
+  const filtered = useMemo(
+    () => filterDeckHackathons(hackathons, { q, status, format }),
+    [hackathons, q, status, format],
+  );
 
   return (
     <section id="deck" className="p-2 pt-0">
@@ -65,7 +58,7 @@ export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
                 ["open", "OPEN"],
                 ["closing_soon", "CLOSING SOON"],
                 ["opens_soon", "OPENS SOON"],
-              ] as [StatusFilter, string][]
+              ] as [DeckStatusFilter, string][]
             ).map(([id, label]) => (
               <FilterPill
                 key={id}
@@ -82,7 +75,7 @@ export function Deck({ hackathons }: { hackathons: Hackathon[] }) {
                 ["all", "ANY FORMAT"],
                 ["In-Person", "IN-PERSON"],
                 ["Virtual", "VIRTUAL"],
-              ] as [FormatFilter, string][]
+              ] as [DeckFormatFilter, string][]
             ).map(([id, label]) => (
               <FilterPill
                 key={id}

--- a/web/components/hq/resources.tsx
+++ b/web/components/hq/resources.tsx
@@ -126,13 +126,22 @@ function LinkRow({ link }: { link: ResourceLink }) {
   );
 }
 
+function ComingSoonBadge() {
+  return (
+    <span className="inline-flex shrink-0 items-center rounded-full border border-coral/40 bg-coral/15 px-2.5 py-0.5 font-mono text-[9px] font-bold tracking-[0.16em] text-coral">
+      COMING SOON
+    </span>
+  );
+}
+
 function ToolsStrip() {
   return (
     <section id="tools" style={CLEARS_RAIL} className="p-2 pt-0">
       <div className="shell bg-ink-soft px-6 py-14 sm:px-12 sm:py-20">
         <div className="kicker text-coral">Toolkit · Always useful</div>
-        <h2 className="display mt-3 text-[clamp(1.5rem,3.5vw,2.6rem)] text-paper">
-          Tools & templates
+        <h2 className="mt-3 flex flex-wrap items-center gap-3 text-[clamp(1.5rem,3.5vw,2.6rem)] text-paper">
+          <span className="display">Tools & templates</span>
+          <ComingSoonBadge />
         </h2>
         <p className="mt-4 max-w-xl text-sm leading-relaxed text-paper/60">
           Steal these for any weekend—first hackathon or fiftieth.
@@ -141,8 +150,11 @@ function ToolsStrip() {
         <div className="mt-12 grid gap-10 md:grid-cols-3">
           {RESOURCE_TOOLS.map((tool) => (
             <div key={tool.title}>
-              <div className="font-mono text-[12px] tracking-[0.18em] text-paper">
-                {tool.title.toUpperCase()}
+              <div className="flex flex-wrap items-center gap-2">
+                <div className="font-mono text-[12px] tracking-[0.18em] text-paper">
+                  {tool.title.toUpperCase()}
+                </div>
+                <ComingSoonBadge />
               </div>
               <p className="mt-2 text-sm text-paper/50">{tool.blurb}</p>
               <ul className="mt-5 space-y-2.5">

--- a/web/components/hq/sections.tsx
+++ b/web/components/hq/sections.tsx
@@ -368,7 +368,7 @@ export function Developers() {
   );
 }
 
-/* ----- Share a gallery photo (#221) -----
+/* ----- Share a gallery photo -----
    Same glass-card pattern as SubmitSection, parked between the infinite
    canvas and the crew so a visitor who just dragged the wall can contribute
    without scrolling to the hackathon form further down. Opens gallery_photo.yaml;
@@ -420,8 +420,6 @@ export function GallerySubmitSection() {
                 credit: credit.trim() || undefined,
               });
               // Same as SubmitSection: open in a new tab from a user gesture.
-              // Do NOT pass "noopener" as a window feature — browsers then return
-              // null even when the tab opened, which falsely looked like a block.
               const win = window.open(url, "_blank");
               if (win) win.opener = null;
               setState(win ? "opened" : "blocked");

--- a/web/lib/deck-order.test.ts
+++ b/web/lib/deck-order.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { filterDeckHackathons } from "./deck-order";
+import type { Hackathon } from "./types-hq";
+
+function hack(over: Partial<Hackathon> & { id: string; title: string }): Hackathon {
+  return {
+    host: "Host",
+    tagline: null,
+    url: "https://example.com",
+    location: "Boston, MA",
+    format: "In-Person",
+    prize: null,
+    prizeValue: 0,
+    state: "open",
+    deadline: null,
+    startDate: null,
+    endDate: null,
+    daysLeft: 10,
+    lat: null,
+    lng: null,
+    themes: [],
+    postedAt: 0,
+    featured: false,
+    ...over,
+  };
+}
+
+const defaults = { q: "", status: "all" as const, format: "all" as const };
+
+describe("filterDeckHackathons", () => {
+  const list = [
+    hack({ id: "a", title: "Alpha", featured: false, daysLeft: 3 }),
+    hack({ id: "b", title: "Beta Featured", featured: true, daysLeft: 20 }),
+    hack({ id: "c", title: "Closed", state: "closed", featured: true }),
+    hack({ id: "d", title: "Delta Featured", featured: true, daysLeft: 5 }),
+  ];
+
+  it("puts featured first when filters are at defaults", () => {
+    const ids = filterDeckHackathons(list, defaults).map((h) => h.id);
+    expect(ids).toEqual(["b", "d", "a"]);
+  });
+
+  it("does not boost featured when a status filter is active", () => {
+    const ids = filterDeckHackathons(list, {
+      ...defaults,
+      status: "open",
+    }).map((h) => h.id);
+    // Relative order of open items unchanged (closed dropped): a, b, d
+    expect(ids).toEqual(["a", "b", "d"]);
+  });
+
+  it("does not boost featured when searching", () => {
+    const ids = filterDeckHackathons(list, {
+      ...defaults,
+      q: "featured",
+    }).map((h) => h.id);
+    expect(ids).toEqual(["b", "d"]);
+  });
+});

--- a/web/lib/deck-order.ts
+++ b/web/lib/deck-order.ts
@@ -1,0 +1,38 @@
+import {
+  isActiveHackathon,
+  type Hackathon,
+  type HackState,
+} from "./types-hq";
+
+export type DeckStatusFilter = "all" | HackState;
+export type DeckFormatFilter = "all" | "In-Person" | "Virtual";
+
+/**
+ * Active listings for the deck list. When every filter is at its default,
+ * featured hackathons float to the top; any status/format/search query keeps
+ * the upstream relative order (state + daysLeft from loadHackathons).
+ */
+export function filterDeckHackathons(
+  hackathons: Hackathon[],
+  opts: { q: string; status: DeckStatusFilter; format: DeckFormatFilter },
+): Hackathon[] {
+  const needle = opts.q.trim().toLowerCase();
+  const filtered = hackathons.filter(isActiveHackathon).filter((h) => {
+    if (opts.status !== "all" && h.state !== opts.status) return false;
+    if (opts.format !== "all" && h.format !== opts.format) return false;
+    if (!needle) return true;
+    return [h.title, h.host, h.location, ...h.themes]
+      .join(" ")
+      .toLowerCase()
+      .includes(needle);
+  });
+
+  const defaults =
+    opts.status === "all" && opts.format === "all" && needle === "";
+  if (!defaults) return filtered;
+
+  // Stable: featured first, otherwise leave loadHackathons order intact.
+  return [...filtered].sort(
+    (a, b) => Number(b.featured) - Number(a.featured),
+  );
+}

--- a/web/lib/listings.test.ts
+++ b/web/lib/listings.test.ts
@@ -44,6 +44,7 @@ function hackStub(over: Partial<Hackathon>): Hackathon {
     lng: null,
     themes: [],
     postedAt: 0,
+    featured: false,
     ...over,
   };
 }

--- a/web/lib/listings.ts
+++ b/web/lib/listings.ts
@@ -31,6 +31,7 @@ type RawListing = {
   deadline?: string;
   startDate?: string;
   endDate?: string;
+  featured?: boolean;
 };
 
 const THEME_RULES: [RegExp, string][] = [
@@ -175,6 +176,7 @@ export function loadHackathons(): Hackathon[] {
         lng,
         themes: themesFor(r.title + " " + r.company_name),
         postedAt: r.date_posted ?? 0,
+        featured: r.featured === true,
       } satisfies Hackathon;
     })
     .sort((a, b) => {

--- a/web/lib/passport-stamps.test.ts
+++ b/web/lib/passport-stamps.test.ts
@@ -32,6 +32,7 @@ function hack(over: Partial<Hackathon> & { id: string }): Hackathon {
     lng: null,
     themes: [],
     postedAt: 0,
+    featured: false,
     ...over,
   };
 }

--- a/web/lib/types-hq.test.ts
+++ b/web/lib/types-hq.test.ts
@@ -135,6 +135,7 @@ function hackStub(over: Partial<Hackathon>): Hackathon {
     lng: null,
     themes: [],
     postedAt: 0,
+    featured: false,
     ...over,
   };
 }

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -23,6 +23,8 @@ export type Hackathon = {
   lng: number | null;
   themes: string[];
   postedAt: number;
+  /** Editorial spotlight from listings.json — deck default view sorts these first. */
+  featured: boolean;
 };
 
 export type SiteStats = {

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -107,7 +107,7 @@ export function submitIssueUrl(name = "", url = ""): string {
 }
 
 /**
- * Prefilled GitHub issue for sharing a gallery photo (#221).
+ * Prefilled GitHub issue for sharing a gallery photo.
  *
  * Targets gallery_photo.yaml. The image itself cannot be attached via query
  * params — GitHub only prefills text fields — so the form opens with the


### PR DESCRIPTION
#### Summary
- Add Coming soon badges to the Tools & templates section on /resources (section title + each of the three tool cards)
- Plumb featured from listings.json onto the HQ Hackathon type
- On /deck, when status/format/search are all at defaults, sort featured hackathons first; active filters keep the existing relative order

#### Test plan
- [x]  npm test (including new lib/deck-order.test.ts)
- [x] /resources#tools — section + Pitch outline / README template / Demo checklist each show Coming soon
- [x]  /deck with cleared filters — featured listings appear above the rest
- [x]  /deck with status, format, or search applied — no featured boost; list order matches prior filter behavior