### PR TITLE
fix: record the user_hackathons migration on main (#254)

### DIFF
--- a/supabase/migrations/20260725154500_user_hackathons.sql
+++ b/supabase/migrations/20260725154500_user_hackathons.sql
@@ -1,0 +1,92 @@
+-- supabase/migrations/20260725154500_user_hackathons.sql
+-- NOTE: applied by hand through the Supabase SQL Editor on 2026-07-26, because
+-- this project has no Supabase CLI or MCP `apply_migration` configured. That
+-- path records nothing in `supabase_migrations.schema_migrations`, so unlike
+-- every other file here this timestamp is NOT a recorded version — it will not
+-- appear in `list_migrations`, and `supabase db push` would try to replay it if
+-- a CLI is ever wired up. See README for the divergence.
+--
+-- The tracker's per-user pipeline, moved off localStorage. One row per
+-- (user, hackathon): which stage it sits in, and whether the user won it (#226).
+--
+-- `user_id` is the Clerk `sub`, matching the `submitted_by` convention on
+-- public.hackathons. It defaults from the JWT rather than being sent by the
+-- client, so a caller cannot write a row owned by someone else even before the
+-- policies below are consulted.
+--
+-- Deliberately NO foreign key to public.hackathons. That table is a mirror the
+-- hourly sync can leave up to an hour behind .github/scripts/listings.json,
+-- which is what the app actually renders from — an FK would reject a save for
+-- any listing added since the last sync. The id is validated in the app layer
+-- against the live listing set instead.
+
+create table if not exists public.user_hackathons (
+  user_id      text        not null default auth.jwt() ->> 'sub',
+  hackathon_id uuid        not null,
+  stage        text        not null default 'interested',
+  is_win       boolean     not null default false,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now(),
+  primary key (user_id, hackathon_id),
+  constraint user_hackathons_stage_check
+    check (stage in ('interested', 'applied', 'accepted', 'going'))
+);
+
+-- `origin` on public.hackathons is text + check for the same reason: adding a
+-- stage means dropping and recreating one constraint, not altering a pg enum.
+
+comment on table public.user_hackathons is
+  'Per-user hackathon tracker: pipeline stage and win flag. user_id is the Clerk sub.';
+
+alter table public.user_hackathons enable row level security;
+
+-- Reads and writes are the owner's only. `(select auth.jwt())` is wrapped so
+-- Postgres evaluates the claim once per statement instead of once per row —
+-- the unwrapped form is what Supabase's performance advisor flags.
+
+drop policy if exists "read own tracker" on public.user_hackathons;
+
+create policy "read own tracker"
+  on public.user_hackathons for select
+  to authenticated
+  using ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "insert own tracker" on public.user_hackathons;
+
+create policy "insert own tracker"
+  on public.user_hackathons for insert
+  to authenticated
+  with check ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "update own tracker" on public.user_hackathons;
+
+create policy "update own tracker"
+  on public.user_hackathons for update
+  to authenticated
+  using ((select auth.jwt() ->> 'sub') = user_id)
+  with check ((select auth.jwt() ->> 'sub') = user_id);
+
+drop policy if exists "delete own tracker" on public.user_hackathons;
+
+create policy "delete own tracker"
+  on public.user_hackathons for delete
+  to authenticated
+  using ((select auth.jwt() ->> 'sub') = user_id);
+
+-- Explicit grants, matching 20260722190741: Supabase's stock bootstrap is not
+-- relied on, so a replay onto a fresh database produces a usable table.
+-- `anon` gets nothing — a tracker has no public read.
+grant select, insert, update, delete on public.user_hackathons to authenticated;
+grant all on public.user_hackathons to service_role;
+
+-- Supabase's stock bootstrap grants every new public table to anon and
+-- authenticated via ALTER DEFAULT PRIVILEGES. A per-user tracker must not
+-- inherit that, so undo it: anon gets nothing at all, and authenticated keeps
+-- only the row DML the policies above gate. TRUNCATE in particular is NOT
+-- subject to RLS, so it must never linger on an API role. Mirrors the intent of
+-- 20260722154244 for the hackathons table.
+revoke all on public.user_hackathons from anon;
+revoke truncate, references, trigger on public.user_hackathons from authenticated;
+
+-- Listing a user's tracker is the only read pattern; the primary key already
+-- serves it (user_id leads), so no extra index is created here.

--- a/supabase/migrations/README.md
+++ b/supabase/migrations/README.md
@@ -28,6 +28,23 @@ top saying so and saying how:
 | `20260722145817_rls_policies.sql` | executable SQL — gained four `drop policy if exists` lines |
 | `20260722144205_add_deck_columns.sql` | comments only — a stale claim about enforcement, corrected |
 
+One file was **applied by hand**, not through `apply_migration`, so it is absent
+from `list_migrations` and `ls` here returns one more entry than the recorded
+ledger does:
+
+| file | state |
+| --- | --- |
+| `20260725154500_user_hackathons.sql` | applied via the Supabase SQL Editor on 2026-07-26; never sent to `apply_migration` |
+
+This project has no Supabase CLI or MCP configured, so the migration was run
+directly in the dashboard. That records nothing in
+`supabase_migrations.schema_migrations`, so its timestamp stays a placeholder
+rather than a recorded version, the two lists do not align, and `supabase db
+push` would try to replay it if a CLI is ever wired up. If you later adopt the
+CLI/MCP, reconcile by inserting the version into the ledger (or re-running it
+through `apply_migration` against a fresh database) rather than trusting the
+filename alone.
+
 The three SQL divergences all exist so the chain replays cleanly onto a fresh
 database. That makes the files the runnable artefact and the recorded statements
 the historical record; they are not interchangeable, and where they disagree the
@@ -53,6 +70,16 @@ They predate this work. `.github/scripts/seed_supabase.py` reads them under thos
 names, so renaming them is a breaking change for no benefit.
 
 **`host` is `company_name` renamed**, done by `build_row` in that same script.
+
+**`user_hackathons` has no foreign key to `hackathons`.** It is the per-user
+tracker (stage + win flag) added for #226, keyed on the Clerk `sub` like
+`submitted_by`. An FK would look obvious and be wrong: this table's `hackathon_id`
+comes from `listings.json`, which the app renders from directly, while
+`hackathons` trails it by up to an hour — so a user saving a listing added since
+the last sync would hit a constraint violation for a listing that plainly exists
+on screen. The id is checked against the live listing set in the app layer
+instead, and `user_id` defaults from `auth.jwt()` rather than being sent by the
+client, so the owner cannot be spoofed even before the policies are consulted.
 
 ## The two write paths
 


### PR DESCRIPTION
Closes #254.

`public.user_hackathons` exists in the live Supabase project right now — table, RLS policies, grants — but nothing on `main` recorded that it does. This lands the migration that creates it, plus the README section explaining why it's a special case.

## The drift

The migration lived only on the unmerged draft branch for #236; `main`'s migrations stopped at `20260722192614`. That left the repo disagreeing with the database in two directions:

- **Production is ahead of `main`.** Rebuild a database from `main`'s migrations and you get a schema missing a table production has.
- **The migration isn't in the ledger.** It's absent from `supabase_migrations.schema_migrations`, so a future `supabase db push` would try to replay a `create table` for a table that already exists.

## Why land it separately from #236

The drift isn't contingent on that feature merging. #236 is still a draft and blocked behind a Clerk↔Supabase dashboard configuration (#235); the repo shouldn't keep misdescribing the database until that resolves.

## This changes nothing about the running system

The migration is idempotent against the live database, so recording it here is inert:

| statement | re-run behaviour |
| --- | --- |
| `create table if not exists public.user_hackathons` | no-op |
| 4 × `create policy` | each preceded by `drop policy if exists` |
| `alter table … enable row level security` | no-op when already enabled |
| `comment on table` | idempotent |
| `grant` / `revoke` (×4) | idempotent |

## Also included

The README section documenting the divergence. The migration header already points at it — *"See README for the divergence"* — but that section only existed on the same draft branch, so on `main` the reference dangled. It records that the file was applied through the SQL Editor rather than `apply_migration`, why `ls` returns one more entry than the recorded ledger, and how to reconcile if a CLI is ever adopted. The README change is **purely additive**: 27 insertions, 0 deletions.

## Deliberately not included

`20260810064325_atomic_tracker_upsert.sql`, the atomic-upsert fix from #236. It defines a function only `tracker-store.ts` calls, and that file exists on #236's branch alone — landing it here would add a function nothing on `main` uses. It stays with the PR that needs it.

## Still outstanding after this

This does not reconcile the ledger. `main` and production now agree about *what exists*; `supabase_migrations.schema_migrations` still has no row for this version. If a Supabase CLI or MCP is ever wired up, that reconciliation — insert the version, or re-run through `apply_migration` against a fresh database — is still needed, and the README now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)