### PR TITLE
Stop Workers Builds deploying this Worker; stop the freshness check racing the deploy

### DIFF
--- a/.github/scripts/test_workflows.py
+++ b/.github/scripts/test_workflows.py
@@ -277,6 +277,44 @@ class DeployChaining(unittest.TestCase):
         self.assertIn("Deploy to Cloudflare", workflow_run_names(read("site_freshness.yml")))
         self.assertEqual("Deploy to Cloudflare", workflow_name(read("deploy.yml")))
 
+    def test_freshness_does_not_race_the_deploy_it_shares_a_push_with(self):
+        """The freshness push trigger must not fire on listing changes.
+
+        A push that changes listings.json also starts deploy.yml. The check
+        finishes in ~20s and the deploy takes a minute or more, so the check
+        would read the pre-deploy site and report every listing in that push as
+        missing - which is what happened on all three merges of 2026-09-02.
+        The deploy-completion trigger covers those pushes properly.
+        """
+        text = read("site_freshness.yml")
+        m = re.search(r"^on:\n(.*?)^permissions:", text, re.MULTILINE | re.DOTALL)
+        self.assertIsNotNone(m, "could not find the `on:` block in site_freshness.yml")
+        push_block = re.search(
+            r"^  push:\n(?:.*\n)*?(?=^  \w)", m.group(1), re.MULTILINE
+        )
+        self.assertIsNotNone(push_block, "site_freshness.yml lost its push trigger")
+        self.assertNotIn(
+            "listings.json",
+            push_block.group(0),
+            "site_freshness.yml runs on pushes that change listings.json. That push "
+            "also triggers the deploy, so the check races it and reports the "
+            "pre-deploy site as stale on every merge.",
+        )
+
+    def test_the_build_refuses_to_run_under_another_ci_system(self):
+        """Only one pipeline may deploy this Worker.
+
+        Cloudflare Workers Builds promoted its own build over a verified deploy
+        on 2026-09-02. Disconnecting it is a dashboard step; this is the half
+        that lives in the repo, and it has to sit where any `next build` loads
+        it rather than in an npm script the other pipeline does not run.
+        """
+        config = os.path.join(WORKFLOW_DIR, "..", "..", "web", "next.config.ts")
+        with open(config, encoding="utf-8") as f:
+            text = f.read()
+        self.assertIn("foreignCiError", text)
+        self.assertIn("throw new Error", text)
+
     def test_freshness_heals_a_development_build_by_redeploying(self):
         """A build from another pipeline on production is the one failure the
         check can fix itself: dispatch deploy.yml with force. That needs

--- a/.github/workflows/site_freshness.yml
+++ b/.github/workflows/site_freshness.yml
@@ -21,16 +21,26 @@ name: Site freshness
 #   - hourly, as a backstop for a Worker rolled back or deployed from outside
 #     CI (which is how a Clerk development build reached production for days
 #     in 2026-08, see check_site_freshness.py);
-#   - on human pushes to the files involved.
-#   A push made with the default GITHUB_TOKEN starts no workflow run, so the
-#   push trigger alone would never see bot-written listings - the same gap
-#   sync_supabase.yml documents and test_workflows.py pins down.
+#   - on a push that changes the checker itself, so a change to this check is
+#     exercised by the change that makes it.
+#
+# Deliberately NOT on a push that changes listings.json. That push also starts
+# deploy.yml, and this job finishes in ~20s while the deploy takes a minute or
+# more - so it would read the pre-deploy site and report every listing in the
+# push as missing. It did, on all three merges of 2026-09-02: red runs whose
+# own `workflow_run` counterpart, minutes later, was green. A check that cries
+# stale on every merge is a check people learn to ignore. The deploy-completion
+# trigger below covers exactly the same pushes, after the deploy that fixes
+# them.
+#
+# A push made with the default GITHUB_TOKEN starts no workflow run at all, so
+# the push trigger could never have covered bot-written listings anyway - the
+# same gap sync_supabase.yml documents and test_workflows.py pins down.
 
 on:
   push:
     branches: [main]
     paths:
-      - '.github/scripts/listings.json'
       - '.github/scripts/check_site_freshness.py'
       - '.github/workflows/site_freshness.yml'
   workflow_run:

--- a/web/README.md
+++ b/web/README.md
@@ -551,17 +551,24 @@ Cloudflare dashboard rather than in this repository. Either:
   variable to the production `pk_live_…` key, so a later re-enable cannot ship
   a dev build.
 
-Until that is done, every push to `main` is followed within a minute or two by
-a dev-key build — it happened again on 2026-09-02 07:33 UTC, 55 seconds after
-`deploy.yml` had verified its own build live. Three things now limit the
-damage: `deploy.yml` re-checks the served build two minutes after verifying
-and fails (leaving the `production` tag where it was) if the build changed
-underneath it; `site_freshness.yml` names the Clerk handshake for what it is;
-and when it finds one it re-runs `deploy.yml` with **force**, so production
-is put back within the hour while the run stays red. That is a tug of war,
-not a fix — the fix is the dashboard step above. Do not re-enable automatic
-deployments from Workers Builds unless `deploy.yml` is retired at the same
-time — one pipeline, not two.
+**The repository half of the fix is already in place.** `next.config.ts` calls
+`foreignCiError()` from [`lib/foreign-ci.ts`](lib/foreign-ci.ts) and throws when
+`WORKERS_CI=1` — the variable Workers Builds
+[injects into its own builds](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/#default-variables).
+A Workers Builds run now fails while loading the Next config, before it has a
+bundle to promote, and its error names the dashboard step above. The guard sits
+in the config rather than an npm script because that is the one file every
+`next build` loads, whichever command invoked it. It cannot fire on a laptop or
+in GitHub Actions, neither of which sets `WORKERS_CI`. To deliberately move
+production onto Workers Builds later, set `HACKHQ_ALLOW_FOREIGN_CI=1` as a build
+variable and retire `deploy.yml` in the same change — one pipeline, not two.
+
+Two more guards stay, for a build that reaches production some other way (a
+rollback, a hand deploy): `deploy.yml` re-checks the served build two minutes
+after verifying it and fails, leaving the `production` tag where it was, if the
+build changed underneath it; and `site_freshness.yml` names the Clerk handshake
+for what it is and re-runs `deploy.yml` with **force** when it finds one, so
+production is put back within the hour while the run stays red.
 
 The local tooling for Cloudflare is live, not vestigial: `wrangler.jsonc`,
 `open-next.config.ts` and the `preview` / `deploy` / `cf-typegen` scripts are

--- a/web/lib/foreign-ci.test.ts
+++ b/web/lib/foreign-ci.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { ALLOW_VAR, foreignCiError, FOREIGN_CI_MESSAGE } from "./foreign-ci";
+
+/**
+ * The guard that keeps a second pipeline from deploying this Worker.
+ *
+ * It has to fire in exactly one place — a Workers Builds build — and stay
+ * silent everywhere else, because a false positive here breaks every local
+ * build and the GitHub deploy along with it.
+ */
+describe("foreignCiError", () => {
+  it("fails a Workers Builds build", () => {
+    expect(foreignCiError({ WORKERS_CI: "1" })).toBe(FOREIGN_CI_MESSAGE);
+  });
+
+  it("names the dashboard step that actually fixes it", () => {
+    const msg = foreignCiError({ WORKERS_CI: "1" }) ?? "";
+    expect(msg).toContain("Settings -> Builds ->");
+    expect(msg).toContain("deploy.yml");
+    expect(msg).toContain(ALLOW_VAR);
+  });
+
+  it("stays silent on a laptop", () => {
+    expect(foreignCiError({})).toBeNull();
+  });
+
+  it("stays silent in GitHub Actions", () => {
+    // Actions sets CI and GITHUB_ACTIONS, never WORKERS_CI. Our own deploy
+    // must not be blocked by the guard aimed at the other pipeline.
+    expect(
+      foreignCiError({ CI: "true", GITHUB_ACTIONS: "true", GITHUB_SHA: "abc" }),
+    ).toBeNull();
+  });
+
+  it("can be overridden deliberately", () => {
+    expect(foreignCiError({ WORKERS_CI: "1", [ALLOW_VAR]: "1" })).toBeNull();
+    expect(foreignCiError({ WORKERS_CI: "1", [ALLOW_VAR]: "true" })).toBeNull();
+  });
+
+  it("is not overridden by an unset or empty opt-out", () => {
+    expect(foreignCiError({ WORKERS_CI: "1", [ALLOW_VAR]: "" })).toBe(
+      FOREIGN_CI_MESSAGE,
+    );
+    expect(foreignCiError({ WORKERS_CI: "1", [ALLOW_VAR]: "0" })).toBe(
+      FOREIGN_CI_MESSAGE,
+    );
+  });
+});

--- a/web/lib/foreign-ci.ts
+++ b/web/lib/foreign-ci.ts
@@ -1,0 +1,63 @@
+/**
+ * Refuse to build production from a CI system that is not this repo's pipeline.
+ *
+ * The failure this exists to prevent is a race nobody can see in a green run.
+ * Cloudflare Workers Builds has been connected to this repository since
+ * 2026-08-21 with a Clerk *development* publishable key as its build variable
+ * (see web/README.md -> Deployment -> Workers Builds). It builds every push to
+ * `main` and promotes about a minute later, so on 2026-09-02 it deployed its
+ * own build of commit af5b3d6 over the one deploy.yml had just verified: same
+ * commit, same listings, but `pk_test_` in the bundle, which bounces every
+ * first-time visitor into a Clerk dev-instance handshake (HTTP 307) and breaks
+ * sign-in until the next GitHub deploy overwrites it.
+ *
+ * Disabling that integration lives in the Cloudflare dashboard. This is the
+ * half that lives in the repository: its build fails here, before it can
+ * produce a bundle to promote, and the error says where to fix it. One
+ * pipeline, not two.
+ *
+ * `WORKERS_CI=1` is injected by Workers Builds itself
+ * (developers.cloudflare.com/workers/ci-cd/builds/configuration/#default-variables),
+ * so this cannot fire on a laptop, in GitHub Actions, or in `next dev` — only
+ * inside the build system it names.
+ */
+
+/** Escape hatch, for deliberately re-enabling Workers Builds later. */
+export const ALLOW_VAR = "HACKHQ_ALLOW_FOREIGN_CI";
+
+export const FOREIGN_CI_MESSAGE = [
+  "Refusing to build: this build is running on Cloudflare Workers Builds (WORKERS_CI=1),",
+  "which is not this repository's deploy pipeline.",
+  "",
+  "Production deploys come from .github/workflows/deploy.yml, which supplies production",
+  "credentials from repository secrets, runs the credential preflight, and verifies that",
+  "the public site actually serves the build before recording it as shipped. Workers Builds",
+  "was connected with a Clerk development key and promotes its build about a minute after",
+  "every push, overwriting that verified deploy with one that redirects visitors to a Clerk",
+  "development instance.",
+  "",
+  "Fix it in the Cloudflare dashboard: Workers & Pages -> hackhq -> Settings -> Builds ->",
+  "Disconnect. To keep the integration but stop it deploying, set its deploy command to",
+  "`npx wrangler versions upload` and its NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY build variable",
+  "to the production pk_live_ key.",
+  "",
+  `If you are deliberately moving production onto Workers Builds, set ${ALLOW_VAR}=1 as a`,
+  "build variable and retire deploy.yml in the same change. See web/README.md -> Deployment.",
+].join("\n");
+
+/**
+ * The error message for a build that must not run here, or null when the build
+ * is allowed to proceed.
+ *
+ * Takes the environment as an argument rather than reading `process.env`, so
+ * the rule is testable without mutating global state.
+ */
+export function foreignCiError(
+  env: Record<string, string | undefined>,
+): string | null {
+  const allowed = env[ALLOW_VAR];
+  if (allowed === "1" || allowed?.toLowerCase() === "true") return null;
+  // Only Workers Builds sets this. GitHub Actions sets CI=true but never
+  // WORKERS_CI, so this stays silent in the pipeline we do want.
+  return env.WORKERS_CI ? FOREIGN_CI_MESSAGE : null;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,6 +4,16 @@ import { dirname } from "node:path";
 
 import type { NextConfig } from "next";
 
+import { foreignCiError } from "./lib/foreign-ci";
+
+// Refuse to build under a CI system that is not this repo's pipeline. Checked
+// here rather than in an npm script because this file is loaded by `next build`
+// however the build was invoked - including by `opennextjs-cloudflare build`,
+// which is the command Cloudflare Workers Builds runs. See lib/foreign-ci.ts
+// for what went wrong and web/README.md -> Deployment -> Workers Builds.
+const foreignCi = foreignCiError(process.env);
+if (foreignCi) throw new Error(foreignCi);
+
 // Single source of repo identity (mirrors lib/repo.ts; kept inline so the
 // config file has no local-module import). Override via NEXT_PUBLIC_REPO_SLUG.
 const REPO_SLUG =


### PR DESCRIPTION
Both causes of the red checks on the 2026-09-02 merges. Neither was a bad listing — the data on those merges was correct.

## 1. Site freshness failed on every merge (a self-inflicted race)

`site_freshness.yml` ran on pushes that change `listings.json`. That same push starts `deploy.yml`. The check finishes in about 20 seconds, the deploy takes a minute or more — so the check read the **pre-deploy** site and reported every listing in that push as missing. That is the failure quoted on #294: 19 listings "missing", all of them added by that very push.

Its `workflow_run` counterpart, which runs *after* the deploy, was green every time:

| Merge | push-triggered freshness | after-deploy freshness |
| --- | --- | --- |
| #294 `999dc8b` | ✗ 07:31 (19 missing) | ✓ 07:33 |
| #295 `6d82148` | ✗ 07:43 | ✓ (after #296's deploy) |
| #297 `af5b3d6` | ✗ 15:08 | ✓ 15:13 (data), see below |

The push trigger now covers only `check_site_freshness.py` and the workflow file, so changing the checker still exercises it. Listing pushes are covered by the deploy-completion trigger, after the deploy that fixes them. A test pins this so the path filter can't quietly come back.

## 2. Workers Builds is still overwriting production

The other red run is real and ongoing. Cloudflare Workers Builds appears as a check on every merge commit here (`Workers Builds: hackhq`), and at **15:11 UTC it deployed its own build of `af5b3d6` over the deploy this repo had verified at 15:09** — same commit, same 185 listings, but built with a `pk_test_` Clerk key, so browsers get a 307 into a Clerk dev instance. The self-heal caught it and re-dispatched the deploy, as designed, but that is a tug of war.

Disconnecting the integration is a dashboard step. **The repository half is now in place:** `next.config.ts` throws when `WORKERS_CI=1` — the variable [Workers Builds injects into its own builds](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/#default-variables) — so its build fails while loading the config, before it has a bundle to promote, and the error names the dashboard fix. The guard sits in the Next config because that is the one file every `next build` loads, whichever command invoked it. It cannot fire on a laptop or in GitHub Actions (neither sets `WORKERS_CI`); `HACKHQ_ALLOW_FOREIGN_CI=1` is the deliberate override for a future migration.

**Still yours to do:** Workers &amp; Pages → hackhq → Settings → Builds → **Disconnect**. After this PR its builds fail loudly instead of shipping a broken site, but they will keep failing until it is disconnected.

## Verification
- `WORKERS_CI=1 npx next build` → fails immediately with the guard's message; the same build without it is unaffected.
- Python 189 passed (3 new), web 264 passed (6 new), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnEvd2412UaeY3io62dxnt
