### PR TITLE
feat: bug-report / feature-idea request form wired to the HackHQ inbox

### DIFF
--- a/web/components/hq/sections.tsx
+++ b/web/components/hq/sections.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { buildContactMailto } from "@/lib/contact-email";
+import { buildRequestMailto, type RequestKind } from "@/lib/contact-email";
 import type { Hackathon, SiteStats } from "@/lib/types-hq";
 import { REPO_URL, submitIssueUrl } from "@/lib/types-hq";
 
@@ -469,7 +469,7 @@ export function SubmitSection() {
 /* ----- Footer / CTA -----
    "Let's build" contact panel: the HACKHQ wordmark stands in for the giant
    headline, a stacked pair of cards on the left (socials + what the product
-   does), and a contact form on the right that opens a prefilled GitHub issue -
+   does), and a bug/idea request form on the right that opens a prefilled email -
    the same "new surface on the same engine" move as SubmitSection. */
 
 export function Footer() {
@@ -613,9 +613,8 @@ const FIELD =
   "w-full rounded-2xl border border-white/10 bg-ink-deep/50 px-5 py-4 text-sm text-paper outline-none transition placeholder:text-paper/35 focus:border-coral";
 
 function ContactCard() {
+  const [kind, setKind] = useState<RequestKind>("idea");
   const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [org, setOrg] = useState("");
   const [message, setMessage] = useState("");
   const [website, setWebsite] = useState("");
   const [hasInteracted, setHasInteracted] = useState(false);
@@ -623,10 +622,11 @@ function ContactCard() {
   return (
     <div className="flex flex-col rounded-[var(--card-radius)] border border-white/8 bg-ink-soft/70 px-7 py-8 sm:px-9">
       <h2 className="text-xl leading-tight text-paper sm:text-2xl">
-        Got a question, challenge, or idea?
+        Found a bug? Want something built?
       </h2>
       <p className="mt-2 text-sm text-paper/50">
-        Tell us what you&rsquo;re building - or what HackHQ is missing.
+        Tell us what broke, or what HackHQ should do next. Every request lands
+        straight in our inbox.
       </p>
 
       <form
@@ -635,40 +635,60 @@ function ContactCard() {
         onSubmit={(e) => {
           e.preventDefault();
           if (!hasInteracted || website) return;
-          window.location.href = buildContactMailto({ name, email, org, message });
+          window.location.href = buildRequestMailto({ kind, name, message });
         }}
       >
-        <input
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Your name"
-          aria-label="Your name"
-          required
-          className={FIELD}
-        />
-        <input
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Your email"
-          aria-label="Your email"
-          type="email"
-          required
-          className={FIELD}
-        />
-        <input
-          value={org}
-          onChange={(e) => setOrg(e.target.value)}
-          placeholder="Your GitHub or org (optional)"
-          aria-label="Your GitHub or org"
-          className={FIELD}
-        />
+        {/* Which kind of request - drives the subject line the Gmail filter
+            sorts on, so it is a real field, not decoration. */}
+        <div
+          role="radiogroup"
+          aria-label="Request type"
+          className="flex gap-2"
+        >
+          {(
+            [
+              ["idea", "Feature idea"],
+              ["bug", "Bug report"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              role="radio"
+              aria-checked={kind === value}
+              onClick={() => {
+                setKind(value);
+                setHasInteracted(true);
+              }}
+              className={`rounded-full border px-4 py-2 font-mono text-[10px] font-bold tracking-[0.15em] transition ${
+                kind === value
+                  ? "border-coral bg-coral text-ink"
+                  : "border-white/15 text-paper/60 hover:border-white/30"
+              }`}
+            >
+              {label.toUpperCase()}
+            </button>
+          ))}
+        </div>
+
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          placeholder="Your message"
-          aria-label="Your message"
+          placeholder={
+            kind === "bug"
+              ? "What broke, and where? A screenshot helps - attach it in the email before sending."
+              : "What should HackHQ have that it doesn't yet?"
+          }
+          aria-label="Your request"
           required
           className={`${FIELD} min-h-[132px] flex-1 resize-none`}
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your name (we credit shipped ideas)"
+          aria-label="Your name"
+          className={FIELD}
         />
         <input
           value={website}
@@ -682,11 +702,12 @@ function ContactCard() {
 
         <div className="mt-1 flex items-center justify-between gap-4 rounded-2xl border border-white/8 px-5 py-4">
           <p className="text-xs italic leading-snug text-paper/45">
-            Sending opens your email app with a prefilled message.
+            Sending opens your email app with the request prefilled - attach
+            screenshots there before you hit send.
           </p>
           <button
             type="submit"
-            aria-label="Send message"
+            aria-label="Send request"
             disabled={!hasInteracted}
             className="grid h-14 w-14 shrink-0 place-items-center rounded-2xl bg-coral text-2xl text-ink transition hover:bg-coral-bright focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral/50 disabled:cursor-not-allowed disabled:opacity-50"
           >

--- a/web/lib/contact-email.test.ts
+++ b/web/lib/contact-email.test.ts
@@ -1,44 +1,44 @@
 import { describe, expect, it } from "vitest";
-import { buildContactMailto } from "./contact-email";
+import { buildRequestMailto, REQUEST_SUBJECT_PREFIX } from "./contact-email";
 
-describe("buildContactMailto", () => {
-  it("addresses HackHQ and prefills the subject and body", () => {
-    const url = new URL(
-      buildContactMailto({
-        name: "Ada Lovelace",
-        email: "ada@example.com",
-        org: "Analytical Engine",
-        message: "I have a challenge idea.",
-      }),
-    );
+function parts(href: string) {
+  const rest = href.split("mailto:")[1] ?? "";
+  const [address = "", query = ""] = rest.split("?");
+  const params = new URLSearchParams(query);
+  return { address, subject: params.get("subject") ?? "", body: params.get("body") ?? "" };
+}
 
-    expect(url.protocol).toBe("mailto:");
-    expect(url.pathname).toBe("hackheadquarters@gmail.com");
-    expect(url.searchParams.get("subject")).toBe("HackHQ website inquiry from Ada Lovelace");
-    expect(url.searchParams.get("body")).toBe(
-      [
-        "From: Ada Lovelace",
-        "Reply email: ada@example.com",
-        "GitHub or organization: Analytical Engine",
-        "",
-        "I have a challenge idea.",
-      ].join("\n"),
+describe("buildRequestMailto", () => {
+  it("addresses HackHQ and carries the filterable prefix", () => {
+    const { address, subject } = parts(
+      buildRequestMailto({ kind: "bug", name: "Jo", message: "The globe spins backwards" }),
     );
+    expect(address).toBe("hackheadquarters@gmail.com");
+    // The prefix is what the Gmail filter keys on - it must lead the subject.
+    expect(subject.startsWith(`${REQUEST_SUBJECT_PREFIX} Bug report:`)).toBe(true);
+    expect(subject).toContain("The globe spins backwards");
   });
 
-  it("omits an empty organization and trims values", () => {
-    const url = new URL(
-      buildContactMailto({
-        name: " Ada ",
-        email: " ada@example.com ",
-        org: " ",
-        message: " Hello ",
-      }),
+  it("labels an idea as an idea and puts the request in the subject", () => {
+    const { subject, body } = parts(
+      buildRequestMailto({ kind: "idea", name: "Sam", message: "Dark mode for the deck\nmore detail here" }),
     );
+    expect(subject).toBe(`${REQUEST_SUBJECT_PREFIX} Feature idea: Dark mode for the deck`);
+    expect(body).toContain("Type: Feature idea");
+    expect(body).toContain("From: Sam");
+    expect(body).toContain("more detail here");
+  });
 
-    expect(url.searchParams.get("subject")).toBe("HackHQ website inquiry from Ada");
-    expect(url.searchParams.get("body")).toBe(
-      ["From: Ada", "Reply email: ada@example.com", "", "Hello"].join("\n"),
-    );
+  it("clips a long first line so the subject stays scannable", () => {
+    const long = "x".repeat(80);
+    const { subject } = parts(buildRequestMailto({ kind: "bug", name: "", message: long }));
+    expect(subject.endsWith("...")).toBe(true);
+    expect(subject.length).toBeLessThan(REQUEST_SUBJECT_PREFIX.length + 80);
+  });
+
+  it("survives an empty name without inventing one in the subject", () => {
+    const { subject, body } = parts(buildRequestMailto({ kind: "idea", name: "  ", message: "hi" }));
+    expect(subject).toContain("hi");
+    expect(body).toContain("From: (no name given)");
   });
 });

--- a/web/lib/contact-email.ts
+++ b/web/lib/contact-email.ts
@@ -1,28 +1,39 @@
 const CONTACT_EMAIL = "hackheadquarters@gmail.com";
 
-type ContactMessage = {
+/** Stable, filterable prefix: a Gmail filter on subject:"[HackHQ request]"
+    routes every submission into the HackHQ_Website_Requests label without
+    ever catching ordinary correspondence. */
+export const REQUEST_SUBJECT_PREFIX = "[HackHQ request]";
+
+export type RequestKind = "bug" | "idea";
+
+type WebsiteRequest = {
+  kind: RequestKind;
   name: string;
-  email: string;
-  org: string;
   message: string;
 };
 
-export function buildContactMailto({
-  name,
-  email,
-  org,
-  message,
-}: ContactMessage): string {
-  const subject = `HackHQ website inquiry from ${name.trim()}`;
+const KIND_LABEL: Record<RequestKind, string> = {
+  bug: "Bug report",
+  idea: "Feature idea",
+};
+
+/** First line of the message, clipped, so the inbox row reads as the request
+    itself rather than a generic subject. */
+function summarize(message: string, name: string): string {
+  const firstLine = message.trim().split("\n")[0]?.trim() ?? "";
+  if (!firstLine) return `from ${name.trim() || "the website"}`;
+  return firstLine.length > 60 ? `${firstLine.slice(0, 57)}...` : firstLine;
+}
+
+export function buildRequestMailto({ kind, name, message }: WebsiteRequest): string {
+  const subject = `${REQUEST_SUBJECT_PREFIX} ${KIND_LABEL[kind]}: ${summarize(message, name)}`;
   const body = [
-    `From: ${name.trim()}`,
-    `Reply email: ${email.trim()}`,
-    org.trim() ? `GitHub or organization: ${org.trim()}` : null,
+    `Type: ${KIND_LABEL[kind]}`,
+    `From: ${name.trim() || "(no name given)"}`,
     "",
     message.trim(),
-  ]
-    .filter((line): line is string => line !== null)
-    .join("\n");
+  ].join("\n");
 
   return `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 }


### PR DESCRIPTION
Replaces the generic contact card with the requested bug/idea form (reference-style): a **BUG REPORT / FEATURE IDEA** toggle, a description box whose placeholder adapts to the kind, and an optional name ("we credit shipped ideas"). Sending still opens the visitor's mail app addressed to **hackheadquarters@gmail.com** — no backend, honeypot kept, and the email/org fields dropped since the sender's address arrives with the email anyway.

**Made for the Gmail label in your screenshot:** every subject leads with `[HackHQ request]` + kind + the request's own first line (clipped at 60 chars). One filter — subject: `[HackHQ request]` → label `HackHQ_Website_Requests` — catches all of them, and the inbox row reads as the request itself.

Verified: tsc 0 · eslint clean · **213/213 tests** (4 new pinning the prefix, kind labels, subject clipping, and empty-name handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)