### PR TITLE
fix(my): render /my dynamically so Clerk auth() can read headers

### DIFF
--- a/web/app/my/page.tsx
+++ b/web/app/my/page.tsx
@@ -4,8 +4,11 @@ import { loadHackathons } from "@/lib/listings";
 import { MyClient } from "@/components/hq/my-client";
 import { isClerkConfigured } from "@/lib/env";
 
-// ISR: keep deadline-derived status/countdowns fresh without a rebuild (#47).
-export const revalidate = 3600;
+// /my calls auth(), which reads request headers, so it must render per request:
+// combining that with ISR (revalidate) throws DYNAMIC_SERVER_USAGE in a
+// production build. force-dynamic also keeps deadline-derived countdowns fresh,
+// which is the reason #47 originally set revalidate here.
+export const dynamic = "force-dynamic";
 
 export const metadata = {
   title: "My HackHQ · Members Hub",
@@ -15,46 +18,13 @@ export const metadata = {
 
 export default async function MyPage() {
   if (isClerkConfigured()) {
-    let userId: string | null = null;
-    try {
-      const authResult = await auth();
-      userId = authResult.userId;
-      // TEMP DIAGNOSTIC: safe metadata only - no tokens/cookies/JWTs/PII.
-      console.log("CLERK AUTH OK ON /my", {
-        hasUserId: Boolean(authResult.userId),
-        hasSessionId: Boolean(authResult.sessionId),
-      });
-    } catch (error) {
-      // TEMP DIAGNOSTIC: log the ORIGINAL auth exception before Next.js
-      // sanitizes it in the production Server Components error.
-      console.error("CLERK AUTH FAILURE ON /my", {
-        error,
-        message: error instanceof Error ? error.message : undefined,
-        stack: error instanceof Error ? error.stack : undefined,
-        cause: error instanceof Error ? error.cause : undefined,
-      });
-      throw error;
-    }
-    // Kept outside the try so Next's redirect control-flow isn't caught/logged.
+    const { userId } = await auth();
     if (!userId) {
       redirect("/auth/sign-in?redirect_url=/my");
     }
   }
 
-  // TEMP DIAGNOSTIC: distinguish a data/render throw from an auth throw.
-  let hackathons: ReturnType<typeof loadHackathons>;
-  try {
-    hackathons = loadHackathons();
-  } catch (error) {
-    console.error("DATA FAILURE ON /my (loadHackathons)", {
-      error,
-      message: error instanceof Error ? error.message : undefined,
-      stack: error instanceof Error ? error.stack : undefined,
-      cause: error instanceof Error ? error.cause : undefined,
-    });
-    throw error;
-  }
-
+  const hackathons = loadHackathons();
   return (
     <MyClient hackathons={hackathons} authEnabled={isClerkConfigured()} />
   );


### PR DESCRIPTION
## Summary
- Fixes the production-only 500 on `/my` for signed-in users.
- Root cause: `/my` used `export const revalidate = 3600` (ISR) while `auth()` reads request `headers()`. In a production build these conflict and `headers()` throws `DYNAMIC_SERVER_USAGE`, surfacing as a sanitized Server Components 500. Signed-out users were unaffected because middleware redirects them before the page runs `auth()`.
- Switches `/my` to `export const dynamic = "force-dynamic"`, matching `/auth` and `/api/tracker`. Per-request rendering also keeps deadline-derived countdowns fresh (the original reason `#47` set `revalidate`).
- Removes the temporary diagnostic logging added to capture the exception.

## Test plan
- [ ] Merge to `main`; confirm Workers Builds deploys production.
- [ ] With `wrangler tail hackhq` running, sign in via GitHub and land on `/my` in incognito.
- [ ] `GET /my` returns Ok, no `DYNAMIC_SERVER_USAGE`, hub renders.
- [ ] Signed-out `GET /api/tracker` returns 401.

Made with [Cursor](https://cursor.com)