### PR TITLE
fix(deck): stable list columns, clamped prize cell, compact date ranges

### DIFF
--- a/web/components/hq/deck.tsx
+++ b/web/components/hq/deck.tsx
@@ -229,23 +229,35 @@ function HackRow({ h }: { h: Hackathon }) {
           {cd ? ` · ${cd.toUpperCase()}` : ""}
         </div>
       </div>
-      <div className="hidden w-28 font-mono text-[10px] tracking-wider text-ink/50 md:block">
+      <div className="hidden w-28 shrink-0 font-mono text-[10px] tracking-wider text-ink/50 md:block">
         {h.format.toUpperCase()}
       </div>
-      <div className="hidden w-32 text-right font-display text-sm font-semibold text-ink sm:block">
+      {/* Clamped, not free-flowing: sponsor prize copy runs to sentences
+          ("Internship consideration; travel covered") and a free-wrapping cell
+          turned one row into a four-line tower. Full text stays reachable via
+          title and the details modal. */}
+      <div
+        className="line-clamp-2 hidden w-36 shrink-0 text-right font-display text-[13px] font-semibold leading-snug text-ink sm:block"
+        title={h.prize ?? undefined}
+      >
         {h.prize ?? "-"}
       </div>
-      {eventDates && (
-        <DateColumn className="hidden w-44 lg:block" label="Event dates" value={eventDates} />
-      )}
-      {deadline && (
-        <DateColumn
-          className="hidden w-36 text-coral lg:block"
-          label="Deadline"
-          value={deadline}
-          detail={cd?.toUpperCase()}
-        />
-      )}
+      {/* The slots render even when empty. Conditional columns made every row
+          lay out its own grid: a row with no event dates slid FORMAT and the
+          prize into the space, so nothing lined up down the page. */}
+      <div className="hidden w-40 shrink-0 lg:block">
+        {eventDates && <DateColumn label="Event dates" value={eventDates} />}
+      </div>
+      <div className="hidden w-32 shrink-0 lg:block">
+        {deadline && (
+          <DateColumn
+            className="text-coral"
+            label="Deadline"
+            value={deadline}
+            detail={cd?.toUpperCase()}
+          />
+        )}
+      </div>
       <SaveHeart h={h} />
       <a
         href={safeHttpUrl(h.url)}
@@ -264,12 +276,12 @@ function HackRow({ h }: { h: Hackathon }) {
 }
 
 function DateColumn({
-  className,
+  className = "",
   label,
   value,
   detail,
 }: {
-  className: string;
+  className?: string;
   label: string;
   value: string;
   detail?: string;
@@ -277,7 +289,9 @@ function DateColumn({
   return (
     <div className={`text-right font-mono text-[10px] tracking-wider ${className}`}>
       <div className="text-[9px] text-ink/40">{label.toUpperCase()}</div>
-      <div className="mt-1 leading-tight text-ink/70">{value}</div>
+      {/* nowrap: a date range must never break mid-range; the compact
+          rangeDisplay form is sized to the slot. */}
+      <div className="mt-1 whitespace-nowrap leading-tight text-ink/70">{value}</div>
       {detail && <div className="mt-1 text-[9px]">{detail}</div>}
     </div>
   );

--- a/web/lib/types-hq.test.ts
+++ b/web/lib/types-hq.test.ts
@@ -141,12 +141,28 @@ function hackStub(over: Partial<Hackathon>): Hackathon {
 }
 
 describe("eventDateDisplay", () => {
-  it("formats a start/end range", () => {
+  it("formats a same-month range compactly", () => {
     expect(
       eventDateDisplay(
         hackStub({ startDate: "2026-09-12", endDate: "2026-09-14" }),
       ),
-    ).toBe("Sep 12, 2026 - Sep 14, 2026");
+    ).toBe("Sep 12-14, 2026");
+  });
+
+  it("formats a cross-month range with one year", () => {
+    expect(
+      eventDateDisplay(
+        hackStub({ startDate: "2026-10-30", endDate: "2026-11-02" }),
+      ),
+    ).toBe("Oct 30 - Nov 2, 2026");
+  });
+
+  it("keeps both years across a year boundary", () => {
+    expect(
+      eventDateDisplay(
+        hackStub({ startDate: "2026-12-30", endDate: "2027-01-02" }),
+      ),
+    ).toBe("Dec 30, 2026 - Jan 2, 2027");
   });
 
   it("formats a one-day event once", () => {

--- a/web/lib/types-hq.ts
+++ b/web/lib/types-hq.ts
@@ -68,10 +68,27 @@ export function eventDateDisplay(h: Hackathon): string | null {
   if (!h.startDate && !h.endDate) return null;
   if (h.startDate && h.endDate) {
     if (h.startDate === h.endDate) return dateDisplay(h.startDate);
-    return `${dateDisplay(h.startDate)} - ${dateDisplay(h.endDate)}`;
+    return rangeDisplay(h.startDate, h.endDate);
   }
   if (h.startDate) return `Starts ${dateDisplay(h.startDate)}`;
   return `Ends ${dateDisplay(h.endDate!)}`;
+}
+
+/** Compact range: "Oct 16-17, 2026" / "Oct 30 - Nov 2, 2026", falling back to
+    both-sides-dated only across a year boundary. The verbose form repeated the
+    month and year ("Oct 16, 2026 - Oct 17, 2026") and wrapped inside the
+    deck's fixed date column. */
+function rangeDisplay(startIso: string, endIso: string): string {
+  const s = new Date(`${startIso}T12:00:00`);
+  const e = new Date(`${endIso}T12:00:00`);
+  if (s.getFullYear() !== e.getFullYear()) {
+    return `${dateDisplay(startIso)} - ${dateDisplay(endIso)}`;
+  }
+  const month = (d: Date) => d.toLocaleDateString("en-US", { month: "short" });
+  if (s.getMonth() === e.getMonth()) {
+    return `${month(s)} ${s.getDate()}-${e.getDate()}, ${e.getFullYear()}`;
+  }
+  return `${month(s)} ${s.getDate()} - ${month(e)} ${e.getDate()}, ${e.getFullYear()}`;
 }
 
 function dateDisplay(isoDate: string): string {


### PR DESCRIPTION
Fixes the deck list-view formatting from the screenshot: FORMAT floating to a different x-position per row, the JPMC prize copy towering four lines, and date ranges breaking mid-range.

## Root causes, not cosmetics

| Symptom | Cause | Fix |
|---|---|---|
| Columns don't line up down the page | Event-dates/deadline columns rendered **conditionally** — rows without them collapsed the slots and everything slid over | Slots always render at `lg`, empty when there's no value |
| "Internship consideration; travel covered" = 4-line tower | Prize cell had no wrap control | `line-clamp-2`, full text on `title` + in the details modal |
| "Oct 16, 2026 - Oct 17,\n2026" | Verbose range + no nowrap | New compact `rangeDisplay`: **"Oct 16-17, 2026"** / **"Oct 30 - Nov 2, 2026"**, both years only across a year boundary; value cell `whitespace-nowrap` |

The compact formatter is shared — the detail modal, globe drawer, and map popups pick it up automatically.

Untouched on purpose: the one-line title truncation (details modal carries the full name) and #247's mobile status-line fixes (all `lg:`-gated changes here).

## Verification
- tsc 0 · eslint clean · **211/211 tests** (range formatter now pinned in three shapes: same-month, cross-month, cross-year)
- Preview deploy is the place to eyeball `/deck` in list mode — rows should now share one grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)