### PR TITLE
Docs/security disclosure and threat model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ Spotted a hackathon, a wrong deadline, or a page that needs verifying? Open an i
 **2. Work on the software — invited developers.**
 Building the site, the automation scripts, and fixing bugs is done by developers we invite to the repo. Those issues carry labels like `frontend`, `backend`, `infra`, `security`, and `bug`, and are locked to collaborators. Not on the dev team yet? You can still propose code by **forking the repo and opening a pull request** — a maintainer reviews it. Want to join the team? Add a few hackathons first, then reach out to a maintainer.
 
+**Found a security problem?** Do not open an issue for it. The `security` label
+above is for maintainer triage of work we already know about, not a reporting
+channel. Report it privately instead — [`SECURITY.md`](SECURITY.md) has the two
+routes (GitHub Private Vulnerability Reporting, or email), what to expect from
+us, and a safe-harbour statement for good-faith research.
+
 ## How to Add a Hackathon
 
 ### Just Paste the Link! (Recommended)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,116 @@
+# Security Policy
+
+HackHQ is a community-run, open-source hackathon directory. It holds very little
+about people — a signed-in user's tracker rows are an account id, a hackathon id,
+a stage, a win flag and two timestamps — but it does hold accounts, and it does
+publish community submissions. We would rather hear about a problem early and
+awkwardly than late and publicly.
+
+## Supported versions
+
+There is one deployed version: whatever `main` currently is. HackHQ is a
+continuously deployed site, not a released library, so there are no maintenance
+branches and no back-porting.
+
+| Version | Supported |
+| --- | --- |
+| `main` (the live site) | Yes |
+| Any earlier commit, tag or fork | No |
+
+If you are running a fork, the fix will be in `main` — rebase onto it.
+
+## Reporting a vulnerability
+
+**Do not open a public issue.** A public report is a public exploit window, and
+this repository's issue templates are designed for hackathon listings rather than
+for security reports.
+
+Use whichever is easier:
+
+1. **GitHub Private Vulnerability Reporting** — preferred.
+   [Open a private report](https://github.com/Hack-HQ/hackhq/security/advisories/new).
+   It is private to maintainers, it threads, and it produces an advisory we can
+   publish once the fix is out.
+2. **Email** — <hackheadquarters@gmail.com>, subject line starting
+   `[SECURITY]`. This is the same monitored address as the site's contact form.
+   Say "security" in the first line so it is not triaged as a listing request.
+
+Helpful to include, in rough order of usefulness: what an attacker can do, the
+steps to reproduce, the affected URL or file, and whether you have told anyone
+else. A rough report you are unsure about is still worth sending.
+
+Please **do not** put proof-of-concept code, request captures, session
+identifiers or credentials in a public place — a pull request, a fork's branch, a
+gist or a public issue. Attach them to the private report instead.
+
+## What to expect from us
+
+These are commitments we can actually meet with a small volunteer team, so they
+are deliberately modest. If a deadline is going to slip, we will tell you rather
+than go quiet.
+
+| Stage | Target |
+| --- | --- |
+| We acknowledge your report | Within **3 business days** |
+| We tell you whether we can reproduce it, and our severity assessment | Within **10 business days** |
+| We agree a disclosure timeline with you | Once severity is assessed |
+| Critical issues (account takeover, data exposure across accounts, secret disclosure) | Mitigated as fast as we can, usually configuration first and code after |
+
+We will credit you in the advisory unless you would rather stay anonymous. We
+have no bug bounty and cannot pay for reports.
+
+Some of what runs HackHQ is not ours to fix: authentication is handled by Clerk,
+the database by Supabase, hosting by Vercel. If your finding is in one of those
+platforms rather than in this code, we will say so and help route it to that
+vendor's security team, and we will not disclose it on their behalf.
+
+## Safe harbour
+
+We will not pursue or support legal action against you, and will treat your
+research as authorised, if you act in good faith and:
+
+- **Stay within your own data.** Use accounts you control. If you stumble into
+  someone else's data, stop, do not save it, and tell us what you saw.
+- **Do not degrade the service.** No denial of service, no load testing, no
+  spamming the submission or sign-in flows, no automated scanning that a
+  reasonable person would call an attack.
+- **Do not use social engineering, phishing, or physical access** against
+  maintainers, contributors, or our vendors.
+- **Do not modify or delete data that is not yours**, and do not use a finding to
+  gain more access than the finding itself demonstrates.
+- **Give us a reasonable chance to fix it** before telling anyone else.
+- **Respect the platforms.** Testing against Clerk, Supabase or Vercel
+  infrastructure is governed by their policies, not ours, and we cannot grant you
+  permission for it.
+
+Working within these limits, we consider your testing authorised under the
+computer-misuse laws that would otherwise apply, and we will say so publicly if
+anyone suggests otherwise. Act outside them — particularly against other users'
+accounts — and this does not apply.
+
+## Things that are public on purpose
+
+Please do not report these; they are documented decisions, not oversights. See
+[`docs/threat-model.md`](docs/threat-model.md) for the reasoning.
+
+- **Listing data is fully public**, including `source`, the GitHub username of
+  whoever submitted a listing. It is already in `.github/scripts/listings.json`
+  and the README.
+- **Gallery photo credits are public**, including the name and profile link a
+  contributor chooses to be credited under. The submission form offers a
+  no-attribution option.
+- **Submissions are public from the moment they are made** — they are GitHub
+  issues under the submitter's own account.
+- **Sentry DSNs and the Mapbox and Clerk publishable keys ship in the client
+  bundle.** They are designed to be public. A Supabase *service role* key or a
+  Clerk *secret* key in the bundle would be a real finding; those are server-only
+  and never prefixed `NEXT_PUBLIC_`.
+
+## Scope
+
+In scope: this repository, and the site it deploys.
+
+Out of scope: findings that require a compromised maintainer machine or a leaked
+credential to begin with (report the leak instead — that we very much want to
+know about), the security posture of a hackathon organiser's own site that we
+merely link to, and vendor platform issues as described above.

--- a/docs/runbooks/flip-token-mode.md
+++ b/docs/runbooks/flip-token-mode.md
@@ -24,18 +24,22 @@ failure modes are all external.
 ## Why this is not just "set the env var"
 
 Three things live outside this repo, and the flip is broken until all three are
-true. A repository audit cannot confirm any of them.
+true. Artefact 1 *is* checkable without a dashboard, via the authenticated
+Supabase CLI's Management API token; artefacts 2 and 3 are not, and stay with the
+maintainer.
 
 | # | Artefact | Where to look | Failure if missing |
 | --- | --- | --- | --- |
-| 1 | Clerk registered as a third-party auth provider | Supabase dashboard → Authentication → Sign In / Up → Third Party Auth | Supabase rejects the JWT; every tracker request 500s |
+| 1 | Clerk registered as a third-party auth provider | `GET /v1/projects/<ref>/config/auth/third-party-auth` — a non-empty list. Dashboard equivalent: Authentication → Sign In / Up → Third Party Auth | Supabase rejects the JWT; every tracker request 500s |
 | 2 | A Clerk JWT template named `supabase` carrying `{"role":"authenticated"}` | Clerk dashboard → Configure → JWT Templates | `getToken({ template: "supabase" })` returns null; the store throws by design rather than falling back |
-| 3 | `SUPABASE_ANON_KEY` in the runtime environment | Vercel / Cloudflare project settings | Service mode stays selected and nothing changes |
+| 3 | `SUPABASE_ANON_KEY` in the runtime environment | Vercel project settings | Service mode stays selected and nothing changes |
 
-`docs/superpowers/plans/2026-07-22-supabase-foundation.md` still records that
-artefact 1 was **not** configured. Do not edit that line on the strength of an
-assumption — correct it in the same change that demonstrates the flip, and
-attach the evidence.
+**Artefact 1 was verified ABSENT on 2026-08-18.** The integrations list came back
+empty, and the full auth config carried no JWKS, issuer or third-party field and
+never mentioned Clerk. So the flip is not merely unverified, it is not currently
+possible, and `plans/…`'s "Clerk third-party auth is not configured" line is
+accurate rather than stale. Re-check before starting, and do not correct that
+line until the integration list is non-empty.
 
 ## Step 1 — land the database work first
 
@@ -132,8 +136,16 @@ rollback.
   guarantee and the paragraph should say so. There is a comment in that file
   recording exactly this, and the page's own promise is that it changes when the
   code does.
-- **Correct the plan.** Update the stale "Clerk third-party auth is not
-  configured" line, with the evidence.
+- **Correct the plan — but only once artefact 1 is genuinely true.** The line in
+  `docs/superpowers/plans/2026-07-22-supabase-foundation.md` reading "Clerk
+  third-party auth is not configured" was **verified accurate** on 2026-08-18
+  against the linked project's Management API: `GET
+  /v1/projects/<ref>/config/auth/third-party-auth` returned an empty list, and
+  `GET /v1/projects/<ref>/config/auth` contained no JWKS, issuer or third-party
+  field and never mentioned Clerk. So it is not stale, and correcting it before
+  the provider is actually registered would put a false claim about production
+  into the repository. Re-run those two reads, confirm a non-empty integration
+  list, and only then update the line — citing the evidence.
 - **Then, and only then, consider removing `SUPABASE_SERVICE_ROLE_KEY`** from the
   runtime environment. `tracker-store.ts` is the only runtime code that reads it.
   Note it is a *different* variable from `SUPABASE_SERVICE_KEY`, the GitHub

--- a/docs/superpowers/plans/2026-07-22-supabase-foundation.md
+++ b/docs/superpowers/plans/2026-07-22-supabase-foundation.md
@@ -19,7 +19,7 @@ This is **plan 1 of 4** for `docs/superpowers/specs/2026-07-22-deck-table-redesi
 
 ## Global Constraints
 
-- Supabase project id: `gvdhwygerbsuojwpnsgq` (org `atvjoxcqenrldzrzodsu`). Verify with `list_projects` before any write — the connector is account-scoped, so confirm it is pointed here before applying anything.
+- Supabase project: the ref in `$SUPABASE_PROJECT_REF`, the org in `$SUPABASE_ORG_ID`. Both come from a maintainer's shell or the dashboard URL and are deliberately not written down here, because this is a public repository. Verify with `list_projects` before any write — the connector is account-scoped, so confirm it is pointed here before applying anything.
 - Table: `public.hackathons`, primary key `id` (uuid). 32 rows at time of writing; `listings.json` holds 79.
 - `host` is `company_name` renamed. Do not rename it.
 - `startDate` / `endDate` already exist and are **camelCase**. Do not rename them; `seed_supabase.py` would break.
@@ -62,12 +62,12 @@ The table was created by hand, and Supabase's migration history was empty when t
 
 - [ ] **Step 1: Confirm you are on the right Supabase account**
 
-Call `list_projects`. Expected: exactly one project named `HackHQ`, id `gvdhwygerbsuojwpnsgq`.
-If it returns anything other than exactly that one project, stop — the connector is pointed at the wrong account, and nothing here should be applied to it.
+Call `list_projects`. Expected: exactly one project named `HackHQ`, whose id equals `$SUPABASE_PROJECT_REF`.
+If it returns anything other than exactly that one project, or the id does not equal that value, stop — the connector is pointed at the wrong account, and nothing here should be applied to it. The comparison IS this step; do not skip it because the literal is no longer inline.
 
 - [ ] **Step 2: Check the migration history**
 
-Call `list_migrations` with `project_id: gvdhwygerbsuojwpnsgq`.
+Call `list_migrations` with `project_id: <SUPABASE_PROJECT_REF>`.
 
 Against a project this plan has never run on, expect `{"migrations":[]}` — the
 schema was applied by hand and nothing was tracked.
@@ -120,7 +120,7 @@ alter table public.hackathons enable row level security;
 
 - [ ] **Step 4: Apply it**
 
-Use `apply_migration` with `project_id: gvdhwygerbsuojwpnsgq`, `name: baseline_hackathons`, and the SQL above.
+Use `apply_migration` with `project_id: <SUPABASE_PROJECT_REF>`, `name: baseline_hackathons`, and the SQL above.
 
 - [ ] **Step 5: Verify it recorded and changed nothing**
 

--- a/docs/superpowers/specs/2026-07-22-deck-table-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-22-deck-table-redesign-design.md
@@ -51,8 +51,8 @@ merge logic beyond this.
 
 ## Current state of the database
 
-> **Point-in-time snapshot — superseded.** Taken against project
-> `gvdhwygerbsuojwpnsgq` (org `atvjoxcqenrldzrzodsu`) on 2026-07-22, *before any
+> **Point-in-time snapshot — superseded.** Taken against the HackHQ Supabase
+> project (ref and org redacted; this is a public repository) on 2026-07-22, *before any
 > migration ran*. It is kept because it is what motivated the phases below, not
 > because it is current. `supabase/migrations/` is the authority on the schema as
 > it stands; `list_migrations` is the authority on what has been applied.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -212,4 +212,5 @@ Recorded rather than hidden. Each is tracked.
 | No rate limiting on `/api/tracker` | Bounded by `MAX_IMPORT_ENTRIES` on the import path only |
 | Tracker rows accept any well-formed UUID, so a caller can store ids for listings that do not exist | Confined to the caller's own rows; the existence check exists in `web/lib/tracker.ts` but is not wired into the route |
 | The Mapbox token is public by necessity and billable | Mitigation is a URL restriction on the Mapbox side, not in code |
-| Authentication hardening lives in the Clerk dashboard, not here | Tracked outside this repository; there is no in-repo auth surface to patch |
+| Authentication hardening lives in the Clerk dashboard, not here | Tracked in a private GitHub security advisory, not in this file — there is no in-repo auth surface to patch, and the detail does not belong in a public document |
+| Token-mode flip blocked: Clerk is not registered as a Supabase third-party auth provider (verified 2026-08-18) | Issue #235; see [`docs/runbooks/flip-token-mode.md`](runbooks/flip-token-mode.md). Until it is, the tenant boundary stays application-layer |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,215 @@
+# Threat model
+
+What HackHQ trusts, what it does not, and where each boundary is actually
+enforced. Written so that a reviewer can check a claim against a specific file
+rather than take this document's word for it.
+
+Scope: this repository and the site it deploys. Authentication (Clerk), the
+database (Supabase) and hosting (Vercel) are third-party platforms — their
+internals are out of scope, but the boundaries we draw against them are in.
+
+## Trust boundaries
+
+| # | Boundary | Untrusted side | Enforced at |
+| --- | --- | --- | --- |
+| 1 | Public site → server | Anything in a request | `web/app/api/tracker/route.ts` (the only route handler) |
+| 2 | Server → browser | What we serialise into the page | `web/lib/listings.ts`'s field projection |
+| 3 | One signed-in user → another | The caller's claimed identity | See [Tenant boundary](#tenant-boundary) |
+| 4 | Contributor → repository | Issue text, form fields, attachments | See [Automation trust model](#automation-trust-model) |
+| 5 | Repository → database | Whatever CI sends | `service_role` key, constrained by triggers rather than policies |
+
+Two facts shape most of this:
+
+- **There is exactly one route handler.** `web/app/api/tracker/route.ts`. No
+  server actions exist anywhere in `web/`. So the entire request-handling attack
+  surface of the application is four methods on one path.
+- **There is no admin concept.** No roles, no permissions, no organisations, no
+  `publicMetadata` reads. `web/middleware.ts` calls `auth.protect()` with no
+  arguments — it is a signed-in-or-not check. Consequently there is no privilege
+  escalation *within* the app: the most a hijacked session can do is what that
+  user could already do.
+
+## Data classification
+
+`public.hackathons` is a public board. `public.user_hackathons` is per-user and
+private. The interesting cases are the exceptions.
+
+**Do not maintain a column list here.** It would drift from the code within a
+release, and a stale security document is worse than none. The enforced
+boundaries are:
+
+- **What reaches a browser** is decided by the field projection in
+  `web/lib/listings.ts` — an explicit object literal, deliberately not a spread.
+  If a column is not named there, it does not reach the client. That literal *is*
+  the boundary; read it rather than trusting a copy.
+- **What the database will hand to an API role** is decided by the column-level
+  `GRANT`s in `supabase/migrations/`, asserted on every pull request by
+  `supabase/tests/10_invariants.sql`. If someone widens a grant, that suite fails
+  and names the migration that established the invariant.
+
+The two exceptions worth knowing:
+
+- **`submitted_by` is private.** It is the submitter's Clerk user id. It is
+  readable by neither `anon` nor `authenticated`, is grantable on INSERT but never
+  on UPDATE (so a row cannot be re-owned), and is never emitted to the browser.
+  Withholding it is the reason the read grants are a column list rather than a
+  table grant.
+- **`source` is public, and that is deliberate.** It is a GitHub username, already
+  published in `.github/scripts/listings.json` and in the README's contributor
+  wall. It reads like PII to strip; removing it would also empty the README and
+  the archive, because it is a required field for the listing pipeline.
+
+Gallery credits (a contributor's chosen name and profile link) are public by
+agreement — the terms page commits to showing photos with the credit provided,
+and the submission form offers "no attribution", which is honoured in the
+committed filename, in `gallery.json`, in the issue-closing comment, and in the
+commit's `Co-authored-by` trailer.
+
+## Tenant boundary
+
+One signed-in user must not reach another's tracker rows. **Where that is
+enforced depends on which mode the deployment is running**, and the honest answer
+today is: in application code.
+
+### Current state — service-role mode
+
+`web/lib/tracker-store.ts` authenticates to Supabase with the service role key,
+which **bypasses row level security**. No policy on `public.user_hackathons` is
+consulted. The boundary is four sites in that file: a `user_id` filter on the
+read and on the delete, `p_user_id` on the upsert RPC, and a per-row `user_id`
+stamp on the import. They are covered by tests that run the same suite twice,
+once per mode.
+
+That is a real boundary, and it is also a single layer. A regression in any of
+those four lines is a cross-tenant leak with nothing behind it. This is tracked as
+issue #235.
+
+Two things narrow the blast radius, both in the database and neither dependent on
+the application being correct:
+
+- `public.force_tracker_owner`, a `BEFORE INSERT OR UPDATE` trigger, fills
+  `user_id` from the request's JWT subject when it is omitted and **raises `42501`
+  when a supplied value does not match**. It refuses rather than silently
+  rewriting, so an attempt is loud and reaches Sentry. Note the scope: it keys on
+  the JWT, and `service_role` carries none, so it is a deliberate no-op for the
+  server-side client and for a maintainer in the SQL editor.
+- `user_id` is not UPDATE-grantable at all, so an existing row cannot be re-owned
+  even by a caller whose own claim would satisfy a policy.
+
+The caller's identity itself is not attacker-controlled: the route derives it from
+the verified Clerk session and never reads a user id from a request body, query
+string, header or cookie.
+
+### PENDING — token mode
+
+**This section describes a state that is not live yet.** It becomes true when the
+flip in [`docs/runbooks/flip-token-mode.md`](runbooks/flip-token-mode.md) lands,
+which is gated on three pieces of external configuration, not on code. Do not
+cite it as current until then, and update this section — not just the runbook —
+when it does.
+
+After the flip, each request carries the caller's Clerk JWT, queries run as
+Supabase's `authenticated` role, and the RLS policies on
+`public.user_hackathons` become the enforcement point: a cross-tenant read
+returns zero rows because the database says so, not because the application
+remembered to ask. The application-layer filters stay as a second layer, so a
+misconfigured deployment degrades to today's guarantee rather than to nothing.
+
+`SUPABASE_TRACKER_REQUIRE_RLS=1` makes a deployment that cannot run in token mode
+refuse tracker traffic instead of falling back to the RLS-bypassing key. Every
+tracker error reported to Sentry carries a `tracker_mode` tag, which is how the
+live mode can be established after the fact.
+
+## Privileged writes are a credential problem, not an authz problem
+
+**No application code writes `public.hackathons`.** `web/lib/tracker-store.ts`
+touches exactly one table, `user_hackathons`; there is no `from("hackathons")` and
+no `.insert(` anywhere in `web/`.
+
+The complete set of principals that can write the public board:
+
+| Principal | Reach | Where the credential lives |
+| --- | --- | --- |
+| `service_role` | **Unrestricted**, bypasses RLS | The `SUPABASE_SERVICE_KEY` GitHub Actions secret used by the hourly sync, and `SUPABASE_SERVICE_ROLE_KEY` in a maintainer's local env |
+| `postgres` / `supabase_admin` | Unrestricted | The Supabase dashboard — a human account |
+| `authenticated` | Own `origin = 'user'` rows only | The publishable key plus a Clerk session; cannot set `featured`, `is_visible`, `state` or `id`, and cannot touch a synced row |
+
+The consequence is worth stating plainly, because it redirects where to look after
+an incident: **"someone modified listing data with elevated privileges" is a
+credential-compromise or dashboard-access finding, not an application
+authorisation bug.** There is no app path to it at any privilege level. The
+mitigation is key rotation — see
+[`docs/runbooks/rotate-credentials.md`](runbooks/rotate-credentials.md) — and MFA
+on maintainer accounts.
+
+The sync is constrained by a **trigger** rather than a policy, precisely because
+`service_role` bypasses policies: `skip_sync_over_user_rows` discards any update
+that would let the hourly sync take over a row a user submitted. Triggers are not
+bypassed by any role.
+
+## Automation trust model
+
+Six workflows commit to `main` in response to community input. The model is:
+**contributor input is untrusted data; the bot is the only identity that commits.**
+
+- **Every committing workflow commits as `github-actions[bot]`.** No workflow
+  derives a git identity from user input. A contributor who wants credit gets a
+  `Co-authored-by:` trailer built from the authenticated actor's GitHub noreply
+  address (`<numeric-id>+<login>@users.noreply.github.com`), which cannot be
+  aimed at somebody else because both halves come from the event payload rather
+  than from anything typed. A contributor-typed email field used to become the
+  commit author; it was removed.
+- **Untrusted text never reaches a shell.** Issue titles, bodies, comments and
+  form fields cross into `run:` blocks through the `env:` map and are dereferenced
+  as quoted shell variables. The only inline `${{ }}` uses inside `run:` blocks
+  are `github.event_path` and `github.repository`, both runner-controlled.
+- **`util.set_output` has no escaping of its own.** It is safe because every field
+  reaching it is newline-stripped upstream by `sanitize_field`. Anything new that
+  flows into `$GITHUB_OUTPUT` must keep that property, or it reopens an output
+  injection path.
+- **Label-gated, not open.** The issue-triggered workflows require a maintainer to
+  apply a label, so an anonymous outsider cannot start them. The label is the
+  control; there is no second one.
+- **Third-party model processing is part of the pipeline.** The
+  link-only submission path sends the submitted URL's content, and any free-text
+  context, to the OpenAI API. Submitters should know that; the issue form is where
+  to say so.
+- **Attachments are re-encoded, not trusted.** Gallery images are decoded and
+  re-saved through Pillow before they are committed, which drops camera metadata,
+  and the pipeline refuses anything that will not decode. A CI check rejects any
+  committed gallery image carrying GPS or Artist tags.
+- **Actions are pinned to full commit SHAs** and every workflow declares an
+  explicit `permissions:` block. No workflow uses `pull_request_target`, and none
+  checks out untrusted pull-request code.
+
+## Secrets
+
+The rule is one line, in `web/README.md`: values prefixed `NEXT_PUBLIC_` are
+inlined into the client bundle at build time; everything else is server-only and
+must never gain that prefix. `web/lib/env.ts` reads the server-only values and
+returns booleans, never the values themselves, so importing it cannot leak one.
+
+Highest blast radius, in order: the Supabase `service_role` key (bypasses RLS on
+both tables, so every policy in `supabase/migrations/` stops applying), a Postgres
+connection string (`DATABASE_URL` — embeds the password and connects as the table
+owner, so RLS never applies to it at all), and `CLERK_SECRET_KEY`. Rotation
+procedures are in [`docs/runbooks/rotate-credentials.md`](runbooks/rotate-credentials.md).
+
+Two layers keep them out of the repository: `.gitignore` and `web/.gitignore`
+exclude every `.env` variant except the all-empty `.env.example`, and a
+`.githooks/pre-commit` hook plus a CI job enforce the same rule on the tree and on
+every commit an event introduces — the CI half is what makes `--no-verify`
+harmless. `gitleaks` scans full history on every pull request.
+
+## Known gaps
+
+Recorded rather than hidden. Each is tracked.
+
+| Gap | Status |
+| --- | --- |
+| Tenant boundary is application-layer, not database-enforced | Issue #235; the flip is prepared and gated on external configuration |
+| No resource CSP (`default-src`/`script-src`); only `frame-ancestors` ships | Deliberate — needs per-integration allowances; `web/next.config.ts` records it |
+| No rate limiting on `/api/tracker` | Bounded by `MAX_IMPORT_ENTRIES` on the import path only |
+| Tracker rows accept any well-formed UUID, so a caller can store ids for listings that do not exist | Confined to the caller's own rows; the existence check exists in `web/lib/tracker.ts` but is not wired into the route |
+| The Mapbox token is public by necessity and billable | Mitigation is a URL restriction on the Mapbox side, not in code |
+| Authentication hardening lives in the Clerk dashboard, not here | Tracked outside this repository; there is no in-repo auth surface to patch |

--- a/web/README.md
+++ b/web/README.md
@@ -17,10 +17,19 @@ deck, and member tracker, plus a legacy searchable directory at `/hackathons`.
 
 ## How it works
 
-This app does **not query a database at runtime**. Listing data lives in the repo
-and is read from disk when pages are generated. Supabase is maintained as a
-Postgres mirror for backend/API work; its schema lives in `db/schema.ts` and is
-managed with Drizzle.
+Page content is not fetched from a database at runtime. Listing data lives in the
+repo and is read from disk when pages are generated, which is why the globe, the
+deck and `/hackathons` render with no database configured at all.
+
+There is one exception, and it is a real one: the signed-in tracker.
+`/api/tracker` reads and writes `public.user_hackathons` in Supabase on every
+request — see [Tracker sync modes](#tracker-sync-modes) below. Without Clerk or
+without Supabase it degrades to browser-local storage, so a deployment with
+neither genuinely has no runtime database; a configured one does.
+
+The schema's source of truth is `supabase/migrations/`, not Drizzle. `db/schema.ts`
+mirrors it for types only and is not a migration authority — see
+[Supabase schema](#supabase-schema).
 
 ### Data sources
 

--- a/web/components/hq/sections.tsx
+++ b/web/components/hq/sections.tsx
@@ -716,6 +716,9 @@ function OfferCard() {
             ["Privacy", "/privacy"],
             ["Terms of use", "/terms"],
             ["MIT license", `${REPO_URL}/blob/main/LICENSE`],
+            // Reporting route, not a legal document, but this is the column a
+            // reader scans for "how do I tell them something serious".
+            ["Report a vulnerability", `${REPO_URL}/blob/main/SECURITY.md`],
           ]}
         />
       </div>


### PR DESCRIPTION
Stacked on #282 (`feat/issue-235-prepare-token-mode-flip`). Review that first, or retarget this to `main` if you prefer the flat view — the diff against `main` will then include the whole stack.

## What changed

| File | Change |
|---|---|
| `SECURITY.md` | **New.** Supported versions, two private reporting routes, response-time targets, safe harbour, and a "public on purpose" list |
| `docs/threat-model.md` | **New.** Trust boundaries, data classification, tenant boundary (current + PENDING), privileged-writer analysis, automation trust model, known gaps |
| `docs/superpowers/plans/…` | Project/org ref redacted — plain MCP args to `<SUPABASE_PROJECT_REF>`, the two safety interlocks kept **checkable** as `$SUPABASE_PROJECT_REF` |
| `docs/superpowers/specs/…` | Ref redacted (block already marked superseded, so provenance only) |
| `web/README.md` | `:20`'s false "does not query a database at runtime" corrected; the stale Drizzle sentence after it too |
| `CONTRIBUTING.md` | Links `SECURITY.md`, and says the `security` label is triage, not a reporting channel |
| `web/components/hq/sections.tsx` | One footer link, Legal column |

## Deliberate choices

- **No column list in the threat model.** It names `web/lib/listings.ts`'s projection and the column grants as the enforced boundaries instead, because a restated list drifts and a stale security doc is worse than none.
- **The two interlocks are not blanked.** `plans:22` and `:65-66` compare against the expected project and stop if it differs. Blanking them would delete the guard that stops an agent applying migrations to the wrong account, so they keep a checkable env-lookup form, and the step now says the comparison must not be skipped just because the literal is gone.
- **Token mode is marked PENDING**, with a note to update the threat model and not just the runbook when #282's flip lands.
- **`service_role` recorded as the only unrestricted writer** of `public.hackathons`, so privileged listing modification is a credential-compromise vector rather than an app authz path — that is where an incident responder should look.

## Already done elsewhere, so not repeated

`DATABASE_URL`/`SUPABASE_DATABASE_URL` are already classified `Runtime, secret` with the RLS-free rationale, by #284 earlier in this stack.

## Verification

- No real project ref, org id, or key material in **any added line**; zero tracked files contain either literal (remaining copies are in gitignored `.claude/worktrees` and `supabase/.temp`).
- Every relative link resolves; the footer link appears in the built output.
- `tsc`, `lint`, **253** vitest, **155** python, `next build` — all clean.
- Merges clean onto the stack in sequence with all seven other branches.

## Rollback

Revert the commit. Documentation plus one footer array entry; nothing depends on it.
