### PR TITLE
perf(nav): disable eager prefetch on site-wide nav links

### DIFF
--- a/web/components/hq/mobile-menu.tsx
+++ b/web/components/hq/mobile-menu.tsx
@@ -116,6 +116,10 @@ export function MobileMenu() {
               <Link
                 key={label}
                 href={href}
+                // Opening the panel would otherwise prefetch every nav route at
+                // once; that RSC burst helped saturate the Worker isolate
+                // (#CPU-limit). Fetch on tap instead.
+                prefetch={false}
                 // Dismiss on the press. A route change does remount the nav (each
                 // page renders its own PageShell), but that lands after the
                 // navigation resolves — and it never happens at all for GITHUB

--- a/web/components/hq/nav.tsx
+++ b/web/components/hq/nav.tsx
@@ -65,6 +65,10 @@ export function NavPill() {
         {/* Logo chip - HQ monogram */}
         <Link
           href="/"
+          // The pill renders on every page, so default prefetch fires an RSC
+          // request for each nav route on load. A burst of those saturated the
+          // Worker isolate (#CPU-limit). Fetch on hover/tap instead.
+          prefetch={false}
           className="mr-1 flex items-center rounded-2xl bg-ink px-3.5 py-3.5 ring-1 ring-white/10 transition hover:ring-coral/60"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -119,6 +123,7 @@ export function NavPill() {
               <Link
                 key={label}
                 href={href}
+                prefetch={false}
                 aria-current={active ? "page" : undefined}
                 onMouseEnter={() => setHovered(label)}
                 onFocus={() => setHovered(label)}
@@ -144,6 +149,7 @@ export function NavPill() {
             still does the work and we leave it alone. */}
         <Link
           href="/#submit"
+          prefetch={false}
           onClick={(e) => {
             if (pathname !== "/") return;
             // Leave modified and non-primary clicks to the browser, or


### PR DESCRIPTION
## Summary
- Hardens against the `Worker exceeded CPU time limit` burst seen in production (all routes, including the static `/icon.svg`, failed for ~1s then recovered).
- Root cause: the nav pill renders on every page, so Next's default `<Link>` prefetch fired an RSC request for each nav route (`/deck`, `/globe`, `/resources`, `/`) on load. A burst of those concurrent server renders saturated the Worker isolate.
- Sets `prefetch={false}` on the desktop nav links, logo, submit CTA, and mobile-menu links. Navigation still works (Next fetches on hover/tap); only the eager on-load fan-out is removed.

## Notes
- Complementary to the Workers plan CPU cap (Free ~10ms vs Paid 30s), which is the underlying enabler and is being checked separately.

## Test plan
- [ ] Merge to `main`; confirm Workers Builds deploys production.
- [ ] With `wrangler tail hackhq` running, load `/`, navigate to `/deck` and `/globe`; confirm no RSC prefetch burst on load and no CPU-limit errors.
- [ ] Links still navigate correctly on hover/click.

Made with [Cursor](https://cursor.com)