### PR TITLE
feat(#235): tracker ownership enforcement moves into Postgres (user-token mode)

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -10,12 +10,23 @@ NEXT_PUBLIC_MAPBOX_TOKEN=
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
 CLERK_SECRET_KEY=
 
-# Supabase — optional; both are required to persist trackers and wins to an
-# account instead of the browser. Server-only on purpose: the service role key
-# must never carry a NEXT_PUBLIC_ prefix. Clerk must be configured too, or there
-# is no user to attribute a saved hackathon to.
-# Project URL and service_role key: Supabase dashboard -> Project Settings -> API.
+# Supabase — optional; the URL plus at least one key persists trackers and wins
+# to an account instead of the browser. Server-only on purpose: no NEXT_PUBLIC_
+# prefix on any of these. Clerk must be configured too, or there is no user to
+# attribute a saved hackathon to.
+# Project URL and keys: Supabase dashboard -> Project Settings -> API.
 SUPABASE_URL=
+
+# Preferred: the publishable (anon) key. Setting it flips tracker writes onto
+# the caller's Clerk token, so Postgres RLS enforces row ownership instead of
+# app code. Requires the Clerk JWT template named "supabase" (with
+# {"role":"authenticated"}) and Clerk registered as a third-party auth provider
+# in Supabase; see web/README.md for the flip procedure.
+SUPABASE_ANON_KEY=
+
+# Legacy fallback: service mode. Bypasses RLS, so ownership is enforced by
+# lib/tracker-store.ts instead. Ignored when SUPABASE_ANON_KEY is set, and can
+# be removed from the runtime env once token mode is verified.
 SUPABASE_SERVICE_ROLE_KEY=
 
 # PostHog — optional; cookieless, anonymous product analytics. Leave unset and

--- a/web/README.md
+++ b/web/README.md
@@ -194,7 +194,8 @@ Copy `.env.example` to `.env.local` (gitignored) and set the values you need.
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | For auth | `app/layout.tsx`, `app/my/page.tsx`, `middleware.ts` | Site runs without Clerk; `/my` shows setup instructions and `/auth/*` redirects to `/my` |
 | `CLERK_SECRET_KEY` | For auth | `app/my/page.tsx`, `middleware.ts` | Same as above — both Clerk keys are needed together |
 | `SUPABASE_URL` | For tracker sync | `lib/tracker-store.ts` | Tracker stays browser-local; `/api/tracker` reports `synced: false` |
-| `SUPABASE_SERVICE_ROLE_KEY` | For tracker sync | `lib/tracker-store.ts` | Same as above — both Supabase values are needed together, **and** Clerk must be configured or there is no user to attribute a row to |
+| `SUPABASE_ANON_KEY` | For tracker sync (token mode) | `lib/tracker-store.ts` | Tracker sync falls back to service mode if the service role key is set, otherwise stays browser-local. See [Tracker sync modes](#tracker-sync-modes) |
+| `SUPABASE_SERVICE_ROLE_KEY` | For tracker sync (service mode) | `lib/tracker-store.ts` | Fine once token mode is live; without either key the tracker stays browser-local. Clerk must be configured in every case or there is no user to attribute a row to |
 | `DATABASE_URL` | For DB scripts | `drizzle.config.ts` | `npm run db:*` commands fail fast before touching Supabase |
 | `NEXT_PUBLIC_POSTHOG_KEY` | No | `lib/analytics.ts` | Analytics is fully off — posthog-js is never downloaded |
 | `NEXT_PUBLIC_POSTHOG_HOST` | No | `lib/analytics.ts` | Defaults to `https://us.i.posthog.com` |
@@ -212,6 +213,41 @@ Without them, the tracker still works locally; nothing is persisted server-side.
 
 To finish Clerk setup in the dashboard, enable Google and GitHub under social
 connections, and enable email/password under email authentication.
+
+### Tracker sync modes
+
+`lib/tracker-store.ts` (behind `/api/tracker`) talks to Supabase in one of two
+modes, chosen by which key is present:
+
+- **Token mode** (preferred, `SUPABASE_ANON_KEY`): every request carries the
+  signed-in caller's Clerk JWT, so queries run as Supabase's `authenticated`
+  role and the RLS policies on `public.user_hackathons` (migration
+  `20260725154500`) enforce row ownership **in Postgres**. The
+  `upsert_tracker_row` RPC is `SECURITY INVOKER`, so it inherits the same
+  policies. A missing Clerk token is a hard error, never a fallback to the
+  service role.
+- **Service mode** (legacy, `SUPABASE_SERVICE_ROLE_KEY` only): the service role
+  bypasses RLS, so ownership is enforced **in app code** by the
+  `.eq("user_id", ...)` filters and explicit `user_id` stamping in
+  `lib/tracker-store.ts`. Those filters stay in token mode too, as a
+  belt-and-braces layer under RLS.
+
+Flipping a deployment to token mode takes three steps (issue
+[#235](https://github.com/Hack-HQ/hackhq/issues/235)):
+
+1. **Clerk dashboard**: create a JWT template named `supabase` whose claims
+   include `{"role": "authenticated"}`.
+2. **Supabase dashboard**: register Clerk as a third-party auth provider
+   (Authentication -> Sign In / Up -> Third Party Auth), so Supabase accepts
+   Clerk-issued JWTs.
+3. **Runtime env**: set `SUPABASE_ANON_KEY` to the publishable key from
+   Project Settings -> API. Token mode wins whenever it is set, so the service
+   role key does not need to be removed for the flip itself.
+
+Once token mode is verified in production, `SUPABASE_SERVICE_ROLE_KEY` can be
+removed from the runtime environment entirely: `lib/tracker-store.ts` is the
+only runtime code that reads it (the only other mentions in the repo are
+`lib/env.ts` reporting and these docs), so nothing else breaks without it.
 
 ## Analytics
 
@@ -289,8 +325,9 @@ are server-only and must never gain a `NEXT_PUBLIC_` prefix.
 | `NEXT_PUBLIC_MAPBOX_TOKEN` | Build, public | Globe renders a placeholder without it |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Build, public | Both Clerk values or neither |
 | `CLERK_SECRET_KEY` | Runtime, secret | Both Clerk values or neither |
-| `SUPABASE_URL` | Runtime, secret | Both Supabase values or neither, **and** Clerk configured |
-| `SUPABASE_SERVICE_ROLE_KEY` | Runtime, secret | Bypasses RLS — see [#235](https://github.com/Hack-HQ/hackhq/issues/235) |
+| `SUPABASE_URL` | Runtime, secret | URL plus at least one Supabase key, **and** Clerk configured |
+| `SUPABASE_ANON_KEY` | Runtime, secret | Token mode: RLS enforces ownership in Postgres. See [Tracker sync modes](#tracker-sync-modes) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Runtime, secret | Service mode only; bypasses RLS ([#235](https://github.com/Hack-HQ/hackhq/issues/235)). Ignored when the anon key is set, removable once token mode is verified |
 
 Every one is optional and degrades gracefully: without Mapbox the globe shows a
 placeholder, without Clerk the tracker stays browser-local, without Supabase it

--- a/web/lib/env.test.ts
+++ b/web/lib/env.test.ts
@@ -5,6 +5,7 @@ const KEYS = [
   "CLERK_SECRET_KEY",
   "SUPABASE_URL",
   "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_ANON_KEY",
 ] as const;
 
 /**
@@ -55,6 +56,15 @@ describe("isTrackerSyncConfigured", () => {
     });
     expect(isTrackerSyncConfigured()).toBe(false);
   });
+
+  it("is on with the anon key alone - token mode needs no service role key", async () => {
+    const { isTrackerSyncConfigured } = await loadEnv({
+      ...CLERK,
+      SUPABASE_URL: SUPABASE.SUPABASE_URL,
+      SUPABASE_ANON_KEY: "anon-key",
+    });
+    expect(isTrackerSyncConfigured()).toBe(true);
+  });
 });
 
 describe("validateEnv", () => {
@@ -83,6 +93,45 @@ describe("validateEnv", () => {
     );
   });
 
+  it("names the anon key when token mode is set up without Clerk", async () => {
+    // Token mode's only credential is the caller's Clerk JWT, so this is a
+    // sharper misconfiguration than the generic Supabase-without-Clerk case
+    // and deserves a warning that says which variable caused it.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateEnv } = await loadEnv({
+      SUPABASE_URL: SUPABASE.SUPABASE_URL,
+      SUPABASE_ANON_KEY: "anon-key",
+    });
+    const report = validateEnv();
+
+    expect(report.trackerSync).toBe("enabled");
+    expect(report.trackerRls).toBe(true);
+    const text = warn.mock.calls.flat().join(" ");
+    expect(text).toContain("SUPABASE_ANON_KEY is set but Clerk");
+    // The specific warning replaces the generic one, not stacks on top of it.
+    expect(text).not.toContain("Supabase is configured but Clerk is not");
+  });
+
+  it("reports token mode in trackerRls when the anon key is present", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateEnv } = await loadEnv({
+      ...CLERK,
+      SUPABASE_URL: SUPABASE.SUPABASE_URL,
+      SUPABASE_ANON_KEY: "anon-key",
+      NEXT_PUBLIC_MAPBOX_TOKEN: "pk.mapbox",
+    } as Record<string, string>);
+
+    expect(validateEnv()).toEqual({
+      mapbox: true,
+      clerk: "enabled",
+      trackerSync: "enabled",
+      trackerRls: true,
+      posthog: false,
+    });
+    // Token mode fully configured is the intended end state, not a warning.
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("stays quiet about auth and sync when everything is set", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { validateEnv } = await loadEnv({
@@ -95,6 +144,9 @@ describe("validateEnv", () => {
       mapbox: true,
       clerk: "enabled",
       trackerSync: "enabled",
+      // Service role key without an anon key is service mode: enforcement
+      // stays in lib/tracker-store.ts rather than Postgres RLS.
+      trackerRls: false,
       // No key in this fixture: analytics off is the intended default, and it
       // must not warn — see lib/analytics.ts.
       posthog: false,

--- a/web/lib/env.ts
+++ b/web/lib/env.ts
@@ -10,6 +10,11 @@ export type EnvReport = {
   mapbox: boolean;
   clerk: Availability;
   trackerSync: Availability;
+  // True when tracker writes run in token mode (SUPABASE_ANON_KEY set): each
+  // request carries the caller's Clerk JWT and Postgres RLS enforces row
+  // ownership. False means service mode, where lib/tracker-store.ts enforces
+  // ownership in app code with the service role key.
+  trackerRls: boolean;
   posthog: boolean;
 };
 
@@ -28,13 +33,16 @@ export function isClerkConfigured(): boolean {
 // Persisting a tracker needs somewhere to put it *and* someone to attribute it
 // to, so this is deliberately Clerk-inclusive: with Supabase configured but
 // sign-in switched off there is no user id, and /api/tracker would have nothing
-// to scope a row by. Both variables are server-only — no NEXT_PUBLIC_ prefix —
-// so the service role key never reaches the browser bundle.
+// to scope a row by. Either key works: SUPABASE_ANON_KEY selects token mode
+// (requests carry the caller's Clerk JWT, RLS enforces ownership in Postgres),
+// SUPABASE_SERVICE_ROLE_KEY alone selects service mode (ownership enforced in
+// lib/tracker-store.ts). All variables are server-only (no NEXT_PUBLIC_
+// prefix), so neither key reaches the browser bundle.
 export function isTrackerSyncConfigured(): boolean {
   return Boolean(
     isClerkConfigured() &&
       process.env.SUPABASE_URL &&
-      process.env.SUPABASE_SERVICE_ROLE_KEY,
+      (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY),
   );
 }
 
@@ -52,9 +60,15 @@ export function validateEnv(): EnvReport {
   const pub = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
   const secret = Boolean(process.env.CLERK_SECRET_KEY);
   const supabaseUrl = Boolean(process.env.SUPABASE_URL);
-  const supabaseKey = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const serviceKey = Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const anonKey = Boolean(process.env.SUPABASE_ANON_KEY);
   const clerk = availability(pub, secret);
-  const trackerSync = availability(supabaseUrl, supabaseKey);
+  // Either key satisfies "a way to authenticate": the anon key flips writes
+  // onto the caller's Clerk token (RLS in Postgres), the service role key keeps
+  // the legacy app-layer enforcement. tracker-store prefers the anon key when
+  // both are set.
+  const trackerSync = availability(supabaseUrl, serviceKey || anonKey);
+  const trackerRls = anonKey;
 
   if (!reported) {
     reported = true;
@@ -71,19 +85,29 @@ export function validateEnv(): EnvReport {
     }
     if (trackerSync === "partial") {
       console.warn(
-        "[env] Supabase is half-configured: set BOTH SUPABASE_URL and " +
-          "SUPABASE_SERVICE_ROLE_KEY, or neither. Trackers stay browser-local until both exist.",
+        "[env] Supabase is half-configured: set SUPABASE_URL plus a key " +
+          "(SUPABASE_ANON_KEY for token mode, SUPABASE_SERVICE_ROLE_KEY for service mode), " +
+          "or none of them. Trackers stay browser-local until then.",
       );
     }
-    // Not "partial" in the half-configured sense — both Supabase values are
-    // present and valid — but the result is the same dead end, so it is worth
-    // the same warning rather than a silent fallback to localStorage.
-    if (trackerSync === "enabled" && clerk !== "enabled") {
+    // Token mode has no credential at all without Clerk: the anon key only
+    // identifies the project, the caller's Clerk JWT is what authenticates.
+    // More specific than the generic warning below, so it takes its place.
+    if (anonKey && clerk !== "enabled") {
+      console.warn(
+        "[env] SUPABASE_ANON_KEY is set but Clerk is not fully configured. Token mode " +
+          "authenticates tracker writes with the caller's Clerk JWT, so tracker sync " +
+          "stays off until both Clerk keys exist.",
+      );
+    } else if (trackerSync === "enabled" && clerk !== "enabled") {
+      // Not "partial" in the half-configured sense — both Supabase values are
+      // present and valid — but the result is the same dead end, so it is worth
+      // the same warning rather than a silent fallback to localStorage.
       console.warn(
         "[env] Supabase is configured but Clerk is not, so tracker sync stays off: " +
           "there is no signed-in user to attribute a saved hackathon to.",
       );
     }
   }
-  return { mapbox, clerk, trackerSync, posthog };
+  return { mapbox, clerk, trackerSync, trackerRls, posthog };
 }

--- a/web/lib/tracker-store.test.ts
+++ b/web/lib/tracker-store.test.ts
@@ -1,15 +1,27 @@
 /* ---------------------------------------------------------------------------
-   tracker-store is the only place the app touches the database with the
-   service-role key, which bypasses RLS. Row ownership is therefore enforced
-   here in code rather than by Postgres, so these tests exist to make that
-   guarantee load-bearing: every read, update and delete must be filtered by the
-   caller's user_id, and every write must stamp that same user_id onto the row.
-   A regression that dropped one of those filters would leak or overwrite another
-   user's tracker, and RLS would not catch it.
+   tracker-store talks to the database in one of two modes, and these tests pin
+   the guarantees of both.
 
-   The Supabase client is mocked with a chainable builder that records the calls
-   made against it, so the assertions are about *which filters were applied*, not
-   about a live database.
+   SERVICE MODE uses the service-role key, which bypasses RLS, so row ownership
+   is enforced here in code: every read, update and delete must be filtered by
+   the caller's user_id, and every write must stamp that same user_id onto the
+   row. A regression that dropped one of those filters would leak or overwrite
+   another user's tracker, and RLS would not catch it.
+
+   TOKEN MODE sends the caller's Clerk JWT with every request, so Postgres RLS
+   is the enforcement point. The tests pin the wiring that makes that true: the
+   anon key (not the service key) reaches createClient, the accessToken
+   callback resolves the "supabase" Clerk template, and a missing token is a
+   hard error rather than a silent fall back to the service role. The user_id
+   filters must survive in this mode too - belt and braces, and the safety net
+   if a deployment is ever flipped back.
+
+   The Supabase client is mocked with a chainable builder that records the
+   calls made against it, so the assertions are about *which filters were
+   applied*, not about a live database. createClient itself records its
+   arguments so each mode's credentials and options can be asserted. The store
+   caches its client per module instance, so every test imports a fresh copy
+   via loadStore() after arranging the environment.
 --------------------------------------------------------------------------- */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +29,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // server-only throws when imported outside a React Server Component; in the
 // test runner it has nothing to guard, so stub it out.
 vi.mock("server-only", () => ({}));
+
+// The caller's Clerk session, controllable per test. auth() is what the store
+// uses to resolve the current request's token in token mode.
+let clerkToken: string | null = "clerk-jwt";
+// The implementation takes no parameters, but vi.fn still records the
+// arguments each call passes, which is what the template assertions read.
+const getToken = vi.fn(async () => clerkToken);
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: async () => ({ getToken }),
+}));
 
 type Call = [string, ...unknown[]];
 const calls: Call[] = [];
@@ -47,16 +69,59 @@ const builder: Record<string, unknown> = {
     Promise.resolve(chainResult).then(onFulfilled, onRejected),
 };
 
+type ClientOptions = {
+  accessToken?: () => Promise<string>;
+  auth?: Record<string, unknown>;
+};
+const createClientCalls: Array<{
+  url: string;
+  key: string;
+  options: ClientOptions;
+}> = [];
+
 vi.mock("@supabase/supabase-js", () => ({
-  createClient: () => builder,
+  createClient: (url: string, key: string, options: ClientOptions) => {
+    createClientCalls.push({ url, key, options });
+    return builder;
+  },
 }));
 
-import {
-  deleteTrackerRow,
-  importTrackerRows,
-  listTracker,
-  upsertTrackerRow,
-} from "./tracker-store";
+const ENV_KEYS = [
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_ANON_KEY",
+] as const;
+
+const URL = "https://example.supabase.co";
+const SERVICE_ENV = {
+  SUPABASE_URL: URL,
+  SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+};
+const TOKEN_ENV = {
+  SUPABASE_URL: URL,
+  SUPABASE_ANON_KEY: "anon-key",
+};
+
+type Store = typeof import("./tracker-store");
+
+/**
+ * The store picks its mode when the client singleton is first built, so every
+ * test arranges the environment and then imports a fresh module instance.
+ */
+async function loadStore(env: Partial<Record<string, string>>): Promise<Store> {
+  for (const key of ENV_KEYS) delete process.env[key];
+  Object.assign(process.env, env);
+  vi.resetModules();
+  return import("./tracker-store");
+}
+
+/** The createClient invocation the store made (it makes exactly one). */
+function clientArgs(): { url: string; key: string; options: ClientOptions } {
+  expect(createClientCalls).toHaveLength(1);
+  const first = createClientCalls[0];
+  if (!first) throw new Error("createClient was never called");
+  return first;
+}
 
 const USER = "user_2abc";
 const OTHER = "user_2xyz";
@@ -79,116 +144,215 @@ function lastRpc(): { fn: unknown; args: unknown } | undefined {
 }
 
 beforeEach(() => {
-  process.env.SUPABASE_URL = "https://example.supabase.co";
-  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-key";
   calls.length = 0;
+  createClientCalls.length = 0;
+  clerkToken = "clerk-jwt";
+  getToken.mockClear();
   chainResult = { data: [], error: null };
   singleResult = { data: null, error: null };
   // Reset too, or the error case below leaks into whichever test runs next.
   rpcResult = { data: [], error: null };
 });
 
-describe("listTracker", () => {
-  it("reads user_hackathons scoped to the caller and never another user", async () => {
-    chainResult = {
-      data: [{ hackathon_id: ID_A, stage: "going", is_win: true }],
-      error: null,
-    };
+describe("client construction", () => {
+  it("token mode: authenticates with the anon key and a per-request accessToken", async () => {
+    const store = await loadStore(TOKEN_ENV);
+    await store.listTracker(USER);
 
-    const entries = await listTracker(USER);
-
-    expect(calls).toContainEqual(["from", "user_hackathons"]);
-    expect(eqFilters("user_id")).toEqual([USER]);
-    expect(eqFilters("user_id")).not.toContain(OTHER);
-    expect(entries).toEqual([{ hackathonId: ID_A, stage: "going", isWin: true }]);
-  });
-
-  it("surfaces a database error rather than returning partial data", async () => {
-    chainResult = { data: null, error: { message: "boom" } };
-    await expect(listTracker(USER)).rejects.toThrow("boom");
-  });
-});
-
-describe("upsertTrackerRow", () => {
-  it("stamps the caller's user_id on the write and never another user's", async () => {
-    rpcResult = { data: [{ stage: "applied", is_win: false }], error: null };
-
-    const entry = await upsertTrackerRow(USER, ID_A, { stage: "applied" });
-
-    // The row is written for the caller resolved from the Clerk session — a
-    // client request body has no way to reach p_user_id.
-    const call = lastRpc();
-    expect(call?.fn).toBe("upsert_tracker_row");
-    expect(call?.args).toMatchObject({ p_user_id: USER, p_hackathon_id: ID_A });
-    expect(call?.args).not.toMatchObject({ p_user_id: OTHER });
-    expect(entry).toEqual({ hackathonId: ID_A, stage: "applied", isWin: false });
-  });
-
-  it("does the partial merge in one statement instead of reading first", async () => {
-    // The guarantee this protects: a concurrent PUT must not be able to observe
-    // a half-applied update. Reading the row and merging in JS left a window
-    // where two requests read the same snapshot and the second clobbered the
-    // first, so there must be no pre-read at all.
-    rpcResult = { data: [{ stage: "going", is_win: false }], error: null };
-
-    await upsertTrackerRow(USER, ID_A, { isWin: false });
-
-    expect(calls.some((c) => c[0] === "maybeSingle")).toBe(false);
-    expect(calls.some((c) => c[0] === "upsert")).toBe(false);
-    expect(lastRpc()?.fn).toBe("upsert_tracker_row");
-  });
-
-  it("sends null for an omitted field so the database keeps the stored value", async () => {
-    rpcResult = { data: [{ stage: "going", is_win: false }], error: null };
-
-    const entry = await upsertTrackerRow(USER, ID_A, { isWin: false });
-
-    // null, not a default: "leave stage alone" has to be distinguishable from
-    // "set stage to interested", or recording a win would reset the pipeline.
-    expect(lastRpc()?.args).toMatchObject({ p_stage: null, p_is_win: false });
-    // The row the function returns is what the caller gets back, not the patch.
-    expect(entry).toEqual({ hackathonId: ID_A, stage: "going", isWin: false });
-  });
-
-  it("surfaces a database error rather than reporting a write that did not land", async () => {
-    rpcResult = { data: null, error: { message: "deadlock detected" } };
-
-    await expect(upsertTrackerRow(USER, ID_A, { stage: "applied" })).rejects.toThrow(
-      "deadlock detected",
-    );
-  });
-});
-
-describe("deleteTrackerRow", () => {
-  it("deletes only the caller's row for one hackathon", async () => {
-    await deleteTrackerRow(USER, ID_A);
-
-    expect(calls).toContainEqual(["delete"]);
-    expect(eqFilters("user_id")).toEqual([USER]);
-    expect(eqFilters("hackathon_id")).toEqual([ID_A]);
-  });
-});
-
-describe("importTrackerRows", () => {
-  it("stamps the caller's user_id on every imported row and stays additive", async () => {
-    await importTrackerRows(USER, [
-      { hackathonId: ID_A, stage: "going", isWin: true },
-      { hackathonId: ID_B, stage: "applied", isWin: false },
-    ]);
-
-    const up = lastUpsert();
-    const rows = up?.payload as Array<{ user_id: string }>;
-    expect(rows).toHaveLength(2);
-    expect(rows.every((r) => r.user_id === USER)).toBe(true);
-    // ignoreDuplicates keeps the server's existing stage on a second device.
-    expect(up?.opts).toMatchObject({
-      onConflict: "user_id,hackathon_id",
-      ignoreDuplicates: true,
+    const { url, key, options } = clientArgs();
+    expect(url).toBe(URL);
+    expect(key).toBe("anon-key");
+    expect(typeof options.accessToken).toBe("function");
+    // Server-side per-request client: the browser auth machinery stays off.
+    expect(options.auth).toMatchObject({
+      persistSession: false,
+      autoRefreshToken: false,
     });
   });
 
-  it("makes no database call for an empty import", async () => {
-    await importTrackerRows(USER, []);
-    expect(calls).toEqual([]);
+  it("token mode: the accessToken callback resolves the caller's supabase-template Clerk JWT", async () => {
+    const store = await loadStore(TOKEN_ENV);
+    await store.listTracker(USER);
+
+    const { options } = clientArgs();
+    await expect(options.accessToken!()).resolves.toBe("clerk-jwt");
+    // The template is what carries {"role":"authenticated"}; the raw session
+    // token would not satisfy the RLS policies' role grant.
+    expect(getToken).toHaveBeenCalledWith({ template: "supabase" });
+  });
+
+  it("token mode: a missing Clerk token is a hard error, never a service-role fallback", async () => {
+    const store = await loadStore(TOKEN_ENV);
+    await store.listTracker(USER);
+
+    clerkToken = null;
+    const { options } = clientArgs();
+    // Naming the misconfiguration matters: this fires when the Clerk JWT
+    // template is missing or a signed-out code path reached the store.
+    await expect(options.accessToken!()).rejects.toThrow(/JWT template/);
+    await expect(options.accessToken!()).rejects.toThrow(
+      /Refusing to fall back to the service role/,
+    );
+  });
+
+  it("token mode wins when both keys are set, so setting the anon key is the whole flip", async () => {
+    const store = await loadStore({ ...SERVICE_ENV, ...TOKEN_ENV });
+    await store.listTracker(USER);
+
+    const { key, options } = clientArgs();
+    expect(key).toBe("anon-key");
+    expect(typeof options.accessToken).toBe("function");
+  });
+
+  it("service mode: authenticates with the service role key and no accessToken", async () => {
+    const store = await loadStore(SERVICE_ENV);
+    await store.listTracker(USER);
+
+    const { url, key, options } = clientArgs();
+    expect(url).toBe(URL);
+    expect(key).toBe("service-role-key");
+    expect(options.accessToken).toBeUndefined();
+    expect(options.auth).toMatchObject({
+      persistSession: false,
+      autoRefreshToken: false,
+    });
+    // Service mode never consults Clerk; the route handler already did.
+    expect(getToken).not.toHaveBeenCalled();
+  });
+
+  it("throws when neither key (or no URL) is configured", async () => {
+    const store = await loadStore({});
+    await expect(store.listTracker(USER)).rejects.toThrow(
+      "Supabase is not configured for tracker sync",
+    );
+    expect(createClientCalls).toHaveLength(0);
   });
 });
+
+/**
+ * The four operations must behave identically in both modes: in service mode
+ * the user_id scoping is the entire ownership guarantee, in token mode it is
+ * the belt-and-braces layer under RLS. Running the same suite against each
+ * mode pins that neither can drop a filter without a test noticing.
+ */
+function describeStoreOperations(
+  mode: string,
+  env: Partial<Record<string, string>>,
+) {
+  describe(`listTracker (${mode})`, () => {
+    it("reads user_hackathons scoped to the caller and never another user", async () => {
+      const store = await loadStore(env);
+      chainResult = {
+        data: [{ hackathon_id: ID_A, stage: "going", is_win: true }],
+        error: null,
+      };
+
+      const entries = await store.listTracker(USER);
+
+      expect(calls).toContainEqual(["from", "user_hackathons"]);
+      expect(eqFilters("user_id")).toEqual([USER]);
+      expect(eqFilters("user_id")).not.toContain(OTHER);
+      expect(entries).toEqual([{ hackathonId: ID_A, stage: "going", isWin: true }]);
+    });
+
+    it("surfaces a database error rather than returning partial data", async () => {
+      const store = await loadStore(env);
+      chainResult = { data: null, error: { message: "boom" } };
+      await expect(store.listTracker(USER)).rejects.toThrow("boom");
+    });
+  });
+
+  describe(`upsertTrackerRow (${mode})`, () => {
+    it("stamps the caller's user_id on the write and never another user's", async () => {
+      const store = await loadStore(env);
+      rpcResult = { data: [{ stage: "applied", is_win: false }], error: null };
+
+      const entry = await store.upsertTrackerRow(USER, ID_A, { stage: "applied" });
+
+      // The row is written for the caller resolved from the Clerk session — a
+      // client request body has no way to reach p_user_id.
+      const call = lastRpc();
+      expect(call?.fn).toBe("upsert_tracker_row");
+      expect(call?.args).toMatchObject({ p_user_id: USER, p_hackathon_id: ID_A });
+      expect(call?.args).not.toMatchObject({ p_user_id: OTHER });
+      expect(entry).toEqual({ hackathonId: ID_A, stage: "applied", isWin: false });
+    });
+
+    it("does the partial merge in one statement instead of reading first", async () => {
+      // The guarantee this protects: a concurrent PUT must not be able to
+      // observe a half-applied update. Reading the row and merging in JS left
+      // a window where two requests read the same snapshot and the second
+      // clobbered the first, so there must be no pre-read at all.
+      const store = await loadStore(env);
+      rpcResult = { data: [{ stage: "going", is_win: false }], error: null };
+
+      await store.upsertTrackerRow(USER, ID_A, { isWin: false });
+
+      expect(calls.some((c) => c[0] === "maybeSingle")).toBe(false);
+      expect(calls.some((c) => c[0] === "upsert")).toBe(false);
+      expect(lastRpc()?.fn).toBe("upsert_tracker_row");
+    });
+
+    it("sends null for an omitted field so the database keeps the stored value", async () => {
+      const store = await loadStore(env);
+      rpcResult = { data: [{ stage: "going", is_win: false }], error: null };
+
+      const entry = await store.upsertTrackerRow(USER, ID_A, { isWin: false });
+
+      // null, not a default: "leave stage alone" has to be distinguishable from
+      // "set stage to interested", or recording a win would reset the pipeline.
+      expect(lastRpc()?.args).toMatchObject({ p_stage: null, p_is_win: false });
+      // The row the function returns is what the caller gets back, not the patch.
+      expect(entry).toEqual({ hackathonId: ID_A, stage: "going", isWin: false });
+    });
+
+    it("surfaces a database error rather than reporting a write that did not land", async () => {
+      const store = await loadStore(env);
+      rpcResult = { data: null, error: { message: "deadlock detected" } };
+
+      await expect(
+        store.upsertTrackerRow(USER, ID_A, { stage: "applied" }),
+      ).rejects.toThrow("deadlock detected");
+    });
+  });
+
+  describe(`deleteTrackerRow (${mode})`, () => {
+    it("deletes only the caller's row for one hackathon", async () => {
+      const store = await loadStore(env);
+      await store.deleteTrackerRow(USER, ID_A);
+
+      expect(calls).toContainEqual(["delete"]);
+      expect(eqFilters("user_id")).toEqual([USER]);
+      expect(eqFilters("hackathon_id")).toEqual([ID_A]);
+    });
+  });
+
+  describe(`importTrackerRows (${mode})`, () => {
+    it("stamps the caller's user_id on every imported row and stays additive", async () => {
+      const store = await loadStore(env);
+      await store.importTrackerRows(USER, [
+        { hackathonId: ID_A, stage: "going", isWin: true },
+        { hackathonId: ID_B, stage: "applied", isWin: false },
+      ]);
+
+      const up = lastUpsert();
+      const rows = up?.payload as Array<{ user_id: string }>;
+      expect(rows).toHaveLength(2);
+      expect(rows.every((r) => r.user_id === USER)).toBe(true);
+      // ignoreDuplicates keeps the server's existing stage on a second device.
+      expect(up?.opts).toMatchObject({
+        onConflict: "user_id,hackathon_id",
+        ignoreDuplicates: true,
+      });
+    });
+
+    it("makes no database call for an empty import", async () => {
+      const store = await loadStore(env);
+      await store.importTrackerRows(USER, []);
+      expect(calls).toEqual([]);
+    });
+  });
+}
+
+describeStoreOperations("service mode", SERVICE_ENV);
+describeStoreOperations("token mode", TOKEN_ENV);

--- a/web/lib/tracker-store.ts
+++ b/web/lib/tracker-store.ts
@@ -7,49 +7,91 @@
    request body. The id always comes from the Clerk session, resolved in the
    route handler.
 
-   ## Why the service role, and what still guards the rows
+   ## Two modes, two enforcement points
 
-   The client is built with the service role key, which bypasses RLS. Ownership
-   is therefore enforced here, by the `.eq("user_id", userId)` on every read and
-   delete, by writing `user_id` explicitly on every insert, and by passing it as
-   `p_user_id` to the upsert function - which stamps it onto the row rather than
-   taking the caller's word for it.
+   TOKEN MODE (preferred) - active when SUPABASE_ANON_KEY is set. The client
+   authenticates every request with the caller's own Clerk JWT (the "supabase"
+   template), so queries run as the `authenticated` role and Postgres RLS is
+   what enforces row ownership: the policies on user_hackathons compare
+   `auth.jwt() ->> 'sub'` to user_id, and public.upsert_tracker_row is
+   SECURITY INVOKER so the RPC inherits the same policies. A query that
+   forgot its filter would return or touch nothing it should not - the
+   database refuses, not this file.
 
-   The RLS policies in the migration are not redundant. They mean `anon` and
-   `authenticated` cannot touch this table at all, so nothing reachable with a
-   publishable key can read one user's tracker - and they are what a future
-   browser-direct path would run under. The trade-off of the service role is
-   that a missing filter in this file would not be caught by the database, which
-   is why the surface is kept this small and why `userId` is a required
-   parameter rather than an option on every function below.
+   SERVICE MODE (legacy fallback) - active when only SUPABASE_SERVICE_ROLE_KEY
+   is set. The service role bypasses RLS, so ownership is enforced here in the
+   app layer instead: by the `.eq("user_id", userId)` on every read and delete,
+   by writing user_id explicitly on every insert, and by passing it as
+   p_user_id to the upsert function. This keeps production working until the
+   external configuration for token mode (Clerk JWT template plus Supabase
+   third-party auth) lands; see web/README.md for the flip procedure.
 
-   Upgrade path: Clerk's native Supabase integration lets the browser's own
-   session token satisfy those policies directly, moving enforcement back into
-   Postgres. That needs a trust relationship configured in both dashboards, so
-   it is a follow-up rather than a prerequisite for shipping this.
+   The user_id filters and stamping stay in BOTH modes on purpose. In token
+   mode they are belt and braces rather than load-bearing - RLS is the
+   guarantee - but keeping them means a misconfigured deployment degrades to
+   the service-mode guarantee instead of to nothing, and the queries document
+   their own scope.
 --------------------------------------------------------------------------- */
 
 import "server-only";
+import { auth } from "@clerk/nextjs/server";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Stage, TrackerEntry } from "./tracker";
 import { parseTrackerEntries } from "./tracker";
 
 const TABLE = "user_hackathons";
 
+/**
+ * The caller's Clerk JWT for Supabase, fetched fresh per request. auth() reads
+ * the request's async context, so even though the client below is a
+ * module-level singleton, this resolves to whoever is making the CURRENT
+ * request - never a token cached from an earlier one.
+ *
+ * A null token is a hard error, not a cue to fall back to the service role:
+ * falling back would silently bypass RLS and defeat the reason token mode
+ * exists. It means either the Clerk JWT template named "supabase" has not been
+ * created, or a code path called the store without a signed-in user.
+ */
+async function clerkSupabaseToken(): Promise<string> {
+  const { getToken } = await auth();
+  const token = await getToken({ template: "supabase" });
+  if (!token) {
+    throw new Error(
+      'Tracker sync is in token mode (SUPABASE_ANON_KEY is set) but Clerk returned no token for the "supabase" JWT template. ' +
+        'Either create that template in the Clerk dashboard (with {"role":"authenticated"}) or this call happened without a signed-in user. ' +
+        "Refusing to fall back to the service role key, which would bypass row level security.",
+    );
+  }
+  return token;
+}
+
 let cached: SupabaseClient | null = null;
 
 function client(): SupabaseClient {
   if (cached) return cached;
   const url = process.env.SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) {
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || (!anonKey && !serviceKey)) {
     throw new Error("Supabase is not configured for tracker sync");
   }
-  // No session persistence or refresh: this runs per request on the server and
-  // authenticates with a static key, so the auth machinery has nothing to do.
-  cached = createClient(url, key, {
-    auth: { persistSession: false, autoRefreshToken: false },
-  });
+  // No session persistence or refresh in either mode: this runs per request on
+  // the server, so the browser-oriented auth machinery has nothing to do. In
+  // token mode supabase-js ignores these auth options entirely (the accessToken
+  // option replaces its auth client), but passing them keeps the two branches
+  // symmetric and harmless.
+  const options = { auth: { persistSession: false, autoRefreshToken: false } };
+  // Token mode wins when both keys are present, so setting SUPABASE_ANON_KEY is
+  // sufficient to flip enforcement into Postgres; removing the service key can
+  // follow once the flip is verified.
+  cached = anonKey
+    ? createClient(url, anonKey, {
+        ...options,
+        // Runs on every request the client makes, inside the route handler's
+        // async context, so the singleton client is still per-caller.
+        accessToken: clerkSupabaseToken,
+      })
+    : createClient(url, serviceKey as string, options);
   return cached;
 }
 
@@ -84,7 +126,7 @@ export async function upsertTrackerRow(
   // One statement rather than read-merge-write. Reading the row here and
   // merging the patch in JS left a window where two concurrent PUTs for the
   // same (user, hackathon) both read the same snapshot and the second write
-  // clobbered the first — losing exactly the field the other request was
+  // clobbered the first - losing exactly the field the other request was
   // preserving. public.upsert_tracker_row does the coalesce inside the same
   // ON CONFLICT DO UPDATE that writes, so there is nothing to interleave with.
   // A null argument means "leave that column at its stored value", which is how


### PR DESCRIPTION
The code half of #235: `tracker-store.ts` becomes **dual-mode**, so this merges safely today and Postgres enforcement flips on the moment the env var lands.

## Token mode (new, wins when `SUPABASE_ANON_KEY` is set)

Every tracker query runs with the **caller's Clerk JWT** (`getToken({ template: "supabase" })`) via supabase-js's `accessToken` callback on the anon key — so the `authenticated` RLS policies on `user_hackathons` (written for exactly this in `20260725154500`, never yet matched by a live request) become the enforcement, in Postgres. A null token **throws with a descriptive error** — no silent fallback to the service role, which would defeat the point. The `.eq(user_id)` filters and explicit stamping all stay, demoted to belt-and-braces per the issue.

## Service mode (fallback, byte-identical to today)

No anon key → current behavior, unchanged, so production keeps working until the external config is done.

## Verified against the installed packages, not memory

- `@supabase/supabase-js` 2.110.8: top-level `accessToken` option (`dist/index.d.mts:279`); runtime resolves the callback **per fetch** and `.rpc()` rides the same authenticated fetch (`dist/index.mjs` ~340–370, 709, 769–774) — so the module singleton cannot serve a stale/foreign token, and SECURITY INVOKER + RLS bite on the RPC path
- `@clerk/nextjs` 7.6.0: `getToken({template})` typechecks on both auth-object variants, null = signed-out/missing-template
- Repo-wide grep: `SUPABASE_SERVICE_ROLE_KEY`'s only runtime reader is `tracker-store.ts` — it is genuinely removable from the deployed env once token mode is verified (documented in README)

## Also
- `env.ts`: `trackerRls` flag, `trackerSync` counts either key, specific warning for anon-key-without-Clerk (exactly one warning fires, test-pinned)
- `.env.example` + README "Tracker sync modes" section with the 3-step flip
- Tests: **231 passing** (+18) — both modes exercised end-to-end via fresh module loads, ownership scoping re-pinned in each

## What this PR does NOT do (tracked in #235)
External config (Clerk JWT template + Supabase third-party auth registration + `SUPABASE_ANON_KEY` in envs) ships separately via an idempotent setup script, and the forged-request proof needs a real signed-in session — procedure documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)