### PR TITLE
fix(#254): surface tracker schema drift as 503 instead of an opaque 500

### DIFF
--- a/web/app/api/tracker/route.ts
+++ b/web/app/api/tracker/route.ts
@@ -17,9 +17,14 @@
 --------------------------------------------------------------------------- */
 
 import { auth } from "@clerk/nextjs/server";
+import * as Sentry from "@sentry/nextjs";
 import { NextResponse } from "next/server";
 import { isTrackerSyncConfigured } from "@/lib/env";
 import { isHackathonId, isStage, parseTrackerEntries } from "@/lib/tracker";
+import {
+  TrackerStoreError,
+  trackerFailureResponse,
+} from "@/lib/tracker-errors";
 import {
   deleteTrackerRow,
   importTrackerRows,
@@ -53,13 +58,35 @@ async function resolveUser(): Promise<
 }
 
 /**
- * Log the real cause server-side, tell the client only that it failed. Supabase
+ * Log the real cause server-side, tell the client only what it needs. Supabase
  * error messages can name columns and constraints, which is not something to
- * hand back over the wire.
+ * hand back over the wire, so the body carries a stable code from our own
+ * vocabulary instead of the driver's text.
+ *
+ * Schema drift is separated out by lib/tracker-errors: an unapplied migration
+ * answers 503 rather than 500, because the request was fine and the deployment
+ * is not. It is also the failure mode that was invisible before - the RPC
+ * `upsert_tracker_row` is applied by hand (#254), and until it exists every PUT
+ * failed as an opaque 500 that nothing alerted on. Reporting to Sentry is
+ * unconditional and tagged, so the missing-function case is one query away
+ * rather than buried in request logs.
  */
 function serverError(operation: string, error: unknown): NextResponse {
   console.error(`[api/tracker] ${operation} failed:`, error);
-  return NextResponse.json({ error: "Tracker sync failed" }, { status: 500 });
+
+  const pgCode = error instanceof TrackerStoreError ? error.code : undefined;
+  Sentry.captureException(error, {
+    tags: {
+      tracker_operation: operation,
+      // The driver's code, kept out of the response body but essential for
+      // telling PGRST202 (migration missing) from a real query fault.
+      pg_code: pgCode ?? "none",
+      ...(operation === "upsert" ? { rpc: "upsert_tracker_row" } : {}),
+    },
+  });
+
+  const { status, body } = trackerFailureResponse(error);
+  return NextResponse.json(body, { status });
 }
 
 export async function GET() {

--- a/web/lib/tracker-errors.test.ts
+++ b/web/lib/tracker-errors.test.ts
@@ -1,0 +1,138 @@
+/* ---------------------------------------------------------------------------
+   What a tracker failure looks like from outside the server.
+
+   The behaviour under test is the one that was missing while
+   `20260810064325_atomic_tracker_upsert.sql` sat unapplied: PostgREST answered
+   PGRST202 ("function public.upsert_tracker_row does not exist"), the store
+   flattened it to `new Error(error.message)`, and the route returned an opaque
+   500. Nothing distinguished "this deployment is missing a migration" from "the
+   database rejected the write", so the outage was invisible to every client and
+   to alerting.
+
+   These assertions pin three separate guarantees:
+
+   1. The driver's code survives the throw, because classification after the
+      fact must not depend on matching English prose.
+   2. Schema drift maps to 503 and a stable code; everything else stays 500.
+   3. The driver's message and code never reach the response body, because
+      Supabase errors name schema objects.
+
+   The mapping is tested here rather than through the route handler because
+   `route.ts` imports via the `@/` alias, which this project's vitest setup does
+   not resolve (there is no vitest config; every existing test uses relative
+   imports). Keeping the mapping in a dependency-free module is what makes it
+   assertable at all - see the note in tracker-errors.ts.
+--------------------------------------------------------------------------- */
+
+import { describe, expect, it } from "vitest";
+import {
+  BACKEND_UNAVAILABLE_CODES,
+  TRACKER_BACKEND_UNAVAILABLE,
+  TRACKER_SYNC_FAILED,
+  TrackerStoreError,
+  isBackendUnavailable,
+  trackerFailureResponse,
+  trackerStoreError,
+} from "./tracker-errors";
+
+/** The shape @supabase/supabase-js hands back on a failed call. */
+const pgError = (message: string, code?: string) => ({ message, code });
+
+describe("trackerStoreError", () => {
+  it("keeps the driver's code so the failure can be classified later", () => {
+    const error = trackerStoreError(
+      "upsert",
+      pgError(
+        "Could not find the function public.upsert_tracker_row(...)",
+        "PGRST202",
+      ),
+    );
+
+    expect(error).toBeInstanceOf(TrackerStoreError);
+    expect(error.code).toBe("PGRST202");
+    expect(error.operation).toBe("upsert");
+    // The message is preserved for the server-side log and for Sentry.
+    expect(error.message).toContain("upsert_tracker_row");
+  });
+
+  it("survives an error object with no code", () => {
+    const error = trackerStoreError("list", pgError("boom"));
+    expect(error.code).toBeUndefined();
+    expect(error.message).toBe("boom");
+  });
+
+  it("never loses its own message, even for a malformed driver error", () => {
+    expect(trackerStoreError("delete", null).message).toBe(
+      "Unknown database error",
+    );
+    expect(trackerStoreError("delete", { code: 500 }).message).toBe(
+      "Unknown database error",
+    );
+  });
+});
+
+describe("isBackendUnavailable", () => {
+  it("recognises every schema-drift code", () => {
+    for (const code of Object.keys(BACKEND_UNAVAILABLE_CODES)) {
+      expect(isBackendUnavailable(trackerStoreError("upsert", pgError("x", code))))
+        .toBe(true);
+    }
+  });
+
+  it("does not treat a real query fault as drift", () => {
+    // 23505 unique_violation, 23514 check_violation, 40P01 deadlock: the
+    // database is present and answering, so these must stay 500s.
+    for (const code of ["23505", "23514", "40P01", "42501"]) {
+      expect(
+        isBackendUnavailable(trackerStoreError("upsert", pgError("x", code))),
+      ).toBe(false);
+    }
+  });
+
+  it("does not classify an untyped error as drift", () => {
+    expect(isBackendUnavailable(new Error("PGRST202"))).toBe(false);
+    expect(isBackendUnavailable(undefined)).toBe(false);
+  });
+});
+
+describe("trackerFailureResponse", () => {
+  it("answers 503 for an unapplied migration", () => {
+    const { status, body } = trackerFailureResponse(
+      trackerStoreError("upsert", pgError("no such function", "PGRST202")),
+    );
+
+    expect(status).toBe(503);
+    expect(body.code).toBe(TRACKER_BACKEND_UNAVAILABLE);
+  });
+
+  it("answers 500 for anything else", () => {
+    const { status, body } = trackerFailureResponse(
+      trackerStoreError("upsert", pgError("deadlock detected", "40P01")),
+    );
+
+    expect(status).toBe(500);
+    expect(body.code).toBe(TRACKER_SYNC_FAILED);
+  });
+
+  it("leaks neither the driver's message nor its code", () => {
+    const secret =
+      'null value in column "user_id" of relation "user_hackathons"';
+    const { body } = trackerFailureResponse(
+      trackerStoreError("import", pgError(secret, "23502")),
+    );
+
+    const serialised = JSON.stringify(body);
+    expect(serialised).not.toContain("user_hackathons");
+    expect(serialised).not.toContain("user_id");
+    expect(serialised).not.toContain("23502");
+    // Exactly two keys, both from our own vocabulary.
+    expect(Object.keys(body).sort()).toEqual(["code", "error"]);
+  });
+
+  it("keeps the synced:false contract untouched", () => {
+    // resolveUser()'s 200 {synced:false} and its 401 are separate paths that
+    // never reach this mapping; a failure always carries a code.
+    const { body } = trackerFailureResponse(new Error("anything"));
+    expect(body).not.toHaveProperty("synced");
+  });
+});

--- a/web/lib/tracker-errors.ts
+++ b/web/lib/tracker-errors.ts
@@ -1,0 +1,123 @@
+/* ---------------------------------------------------------------------------
+   Classifying tracker database failures, so a missing migration stops looking
+   like a generic outage.
+
+   `20260810064325_atomic_tracker_upsert.sql` has to be applied by hand (this
+   project has no Supabase CLI or MCP wired up), and until it is, every
+   PUT /api/tracker fails. Before this module the failure arrived as
+   `new Error(error.message)` and left the route as an opaque
+   500 `{"error":"Tracker sync failed"}` with the real cause - PostgREST's
+   PGRST202, "function public.upsert_tracker_row does not exist" - visible only
+   in a server log nobody was reading. #254 tracks the wider drift between the
+   committed migrations and the live schema; this is the part that makes the
+   drift observable from the outside.
+
+   Two rules follow from that:
+
+   1. The PostgREST/Postgres code has to survive the throw. `error.message`
+      alone cannot be classified after the fact without matching on prose.
+   2. Schema drift is not a 500. The database is reachable and the request was
+      valid; the deployment is missing a migration, which is an "unavailable,
+      try later" condition and an operator's problem. It answers 503 with a
+      stable machine-readable code, so a client can tell "come back later" from
+      "your request was wrong" without parsing English.
+
+   What deliberately does NOT cross the wire: the Postgres code, the constraint
+   or column names, and the driver's message. Supabase errors name schema
+   objects, which is not something to hand to an anonymous caller. The stable
+   code is a fixed vocabulary of our own, so it discloses nothing.
+--------------------------------------------------------------------------- */
+
+/** Wire vocabulary. Stable across releases: clients may branch on these. */
+export const TRACKER_BACKEND_UNAVAILABLE = "TRACKER_BACKEND_UNAVAILABLE";
+export const TRACKER_SYNC_FAILED = "TRACKER_SYNC_FAILED";
+
+/**
+ * The codes that mean "the live schema is not the schema this code was written
+ * against", rather than "the query was wrong" or "the row was rejected".
+ *
+ * PGRST202/PGRST205 are PostgREST's own: the function or table is absent from
+ * its schema cache, which is exactly the unapplied-migration case. The 42xxx
+ * codes are Postgres proper, and cover the same drift reached by a path that
+ * bypasses the cache.
+ *
+ * `42501` is deliberately absent, and now has two sources, both of which must
+ * stay a 500 rather than a "come back later": a column grant that is wrong (RLS
+ * work can cause that), and `public.force_tracker_owner` refusing a `user_id`
+ * that does not match the caller's JWT subject
+ * (`supabase/migrations/20260818013000`). The second is an attack or a client
+ * bug, so it must be loud in Sentry and must never look transient.
+ */
+export const BACKEND_UNAVAILABLE_CODES: Record<string, true> = {
+  PGRST202: true, // function not found in schema cache
+  PGRST205: true, // table not found in schema cache
+  "42883": true, // undefined_function
+  "42P01": true, // undefined_table
+  "42703": true, // undefined_column
+};
+
+/**
+ * A store failure that remembers where it came from. `code` is whatever the
+ * driver reported, kept verbatim so classification never has to parse prose;
+ * `operation` is the store call, used as the Sentry tag and the log prefix.
+ */
+export class TrackerStoreError extends Error {
+  readonly code?: string;
+  readonly operation: string;
+
+  constructor(operation: string, message: string, code?: string) {
+    super(message);
+    this.name = "TrackerStoreError";
+    this.operation = operation;
+    this.code = code;
+  }
+}
+
+/**
+ * Wrap a Supabase/PostgREST error object. Its shape is `{ message, code? }` in
+ * practice, but it arrives untyped from the driver, so read it defensively -
+ * a thrown error that loses its own message is worse than the original bug.
+ */
+export function trackerStoreError(
+  operation: string,
+  error: unknown,
+): TrackerStoreError {
+  const source = (error ?? {}) as { message?: unknown; code?: unknown };
+  const message =
+    typeof source.message === "string" && source.message.length > 0
+      ? source.message
+      : "Unknown database error";
+  const code = typeof source.code === "string" ? source.code : undefined;
+  return new TrackerStoreError(operation, message, code);
+}
+
+/** True when the failure means "this deployment is missing a migration". */
+export function isBackendUnavailable(error: unknown): boolean {
+  const code = error instanceof TrackerStoreError ? error.code : undefined;
+  return code !== undefined && BACKEND_UNAVAILABLE_CODES[code] === true;
+}
+
+/**
+ * The HTTP answer for a failed store call: status plus the exact body the route
+ * serialises. Pure and dependency-free on purpose - the route needs
+ * next/server and Clerk to be importable, this needs neither, so the mapping
+ * that decides what a caller sees is unit-testable on its own.
+ */
+export function trackerFailureResponse(error: unknown): {
+  status: number;
+  body: { error: string; code: string };
+} {
+  if (isBackendUnavailable(error)) {
+    return {
+      status: 503,
+      body: {
+        error: "Tracker sync is unavailable",
+        code: TRACKER_BACKEND_UNAVAILABLE,
+      },
+    };
+  }
+  return {
+    status: 500,
+    body: { error: "Tracker sync failed", code: TRACKER_SYNC_FAILED },
+  };
+}

--- a/web/lib/tracker-store.ts
+++ b/web/lib/tracker-store.ts
@@ -38,6 +38,7 @@ import { auth } from "@clerk/nextjs/server";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import type { Stage, TrackerEntry } from "./tracker";
 import { parseTrackerEntries } from "./tracker";
+import { trackerStoreError } from "./tracker-errors";
 
 const TABLE = "user_hackathons";
 
@@ -101,7 +102,7 @@ export async function listTracker(userId: string): Promise<TrackerEntry[]> {
     .from(TABLE)
     .select("hackathon_id, stage, is_win")
     .eq("user_id", userId);
-  if (error) throw new Error(error.message);
+  if (error) throw trackerStoreError("list", error);
 
   return parseTrackerEntries(
     (data ?? []).map((row) => ({
@@ -137,7 +138,7 @@ export async function upsertTrackerRow(
     p_stage: patch.stage ?? null,
     p_is_win: patch.isWin ?? null,
   });
-  if (error) throw new Error(error.message);
+  if (error) throw trackerStoreError("upsert", error);
 
   // `returns table (...)` arrives as a one-row array. Fall back to the patch if
   // a client ever hands back a bare object instead, so the caller still gets
@@ -162,7 +163,7 @@ export async function deleteTrackerRow(
     .delete()
     .eq("user_id", userId)
     .eq("hackathon_id", hackathonId);
-  if (error) throw new Error(error.message);
+  if (error) throw trackerStoreError("delete", error);
 }
 
 /**
@@ -187,5 +188,5 @@ export async function importTrackerRows(
       })),
       { onConflict: "user_id,hackathon_id", ignoreDuplicates: true },
     );
-  if (error) throw new Error(error.message);
+  if (error) throw trackerStoreError("import", error);
 }


### PR DESCRIPTION
20260810064325_atomic_tracker_upsert.sql is applied by hand and is not applied yet, so every PUT /api/tracker fails. The store flattened the driver error to `new Error(error.message)`, which discarded PostgREST's code, and the route returned 500 {"error":"Tracker sync failed"} with the real cause visible only in a log nobody reads.

lib/tracker-errors.ts keeps the code on the throw and classifies it: PGRST202, PGRST205, 42883, 42P01 and 42703 mean this deployment is missing a migration, which is a 503 with a stable machine-readable code, not a 500. Everything else stays a 500. 42501 is deliberately excluded - a wrong grant, and now also force_tracker_owner refusing a foreign user_id, must never look transient. Reporting to Sentry is unconditional and tagged with the operation, the pg code and the RPC name. The driver's message and code never reach the response body.

Verified: 15 new tests, including one asserting the body leaks neither the table name, the column name nor the pg code, and one pinning that the {synced:false} offline-first contract is untouched. The four user-scoping sites in tracker-store.ts are byte-identical; the existing "boom" rejection test still passes.

Note: the comment on 42501 forward-references migration 20260818013000, which lands later in this stack.

Rollback: revert all four files together; the module has no other consumers.