### PR TITLE
fix: openai scraper proxy fix

### DIFF
--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -2,3 +2,5 @@
 requests==2.32.3
 beautifulsoup4==4.12.3
 openai==1.54.4
+# openai 1.54 passes `proxies=` to httpx; httpx 0.28 removed that argument.
+httpx==0.27.2


### PR DESCRIPTION
## Hotfix auto-extract OpenAI client initialization

#### Summary
Pins `httpx` to `0.27.2` so the automated hackathon scraper can initialize the existing `openai==1.54.4` client in GitHub Actions.

The scraper was failing before extraction with:
Client.__init__() got an unexpected keyword argument 'proxies' 

openai==1.54.4 passes proxies= internally, but httpx==0.28+ removed that argument. Because httpx was not explicitly pinned, CI resolved the incompatible latest version.

#### Change
Add httpx==0.27.2 to .github/scripts/requirements.txt.
Document why the pin is required alongside the dependency.

#### Validation
Created a fresh virtual environment from .github/scripts/requirements.txt
Confirmed OpenAI(api_key="test-key") initializes with:
openai==1.54.4
httpx==0.27.2